### PR TITLE
Virus change, AI behaviour levels and invasion hotfix

### DIFF
--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -223,7 +223,7 @@ class sdCharacter extends sdEntity
 		this._ai = null; // Object, won't be saved to snapshot
 		this._ai_enabled = false;
 		this._ai_gun_slot = 0; // When AI spawns with a weapon, this variable needs to be defined to the same slot as the spawned gun so AI can use it
-		this._ai_level = 0; // Self explanatory;		
+		this._ai_level = 0; // Self explanatory;
 
 		this.title = 'Random Hero #' + this._net_id;
 		this._my_hash = undefined; // Will be used to let players repsawn within same entity if it exists on map
@@ -726,7 +726,7 @@ class sdCharacter extends sdEntity
 				
 				if ( Math.random() < 0.4 )
 				this._key_states.SetKey( 'KeyS', 1 );
-
+			
 				if ( Math.random() <  0.2 + Math.min( 0.8, (0.25*this._ai_level ) ) ) // Shoot on detection, depends on AI level
 				{
 					this._key_states.SetKey( 'Mouse1', 1 );
@@ -747,7 +747,7 @@ class sdCharacter extends sdEntity
 				{
 					// Try to go through walls of any kinds
 					if ( sdWorld.last_hit_entity )
-					if ( sdWorld.last_hit_entity._natural === false || sdWorld.last_hit_entity.is( sdDoor ) || sdWorld.last_hit_entity.is( sdMatterContainer ) || ( !sdWorld.last_hit_entity.is( sdCharacter ) && Math.random() < ( 0.01 * _ai_level ) ) )
+					if ( sdWorld.last_hit_entity._natural === false || sdWorld.last_hit_entity.is( sdDoor ) || sdWorld.last_hit_entity.is( sdMatterContainer ) || ( !sdWorld.last_hit_entity.is( sdCharacter ) && Math.random() < ( 0.01 * _ai_level ) ) ) // Also affected by AI level
 					{
 						closest = sdWorld.last_hit_entity;
 
@@ -760,16 +760,13 @@ class sdCharacter extends sdEntity
 		
 		if ( this._ai.target && this._ai.target.IsVisible( this ) )
 		{
-			this.look_x = sdWorld.MorphWithTimeScale( this.look_x, this._ai.target.x, Math.min(0.5, ( 0.8 - 0.15*this._ai_level) ), GSPEED );
+			this.look_x = sdWorld.MorphWithTimeScale( this.look_x, this._ai.target.x, Math.min(0.5, ( 0.8 - 0.15*this._ai_level) ), GSPEED ); // Aim accuracy depending on AI level
 			this.look_y = sdWorld.MorphWithTimeScale( this.look_y, this._ai.target.y + ( this._ai.target_local_y || 0 ), Math.min(0.5, ( 0.8 - 0.15*this._ai_level) ), GSPEED );
 		}
 		else
 		{
 			this.look_x = sdWorld.MorphWithTimeScale( this.look_x, this.x + this._ai.direction * 400, 0.9, GSPEED );
 			this.look_y = sdWorld.MorphWithTimeScale( this.look_y, this.y + Math.sin( sdWorld.time / 2000 * Math.PI ) * 50, 0.9, GSPEED );
-			{
-				this._key_states.SetKey( 'Mouse1', 0 );
-			}
 		}
 	}
 	GetBulletSpawnOffset()

--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -223,7 +223,8 @@ class sdCharacter extends sdEntity
 		this._ai = null; // Object, won't be saved to snapshot
 		this._ai_enabled = false;
 		this._ai_gun_slot = 0; // When AI spawns with a weapon, this variable needs to be defined to the same slot as the spawned gun so AI can use it
-		
+		this._ai_level = 0; // Self explanatory;		
+
 		this.title = 'Random Hero #' + this._net_id;
 		this._my_hash = undefined; // Will be used to let players repsawn within same entity if it exists on map
 		//this._old_score = 0; // This value is only read/written to when player disconnects and reconnects
@@ -453,7 +454,7 @@ class sdCharacter extends sdEntity
 				if ( this._ai )
 				{
 					if ( initiator )
-					if ( !initiator._ai || Math.random() < 0.333 ) // 3 times less friendly fire for Falkoks
+					if ( !initiator._ai || Math.random() < (0.333 - Math.min( 0.33, ( 0.09 * this._ai_level ) ) ) ) // 3 times less friendly fire for Falkoks, also reduced by their AI level
 					this._ai.target = initiator;
 				}
 				else
@@ -725,8 +726,8 @@ class sdCharacter extends sdEntity
 				
 				if ( Math.random() < 0.4 )
 				this._key_states.SetKey( 'KeyS', 1 );
-			
-				if ( Math.random() < 0.2 )
+
+				if ( Math.random() <  0.2 + Math.min( 0.8, (0.25*this._ai_level ) ) ) // Shoot on detection, depends on AI level
 				{
 					this._key_states.SetKey( 'Mouse1', 1 );
 				}
@@ -746,7 +747,7 @@ class sdCharacter extends sdEntity
 				{
 					// Try to go through walls of any kinds
 					if ( sdWorld.last_hit_entity )
-					if ( sdWorld.last_hit_entity._natural === false || sdWorld.last_hit_entity.is( sdDoor ) || sdWorld.last_hit_entity.is( sdMatterContainer ) || ( !sdWorld.last_hit_entity.is( sdCharacter ) && Math.random() < 0.01 ) )
+					if ( sdWorld.last_hit_entity._natural === false || sdWorld.last_hit_entity.is( sdDoor ) || sdWorld.last_hit_entity.is( sdMatterContainer ) || ( !sdWorld.last_hit_entity.is( sdCharacter ) && Math.random() < ( 0.01 * _ai_level ) ) )
 					{
 						closest = sdWorld.last_hit_entity;
 
@@ -759,13 +760,16 @@ class sdCharacter extends sdEntity
 		
 		if ( this._ai.target && this._ai.target.IsVisible( this ) )
 		{
-			this.look_x = sdWorld.MorphWithTimeScale( this.look_x, this._ai.target.x, 0.8, GSPEED );
-			this.look_y = sdWorld.MorphWithTimeScale( this.look_y, this._ai.target.y + ( this._ai.target_local_y || 0 ), 0.8, GSPEED );
+			this.look_x = sdWorld.MorphWithTimeScale( this.look_x, this._ai.target.x, Math.min(0.5, ( 0.8 - 0.15*this._ai_level) ), GSPEED );
+			this.look_y = sdWorld.MorphWithTimeScale( this.look_y, this._ai.target.y + ( this._ai.target_local_y || 0 ), Math.min(0.5, ( 0.8 - 0.15*this._ai_level) ), GSPEED );
 		}
 		else
 		{
 			this.look_x = sdWorld.MorphWithTimeScale( this.look_x, this.x + this._ai.direction * 400, 0.9, GSPEED );
 			this.look_y = sdWorld.MorphWithTimeScale( this.look_y, this.y + Math.sin( sdWorld.time / 2000 * Math.PI ) * 50, 0.9, GSPEED );
+			{
+				this._key_states.SetKey( 'Mouse1', 0 );
+			}
 		}
 	}
 	GetBulletSpawnOffset()

--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -774,8 +774,8 @@ class sdCharacter extends sdEntity
 	}
 	GetBulletSpawnOffset()
 	{
-		// Much better for digging down
-		if ( !this._inventory[ this.gun_slot ] || sdGun.classes[ this._inventory[ this.gun_slot ].class ].is_sword )
+		// Much better for digging down. Also will work with all short-range weapons like defibrillators
+		if ( !this._inventory[ this.gun_slot ] || sdGun.classes[ this._inventory[ this.gun_slot ].class ].is_sword || ( sdGun.classes[ this._inventory[ this.gun_slot ].class ].projectile_properties.time_left !== undefined && sdGun.classes[ this._inventory[ this.gun_slot ].class ].projectile_properties.time_left < 5 ) )
 		{
 			return { x:0, y:sdCharacter.bullet_y_spawn_offset };
 		}

--- a/game/entities/sdVirus.js
+++ b/game/entities/sdVirus.js
@@ -60,7 +60,7 @@ class sdVirus extends sdEntity
 		this._last_bite = sdWorld.time;
 		this._last_grow = sdWorld.time;
 		this._last_target_change = 0;
-		
+		this._split = 0;
 		this.side = 1;
 		
 		this.filter = 'hue-rotate(' + ~~( Math.random() * 360 ) + 'deg)';
@@ -72,7 +72,8 @@ class sdVirus extends sdEntity
 		this.hmax += delta;
 		if ( this.hmax > sdVirus.normal_max_health_max )
 		this.hmax = sdVirus.normal_max_health_max;
-	
+		if ( this.hmax >= 160 ) // If it grows 2x it's size, it will split on death
+		this._split = 1;
 		for ( var r = 0; r < 2; r++ )
 		{
 			var dist = 0;
@@ -95,7 +96,6 @@ class sdVirus extends sdEntity
 					this.y += yy * dist;
 					
 					this._hea = this._hea / old * this.hmax;
-
 					return true;
 				}
 				
@@ -167,6 +167,28 @@ class sdVirus extends sdEntity
 			if ( initiator )
 			if ( typeof initiator._score !== 'undefined' )
 			initiator._score += ~~( 1 * this.hmax / sdVirus.normal_max_health );
+			
+			if ( this._split === 1)
+			{
+					let xx = this.x + this.hitbox_x1 + 16;
+					let yy = this.y + this.hitbox_y1 + 16;
+					let i = 0;
+					do
+					{
+						let virus = new sdVirus({ 
+							x: xx,
+							y: yy,
+						});
+						xx += 1 + ( virus.hitbox_x2 - virus.hitbox_x1);
+						if (xx > this.x + this.hitbox_x2 - 16)
+						{
+							xx = this.x + this.hitbox_x1 + 16;
+							yy += 1 + ( virus.hitbox_y2 - virus.hitbox_y1);
+						}
+						sdEntity.entities.push( virus );
+						i++;
+					} while ( ( yy < this.y + this.hitbox_y2 - 8 ) && (i < 12) ); // 12 is the max cap a virus can split into
+			}
 		}
 		
 		if ( this._hea < -this.hmax / 80 * 100 )

--- a/game/entities/sdVirus.js
+++ b/game/entities/sdVirus.js
@@ -59,8 +59,9 @@ class sdVirus extends sdEntity
 		this._last_jump = sdWorld.time;
 		this._last_bite = sdWorld.time;
 		this._last_grow = sdWorld.time;
-		this._last_target_change = 0;
 		this._split = 0;
+		this._last_target_change = 0;
+		
 		this.side = 1;
 		
 		this.filter = 'hue-rotate(' + ~~( Math.random() * 360 ) + 'deg)';
@@ -73,7 +74,8 @@ class sdVirus extends sdEntity
 		if ( this.hmax > sdVirus.normal_max_health_max )
 		this.hmax = sdVirus.normal_max_health_max;
 		if ( this.hmax >= 160 ) // If it grows 2x it's size, it will split on death
-		this._split = 1;
+		this._split = 1;	
+
 		for ( var r = 0; r < 2; r++ )
 		{
 			var dist = 0;
@@ -96,6 +98,7 @@ class sdVirus extends sdEntity
 					this.y += yy * dist;
 					
 					this._hea = this._hea / old * this.hmax;
+
 					return true;
 				}
 				

--- a/game/entities/sdWeather.js
+++ b/game/entities/sdWeather.js
@@ -3,6 +3,7 @@ import sdWorld from '../sdWorld.js';
 import sdEntity from './sdEntity.js';
 import sdEffect from './sdEffect.js';
 import sdAsteroid from './sdAsteroid.js';
+
 import sdCube from './sdCube.js';
 import sdBlock from './sdBlock.js';
 import sdCharacter from './sdCharacter.js';
@@ -208,9 +209,7 @@ class sdWeather extends sdEntity
 										character_entity._ai = { direction: ( x > ( sdWorld.world_bounds.x1 + sdWorld.world_bounds.x2 ) / 2 ) ? -1 : 1 };
 										character_entity._ai_enabled = true;
 										character_entity._ai_level = Math.floor( 1.5 + Math.random()*2 ); // AI Levels from 1 to 3
-										
 										character_entity._matter_regeneration = 1; // At least some ammo regen
-
 
 										break;
 									}
@@ -226,7 +225,6 @@ class sdWeather extends sdEntity
 
 							instances++;
 							ais++;
-							this._invasion_spawns_con -= 1;
 						}
 					}
 			}
@@ -450,8 +448,7 @@ class sdWeather extends sdEntity
 										}	
 										character_entity._ai = { direction: ( x > ( sdWorld.world_bounds.x1 + sdWorld.world_bounds.x2 ) / 2 ) ? -1 : 1 };
 										character_entity._ai_enabled = true;
-										character_entity._ai_level = Math.floor( 0.5 + Math.random() ); // Either 0 or 1
-										
+										character_entity._ai_level = Math.floor( 0.5 + Math.random() * 2 ); // AI Levels from 0 to 2
 										character_entity._matter_regeneration = 1; // At least some ammo regen
 
 										break;
@@ -498,7 +495,6 @@ class sdWeather extends sdEntity
 						this.invasion = true;
 						this._invasion_timer = 120 ; // 2 minutes; using GSPEED for measurement (feel free to change that, I'm not sure how it should work)
 						this._invasion_spawn_timer = 0;
-						this._invasion_spawns_con = 30; // At least 30 Falkoks must spawn otherwise invasion will not end
 						//console.log('Invasion incoming!');
 						}
 					}

--- a/game/entities/sdWeather.js
+++ b/game/entities/sdWeather.js
@@ -3,7 +3,6 @@ import sdWorld from '../sdWorld.js';
 import sdEntity from './sdEntity.js';
 import sdEffect from './sdEffect.js';
 import sdAsteroid from './sdAsteroid.js';
-
 import sdCube from './sdCube.js';
 import sdBlock from './sdBlock.js';
 import sdCharacter from './sdCharacter.js';
@@ -62,6 +61,7 @@ class sdWeather extends sdEntity
 		this.invasion = false;
 		this._invasion_timer = 0; // invasion length timer
 		this._invasion_spawn_timer = 0; // invasion spawn timer
+		this._invasion_spawns_con = 0; // invasion spawn conditions, needs to be 0 or invasion can't end
 		
 		this.raining_intensity = 0;
 		
@@ -106,7 +106,7 @@ class sdWeather extends sdEntity
 			{
 			this._invasion_timer -= 1 / 30  * GSPEED;
 			this._invasion_spawn_timer -= 1 / 30 * GSPEED;
-			if (this._invasion_timer <= 0 )
+			if (this._invasion_timer <= 0 && this._invasion_spawns_con <= 0 )
 			{
 			this.invasion = false;
 			//console.log('Invasion clearing up!');
@@ -207,8 +207,11 @@ class sdWeather extends sdEntity
 										}	
 										character_entity._ai = { direction: ( x > ( sdWorld.world_bounds.x1 + sdWorld.world_bounds.x2 ) / 2 ) ? -1 : 1 };
 										character_entity._ai_enabled = true;
+										character_entity._ai_level = Math.floor( 1.5 + Math.random()*2 ); // AI Levels from 1 to 3
 										
 										character_entity._matter_regeneration = 1; // At least some ammo regen
+
+										this._invasion_spawns_con -= 1;
 
 										break;
 									}
@@ -447,6 +450,7 @@ class sdWeather extends sdEntity
 										}	
 										character_entity._ai = { direction: ( x > ( sdWorld.world_bounds.x1 + sdWorld.world_bounds.x2 ) / 2 ) ? -1 : 1 };
 										character_entity._ai_enabled = true;
+										character_entity._ai_level = Math.floor( 0.5 + Math.random() ); // Either 0 or 1
 										
 										character_entity._matter_regeneration = 1; // At least some ammo regen
 
@@ -494,6 +498,7 @@ class sdWeather extends sdEntity
 						this.invasion = true;
 						this._invasion_timer = 120 ; // 2 minutes; using GSPEED for measurement (feel free to change that, I'm not sure how it should work)
 						this._invasion_spawn_timer = 0;
+						this._invasion_spawns_con = 30; // At least 30 Falkoks must spawn otherwise invasion will not end
 						//console.log('Invasion incoming!');
 						}
 					}

--- a/game/entities/sdWeather.js
+++ b/game/entities/sdWeather.js
@@ -211,7 +211,6 @@ class sdWeather extends sdEntity
 										
 										character_entity._matter_regeneration = 1; // At least some ammo regen
 
-										this._invasion_spawns_con -= 1;
 
 										break;
 									}
@@ -227,6 +226,7 @@ class sdWeather extends sdEntity
 
 							instances++;
 							ais++;
+							this._invasion_spawns_con -= 1;
 						}
 					}
 			}


### PR DESCRIPTION
**Small virus addition**
Virus, if grown at least twice it's size (hmax>=160) can split into smaller viruses.
The amound of viruses depends on the growth of the virus (although it is capped at 12 virus max)

**AI behaviour levels**
AI now has behaviour levels that are given to them on spawn
AI level now affects following:
Aim/ target snapping
Friendly fire return chance
Chance to fire

Levels 1-3 make the most difference, 3 being the strongest, while 0 is mostly default behaviour as it is now.

**Invasion hotfix**
Added a variable _invasion_spawns_con - Acts as a condition for the invasion
Basically, it's given a number (30 for now) that acts as a spawn counter and if it's above 0 the invasion cannot end.

**Notes:**
I couldn't make the virus that spawns when the large one is destroyed have the same color as the dead one.
I tried filter: this.filter in spawn parameters but it didn't seem to work.