### PR TITLE
New entity - Base shielding unit and ( temporary ) removal of reinforced blocks and doors

### DIFF
--- a/game/client/sdShop.js
+++ b/game/client/sdShop.js
@@ -67,11 +67,11 @@ class sdShop
 			sdShop.options.push({ _class: 'sdBlock', width: 16, height: 32, filter: filter, _category:'Walls' });
 			sdShop.options.push({ _class: 'sdBlock', width: 32, height: 32, filter: filter, _category:'Walls' });
 			sdShop.options.push({ _class: 'sdBlock', width: 16, height: 8, filter: filter, _category:'Walls' });
-			sdShop.options.push({ _class: 'sdBlock', width: 16, height: 16, filter: filter, material: sdBlock.MATERIAL_REINFORCED_WALL_LVL1, _reinforced_level: 1, _category:'Walls', _min_build_tool_level: 2 });
-			sdShop.options.push({ _class: 'sdBlock', width: 32, height: 16, filter: filter, material: sdBlock.MATERIAL_REINFORCED_WALL_LVL1, _reinforced_level: 1, _category:'Walls', _min_build_tool_level: 2 });
-			sdShop.options.push({ _class: 'sdBlock', width: 16, height: 32, filter: filter, material: sdBlock.MATERIAL_REINFORCED_WALL_LVL1, _reinforced_level: 1, _category:'Walls', _min_build_tool_level: 2 });
-			sdShop.options.push({ _class: 'sdBlock', width: 32, height: 32, filter: filter, material: sdBlock.MATERIAL_REINFORCED_WALL_LVL1, _reinforced_level: 1, _category:'Walls', _min_build_tool_level: 2 });
-			sdShop.options.push({ _class: 'sdBlock', width: 16, height: 8, filter: filter, material: sdBlock.MATERIAL_REINFORCED_WALL_LVL1, _reinforced_level: 1, _category:'Walls', _min_build_tool_level: 2 });
+			//sdShop.options.push({ _class: 'sdBlock', width: 16, height: 16, filter: filter, material: sdBlock.MATERIAL_REINFORCED_WALL_LVL1, _reinforced_level: 1, _category:'Walls', _min_build_tool_level: 2 });
+			//sdShop.options.push({ _class: 'sdBlock', width: 32, height: 16, filter: filter, material: sdBlock.MATERIAL_REINFORCED_WALL_LVL1, _reinforced_level: 1, _category:'Walls', _min_build_tool_level: 2 });
+			//sdShop.options.push({ _class: 'sdBlock', width: 16, height: 32, filter: filter, material: sdBlock.MATERIAL_REINFORCED_WALL_LVL1, _reinforced_level: 1, _category:'Walls', _min_build_tool_level: 2 });
+			//sdShop.options.push({ _class: 'sdBlock', width: 32, height: 32, filter: filter, material: sdBlock.MATERIAL_REINFORCED_WALL_LVL1, _reinforced_level: 1, _category:'Walls', _min_build_tool_level: 2 });
+			//sdShop.options.push({ _class: 'sdBlock', width: 16, height: 8, filter: filter, material: sdBlock.MATERIAL_REINFORCED_WALL_LVL1, _reinforced_level: 1, _category:'Walls', _min_build_tool_level: 2 });
 			
 			//if ( i !== 0 )
 			//{
@@ -103,7 +103,7 @@ class sdShop
 			{
 				sdShop.options.push({ _class: 'sdDoor', width: 32, height: 32, filter: filter, _category:'Doors' });
 				//var filter = ( i === 0 ) ? '' : 'hue-rotate('+(~~(i/12*360))+'deg) contrast(0.75)';
-				sdShop.options.push({ _class: 'sdDoor', width: 32, height: 32, filter: filter, model: sdDoor.MODEL_ARMORED, _reinforced_level: 1, _category:'Doors', _min_build_tool_level: 2 });
+				//sdShop.options.push({ _class: 'sdDoor', width: 32, height: 32, filter: filter, model: sdDoor.MODEL_ARMORED, _reinforced_level: 1, _category:'Doors', _min_build_tool_level: 2 });
 			}
 		}
 		AddBuildPack( 'hue-rotate(-90deg) contrast(0.5) brightness(1.5) saturate(0)' );
@@ -155,6 +155,7 @@ class sdShop
 		sdShop.options.push({ _class: 'sdCommandCentre', _category:'Base equipment' });
 		sdShop.options.push({ _class: 'sdCrystalCombiner', _category:'Base equipment' });
 		sdShop.options.push({ _class: 'sdRescueTeleport', _category:'Base equipment' });
+		sdShop.options.push({ _class: 'sdBaseShieldingUnit', _category:'Base equipment' });
 		
 		for ( let i = 0; i < sdCaption.colors.length / 3; i++ )
 		sdShop.options.push({ _class: 'sdCaption', type: i, _category:'Base equipment' });

--- a/game/entities/sdBaseShieldingUnit.js
+++ b/game/entities/sdBaseShieldingUnit.js
@@ -356,15 +356,15 @@ class sdBaseShieldingUnit extends sdEntity
 			{
 				if ( command_name === 'SHIELD_ON' )
 				{
-					if ( this.enabled === false )
+					//if ( this.enabled === false )
 					{
 						if ( this.matter_crystal >= 800 )
 						this.SetShieldState( true );
 						else
 						executer_socket.SDServiceMessage( 'Base shield unit needs at least 800 matter' );
 					}
-					else
-					this.SetShieldState();
+					//else
+					//this.SetShieldState();
 				}
 				if ( command_name === 'SHIELD_OFF' )
 				{

--- a/game/entities/sdBaseShieldingUnit.js
+++ b/game/entities/sdBaseShieldingUnit.js
@@ -157,7 +157,7 @@ class sdBaseShieldingUnit extends sdEntity
 				if ( units[ i ] !== this )
 				if ( units[ i ].enabled )
 				{
-					if ( units[ i ].matter_crystal > 500 )
+					if ( units[ i ].matter_crystal >= 350 && this.matter_crystal >= 350 )
 					{
 						units[ i ].matter_crystal -= 350;
 						this.matter_crystal -= 350;

--- a/game/entities/sdBaseShieldingUnit.js
+++ b/game/entities/sdBaseShieldingUnit.js
@@ -152,12 +152,12 @@ class sdBaseShieldingUnit extends sdEntity
 		if ( this._attack_timer <= 0 )
 		{
 			let units = sdWorld.GetAnythingNear( this.x, this.y, sdBaseShieldingUnit.protect_distance + 50, null, [ 'sdBaseShieldingUnit' ] );
-			for ( let i = 0; i < units.length; i++ ) // Protect nearby entities inside base unit's radius
+			for ( let i = 0; i < units.length; i++ ) // Attack nearby base units inside this base unit's radius
 			{
 				if ( units[ i ] !== this )
 				if ( units[ i ].enabled )
 				{
-					if ( units[ i ].matter_crystal >= 350 && this.matter_crystal >= 350 )
+					if ( units[ i ].matter_crystal >= 350 && this.matter_crystal >= 350 ) // this.matter_crystal probably unneded since it shuts down below 800 matter
 					{
 						units[ i ].matter_crystal -= 350;
 						this.matter_crystal -= 350;

--- a/game/entities/sdBaseShieldingUnit.js
+++ b/game/entities/sdBaseShieldingUnit.js
@@ -179,7 +179,7 @@ class sdBaseShieldingUnit extends sdEntity
 		this._regen_timeout -= GSPEED;
 
 		if ( this.matter_crystal < 800 )
-		this.enabled = false; // Shut down if no matter
+		this.SetShieldState( false ); // Shut down if no matter
 
 		else
 		{

--- a/game/entities/sdBaseShieldingUnit.js
+++ b/game/entities/sdBaseShieldingUnit.js
@@ -137,7 +137,10 @@ class sdBaseShieldingUnit extends sdEntity
 		this._regen_timeout -= GSPEED;
 
 		if ( this.matter_crystal < 800 )
-		this.enabled = false; // Shut down if no matter
+		{
+			this.enabled = false; // Shut down if no matter
+			this._repair_timer = 0;
+		}
 
 		else
 		{

--- a/game/entities/sdBaseShieldingUnit.js
+++ b/game/entities/sdBaseShieldingUnit.js
@@ -399,6 +399,7 @@ class sdBaseShieldingUnit extends sdEntity
 				this.AddContextOption( 'Scan nearby unprotected entities ( 800 matter )', 'SHIELD_ON', [] );
 				else
 				{
+					this.AddContextOption( 'Refresh scanning entities', 'SHIELD_ON', [] );
 					this.AddContextOption( 'Turn the shields off', 'SHIELD_OFF', [] );
 					this.AddContextOption( 'Attack nearby shield units', 'ATTACK', [] );
 				}

--- a/game/entities/sdBaseShieldingUnit.js
+++ b/game/entities/sdBaseShieldingUnit.js
@@ -1,0 +1,364 @@
+
+import sdWorld from '../sdWorld.js';
+import sdSound from '../sdSound.js';
+import sdEntity from './sdEntity.js';
+import sdGun from './sdGun.js';
+import sdCom from './sdCom.js';
+import sdBullet from './sdBullet.js';
+import sdEffect from './sdEffect.js';
+import sdCharacter from './sdCharacter.js';
+import sdVirus from './sdVirus.js';
+import sdQuickie from './sdQuickie.js';
+import sdCrystal from './sdCrystal.js';
+import sdBlock from './sdBlock.js';
+
+import sdRenderer from '../client/sdRenderer.js';
+
+class sdBaseShieldingUnit extends sdEntity
+{
+	static init_class()
+	{
+		sdBaseShieldingUnit.img_unit = sdWorld.CreateImageFromFile( 'life_box_turret' );
+		sdBaseShieldingUnit.img_unit_repair = sdWorld.CreateImageFromFile( 'life_box_turret_fire' );
+
+		sdBaseShieldingUnit.protect_distance = 275;
+		
+		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
+	}
+	get hitbox_x1() { return -12; }
+	get hitbox_x2() { return 12; }
+	get hitbox_y1() { return -12; }
+	get hitbox_y2() { return 12; }
+	
+	get hard_collision() // For world geometry where players can walk
+	{ return true; }
+
+	get is_static() // Static world objects like walls, creation and destruction events are handled manually. Do this._update_version++ to update these
+	{ return false; }
+	
+	
+	//get is_static() // Static world objects like walls, creation and destruction events are handled manually. Do this._update_version++ to update these
+	//{ return true; }
+
+	Impact( vel ) // fall damage basically
+	{
+		// No impact damage if has driver (because no headshot damage)
+		if ( vel > 5 )
+		{
+			this.Damage( ( vel - 3 ) * 25 );
+		}
+	}
+	RequireSpawnAlign() 
+	{ return true; }
+
+	constructor( params )
+	{
+		super( params );
+		
+		this.sx = 0;
+		this.sy = 0;
+		
+		this._hmax = 3000; // Just enough so players don't accidentally destroy it when stimpacked and RTP'd
+		this._hea = this._hmax;
+		this._hmax_old = this._hmax;
+		this._regen_timeout = 0;
+		this._last_sync_matter = 0;
+		this.matter_crystal_max = 2000000;
+		this.matter_crystal = 0; // Named differently to prevent matter absorption from entities that emit matter
+		this._protected_entities = [];
+		this.enabled = false;
+		this._attack_other_units = false;
+		
+		this.filter = params.filter || 'none';
+
+		this._repair_timer = 0;
+		this._attack_timer = 0;
+		this.attack_anim = 0; //Animation
+
+		this._target = null;
+		// 1 slot
+	}
+	Damage( dmg, initiator=null )
+	{
+		if ( !sdWorld.is_server )
+		return;
+
+		dmg = Math.abs( dmg );
+		
+		let old_hea = this._hea;
+		
+		this._hea -= dmg;
+
+		if ( this._hea <= 0 )
+		this.remove();
+	
+		this._regen_timeout = 30;
+
+		this._update_version++; // Just in case
+	}
+	SetShieldState()
+	{
+		this.enabled = !this.enabled;
+		this._repair_timer = 0;
+	}
+	SetAttackState()
+	{
+		if ( this.enabled )
+		this._attack_other_units = !this._attack_other_units;
+	}
+	get mass() { return ( this.enabled ) ? 250 : 50; }
+	Impulse( x, y )
+	{
+		this.sx += x / this.mass;
+		this.sy += y / this.mass;
+		//this.sx += x * 0.1;
+		//this.sy += y * 0.1;
+	}
+	onThink( GSPEED ) // Class-specific, if needed
+	{
+		this.sy += sdWorld.gravity * GSPEED;
+		
+		this.ApplyVelocityAndCollisions( GSPEED, 0, true );
+
+		if ( !sdWorld.is_server)
+		return;
+
+		if ( this._repair_timer > 0 )
+		this._repair_timer -= GSPEED;
+
+		if ( this._attack_timer > 0 )
+		this._attack_timer -= GSPEED;
+
+
+		if ( this.attack_anim > 0 )
+		this.attack_anim -= GSPEED;
+
+		if ( this._regen_timeout > 0 )
+		this._regen_timeout -= GSPEED;
+
+		if ( this.matter_crystal < 800 )
+		this.enabled = false; // Shut down if no matter
+
+		else
+		{
+			if ( this._hea > 0 )
+			if ( this._hea < this._hmax )
+			{
+				this._hea = Math.min( this._hea + 2 * ( GSPEED ), this._hmax );
+			}
+		}
+
+		if ( this._attack_other_units )
+		if ( this._attack_timer <= 0 )
+		{
+			let units = sdWorld.GetAnythingNear( this.x, this.y, sdBaseShieldingUnit.protect_distance + 50, null, [ 'sdBaseShieldingUnit' ] );
+			for ( let i = 0; i < units.length; i++ ) // Protect nearby entities inside base unit's radius
+			{
+				if ( units[ i ] !== this )
+				if ( units[ i ].enabled )
+				{
+					if ( units[ i ].matter_crystal > 500 )
+					{
+						units[ i ].matter_crystal -= 350;
+						this.matter_crystal -= 350;
+						sdWorld.SendEffect({ x:this.x, y:this.y, x2:units[ i ].x, y2:units[ i ].y, type:sdEffect.TYPE_BEAM, color:'#f9e853' });
+						this._attack_timer = 30;
+						this.attack_anim = 20;
+					}
+				}
+			}
+		}
+		if ( this._repair_timer <= 0 )
+		{
+			{
+				for ( let j = 0; j < this._protected_entities.length; j++ )
+				{
+					if ( ( sdWorld.Dist2D( this.x, this.y, this._protected_entities[ j ].x, this._protected_entities[ j ].y ) > sdBaseShieldingUnit.protect_distance ) || ( !this.enabled ) ) // If an entity is too far away, let players know it's not protected anymore
+					if ( this._protected_entities[ j ]._shielded === this )
+					{
+						this._protected_entities[ j ]._shielded = null;
+						sdWorld.SendEffect({ x:this.x, y:this.y, x2:this._protected_entities[ j ].x + ( this._protected_entities[ j ].hitbox_x2 / 2 ), y2:this._protected_entities[ j ].y + ( this._protected_entities[ j ].hitbox_y2 / 2 ) , type:sdEffect.TYPE_BEAM, color:'#855805' });
+					}
+				}
+				this._repair_timer = 210; // 7 seconds
+				if ( this.enabled )
+				{
+					let blocks = sdWorld.GetAnythingNear( this.x, this.y, sdBaseShieldingUnit.protect_distance, null, [ 'sdBlock', 'sdDoor' ] );
+					for ( let i = 0; i < blocks.length; i++ ) // Protect nearby entities inside base unit's radius
+					{
+						if ( blocks[ i ].GetClass() === 'sdBlock' )
+						{
+							if ( blocks[ i ].material === sdBlock.MATERIAL_WALL || blocks[ i ].material === sdBlock.MATERIAL_REINFORCED_WALL_LVL1 ) // Only walls, no trap or shield blocks
+							if ( blocks[ i ]._shielded === null )
+							{
+								blocks[ i ]._shielded = this;
+								sdWorld.SendEffect({ x:this.x, y:this.y, x2:blocks[ i ].x + ( blocks[ i ].hitbox_x2 / 2 ), y2:blocks[ i ].y + ( blocks[ i ].hitbox_y2 / 2 ) , type:sdEffect.TYPE_BEAM, color:'#0ACC0A' });
+								this._protected_entities.push( blocks[ i ] );
+							}
+						}
+						
+						if ( blocks[ i ].GetClass() === 'sdDoor' )
+						{
+							if ( blocks[ i ]._shielded === null )
+							{
+								blocks[ i ]._shielded = this;
+								sdWorld.SendEffect({ x:this.x, y:this.y, x2:blocks[ i ].x + ( blocks[ i ].hitbox_x2 / 2 ), y2:blocks[ i ].y + ( blocks[ i ].hitbox_y2 / 2 ) , type:sdEffect.TYPE_BEAM, color:'#0ACC0A' });
+								this._protected_entities.push( blocks[ i ] );
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		if ( Math.abs( this._last_sync_matter - this.matter ) > this.matter_max * 0.01 || this._last_x !== this.x || this._last_y !== this.y )
+		{
+			this._last_sync_matter = this.matter;
+			this._update_version++;
+		}
+		//sdWorld.last_hit_entity = null;
+		
+		//this.ApplyVelocityAndCollisions( GSPEED, 0, true );
+	}
+	onMovementInRange( from_entity )
+	{
+		if ( !sdWorld.is_server )
+		return;
+
+		if ( from_entity.is( sdCrystal ) )
+		if ( this.matter_crystal < this.matter_crystal_max )
+		{
+			if ( !from_entity._is_being_removed ) // One per sdRift, also prevent occasional sound flood
+			{
+				sdSound.PlaySound({ name:'rift_feed3', x:this.x, y:this.y, volume:2, pitch:2 });
+
+				this.matter_crystal = Math.min( this.matter_crystal_max, this.matter_crystal + from_entity.matter_max); // Drain the crystal for it's max value and destroy it
+				//this._update_version++;
+				from_entity.remove();
+			}
+		}
+	}
+
+	DrawHUD( ctx, attached ) // foreground layer
+	{
+		if ( this._hea <= 0 )
+		return;
+	
+		sdEntity.Tooltip( ctx,  "Base shielding unit ( " + ~~(this.matter_crystal) + " / " + ~~(this.matter_crystal_max) + " )" );
+
+		this.DrawConnections( ctx );
+	}
+
+	DrawConnections( ctx )
+	{
+		ctx.lineWidth = 1;
+		ctx.strokeStyle = '#ffffff';
+		ctx.setLineDash([2, 2]);
+		ctx.lineDashOffset = ( sdWorld.time % 1000 ) / 250 * 2;
+/*
+		for ( var i = 0; i < sdEntity.entities.length; i++ )
+		if ( sdEntity.entities[ i ].GetClass() === 'sdCom' )
+		if ( sdWorld.Dist2D( sdEntity.entities[ i ].x, sdEntity.entities[ i ].y, this.x, this.y ) < sdCom.retransmit_range )
+		//if ( sdWorld.CheckLineOfSight( this.x, this.y, sdEntity.entities[ i ].x, sdEntity.entities[ i ].y, this, sdCom.com_visibility_ignored_classes, null ) )
+		if ( sdWorld.CheckLineOfSight( this.x, this.y, sdEntity.entities[ i ].x, sdEntity.entities[ i ].y, this, null, sdCom.com_visibility_unignored_classes ) )
+		{
+			ctx.beginPath();
+			ctx.moveTo( sdEntity.entities[ i ].x - this.x, sdEntity.entities[ i ].y - this.y );
+			ctx.lineTo( 0,0 );
+			ctx.stroke();
+		}
+*/
+		ctx.beginPath();
+		ctx.arc( 0,0, sdBaseShieldingUnit.protect_distance, 0, Math.PI*2 );
+		ctx.stroke();
+		
+		ctx.lineDashOffset = 0;
+		ctx.setLineDash([]);
+	}
+
+	Draw( ctx, attached )
+	{
+		ctx.filter = this.filter;
+		
+		ctx.drawImageFilterCache( ( this.enabled ) ? sdBaseShieldingUnit.img_unit_repair : sdBaseShieldingUnit.img_unit, - 16, -16, 32, 32 );
+		ctx.globalAlpha = 1;
+		ctx.filter = 'none';
+	}
+	onRemove() // Class-specific, if needed
+	{
+
+		for ( let ents = 0; ents < this._protected_entities.length; ents++ )
+		{
+			this._protected_entities[ ents ]._shielded = null;
+			sdWorld.SendEffect({ x:this.x, y:this.y, x2:this._protected_entities[ ents ].x + ( this._protected_entities[ ents ].hitbox_x2 / 2 ), y2:this._protected_entities[ ents ].y + ( this._protected_entities[ ents ].hitbox_y2 / 2 ) , type:sdEffect.TYPE_BEAM, color:'#855805' });
+		}
+		if ( this._broken )
+		{
+			sdWorld.BasicEntityBreakEffect( this, 10 );
+		}
+	}
+	MeasureMatterCost()
+	{
+		//return 0; // Hack
+		
+		return sdWorld.damage_to_matter + 600;
+	}
+	ExecuteContextCommand( command_name, parameters_array, exectuter_character, executer_socket ) // New way of right click execution. command_name and parameters_array can be anything! Pay attention to typeof checks to avoid cheating & hacking here. Check if current entity still exists as well (this._is_being_removed). exectuter_character can be null, socket can't be null
+	{
+		if ( !this._is_being_removed )
+		if ( this._hea > 0 )
+		if ( exectuter_character )
+		if ( exectuter_character.hea > 0 )
+		{
+			if ( sdWorld.inDist2D_Boolean( this.x, this.y, exectuter_character.x, exectuter_character.y, 64 ) )
+			{
+				if ( command_name === 'SHIELD' )
+				{
+					if ( this.enabled === false )
+					{
+						if ( this.matter_crystal >= 800 )
+						this.SetShieldState();
+						else
+						executer_socket.SDServiceMessage( 'Base shield unit needs at least 800 matter' );
+					}
+					else
+					this.SetShieldState();
+				}
+				if ( command_name === 'ATTACK' )
+				{
+					if ( this.enabled )
+					{
+						this.SetAttackState();
+					}
+					else
+					executer_socket.SDServiceMessage( 'Base shield unit needs to be enabled' );
+				}
+			}
+			else
+			executer_socket.SDServiceMessage( 'Base shielding unit is too far' );
+		}
+	}
+	PopulateContextOptions( exectuter_character ) // This method only executed on client-side and should tell game what should be sent to server + show some captions. Use sdWorld.my_entity to reference current player
+	{
+		if ( !this._is_being_removed )
+		if ( this._hea > 0 )
+		if ( exectuter_character )
+		if ( exectuter_character.hea > 0 )
+		if ( sdWorld.inDist2D_Boolean( this.x, this.y, exectuter_character.x, exectuter_character.y, 32 ) )
+		{
+			if ( sdWorld.my_entity )
+			{
+				if ( this.enabled === false )
+				this.AddContextOption( 'Turn the shields on ( 800 matter )', 'SHIELD', [] );
+				else
+				{
+					this.AddContextOption( 'Turn the shields off', 'SHIELD', [] );
+					this.AddContextOption( 'Attack nearby shield units', 'ATTACK', [] );
+				}
+			}
+		}
+	}
+}
+//sdBaseShieldingUnit.init_class();
+
+export default sdBaseShieldingUnit;

--- a/game/entities/sdBlock.js
+++ b/game/entities/sdBlock.js
@@ -266,12 +266,20 @@ class sdBlock extends sdEntity
 				sdSound.PlaySound({ name:'shield', x:this.x, y:this.y, volume:1 });
 			}
 			//console.log( this._shielded );
-			if ( this._shielded === null )
+			if ( this._shielded === null || dmg === Infinity )
 			this._hea -= dmg;
 			else
 			{
-				if ( this._shielded && !this._shielded._is_being_removed )
-				if ( sdWorld.Dist2D( this.x, this.y, this._shielded.x, this._shielded.y ) < sdBaseShieldingUnit.protect_distance )
+				let shield = sdEntity.entities_by_net_id_cache_map.get( this._shielded );
+				//console.log( shield );
+				if ( shield === undefined ) // For some reason shield !== undefined with if statements below doesn't work :/
+				{
+					this._hea -= dmg;
+					this._shielded = null;
+				}
+				else
+				if ( shield.enabled && !shield._is_being_removed )
+				if ( sdWorld.Dist2D( this.x, this.y, shield.x, shield.y ) < sdBaseShieldingUnit.protect_distance )
 				{
 				}
 				else

--- a/game/entities/sdBlock.js
+++ b/game/entities/sdBlock.js
@@ -6,6 +6,7 @@ import sdVirus from './sdVirus.js';
 import sdEffect from './sdEffect.js';
 import sdWater from './sdWater.js';
 import sdBG from './sdBG.js';
+import sdBaseShieldingUnit from './sdBaseShieldingUnit.js';
 
 import sdRenderer from '../client/sdRenderer.js';
 
@@ -264,8 +265,22 @@ class sdBlock extends sdEntity
 			{
 				sdSound.PlaySound({ name:'shield', x:this.x, y:this.y, volume:1 });
 			}
-			
+			//console.log( this._shielded );
+			if ( this._shielded === null )
 			this._hea -= dmg;
+			else
+			{
+				if ( this._shielded && !this._shielded._is_being_removed )
+				if ( sdWorld.Dist2D( this.x, this.y, this._shielded.x, this._shielded.y ) < sdBaseShieldingUnit.protect_distance )
+				{
+				}
+				else
+				{
+					this._hea -= dmg;
+					this._shielded = null;
+				}
+			}
+
 			this.HandleDestructionUpdate();
 			
 			if ( this.material === sdBlock.MATERIAL_TRAPSHIELD ) // Instant regeneration
@@ -377,6 +392,7 @@ class sdBlock extends sdEntity
 		
 		this._armor_protection_level = 0; // Armor level defines lowest damage upgrade projectile that is able to damage this entity
 		this._reinforced_level = params._reinforced_level || 0;
+		this._shielded = null; // Is this entity protected by a base defense unit?
 		
 		this._contains_class = params.contains_class || null;
 		this._contains_class_params = null; // Parameters that are passed to this._contains_class entity
@@ -445,6 +461,10 @@ class sdBlock extends sdEntity
 	}
 	onThink( GSPEED ) // Class-specific, if needed
 	{
+		if ( this._reinforced_level > 0 )
+		this._reinforced_level = 0;
+		if ( this.material === sdBlock.MATERIAL_REINFORCED_WALL_LVL1 )
+		this.material = sdBlock.MATERIAL_WALL;
 		if ( this._regen_timeout > 0 )
 		this._regen_timeout -= GSPEED;
 		else

--- a/game/entities/sdBullet.js
+++ b/game/entities/sdBullet.js
@@ -27,8 +27,7 @@ class sdBullet extends sdEntity
 			'f_psicutter_proj': sdWorld.CreateImageFromFile( 'f_psicutter_proj' ),
 			'ball_charged':  sdWorld.CreateImageFromFile( 'ball_charged' ),
 			'mini_rocket':  sdWorld.CreateImageFromFile( 'mini_rocket' ),
-			'mini_rocket_green':  sdWorld.CreateImageFromFile( 'mini_rocket_green' ),
-			'gauss_rifle_proj':  sdWorld.CreateImageFromFile( 'gauss_rifle_proj' )
+			'mini_rocket_green':  sdWorld.CreateImageFromFile( 'mini_rocket_green' )
 		};
 		
 		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
@@ -438,7 +437,7 @@ class sdBullet extends sdEntity
 		if ( this._damage > 0 )
 		{
 			if ( this.penetrating )
-			return ( from_entity.is( sdBlock ) && this._reinforced_level >= from_entity._reinforced_level) || from_entity.is( sdAntigravity ) || ( from_entity.is( sdDoor ) && this._reinforced_level >= from_entity._reinforced_level );
+			return ( from_entity.is( sdBlock ) && from_entity._shielded === null && this._reinforced_level >= from_entity._reinforced_level) || from_entity.is( sdAntigravity ) || ( from_entity.is( sdDoor ) && from_entity._shielded === null && this._reinforced_level >= from_entity._reinforced_level );
 			else
 			return ( from_entity.is( sdBlock ) && from_entity.material === sdBlock.MATERIAL_WALL ) || from_entity.is( sdAntigravity ) || from_entity.is( sdDoor );
 		}
@@ -604,7 +603,8 @@ class sdBullet extends sdEntity
 						}
 
 						if ( ( typeof from_entity._armor_protection_level === 'undefined' || this._armor_penetration_level >= from_entity._armor_protection_level ) &&
-							 ( typeof from_entity._reinforced_level === 'undefined' || this._reinforced_level >= from_entity._reinforced_level ) )
+							 ( typeof from_entity._reinforced_level === 'undefined' || this._reinforced_level >= from_entity._reinforced_level ) &&
+								 ( typeof from_entity._shielded === 'undefined' || from_entity._shielded === null ) )
 						{
 							if ( !this._wave )
 							{
@@ -698,6 +698,14 @@ class sdBullet extends sdEntity
 									{
 										this._owner._last_damage_upg_complain = sdWorld.time;
 
+										if ( from_entity._shielded !== null )
+										{
+											if ( Math.random() < 0.5 )
+											this._owner.Say( 'This entity is protected by a base shielding unit' );
+											else
+											this._owner.Say( 'A base shielding unit is protecting this' );
+										}
+										else
 										if ( from_entity._reinforced_level > 0 )
 										{
 											if ( Math.random() < 0.5 )

--- a/game/entities/sdDoor.js
+++ b/game/entities/sdDoor.js
@@ -6,6 +6,7 @@ import sdEffect from './sdEffect.js';
 import sdBlock from './sdBlock.js';
 import sdCom from './sdCom.js';
 import sdWater from './sdWater.js';
+import sdBaseShieldingUnit from './sdBaseShieldingUnit.js';
 
 
 import sdRenderer from '../client/sdRenderer.js';
@@ -73,7 +74,20 @@ class sdDoor extends sdEntity
 		
 		if ( this._hea > 0 )
 		{
+			if ( this._shielded === null )
 			this._hea -= dmg;
+			else
+			{
+				if ( this._shielded._hea > 0 )
+				if ( sdWorld.Dist2D( this.x, this.y, this._shielded.x, this._shielded.y ) < sdBaseShieldingUnit.protect_distance )
+				{
+				}
+				else
+				{
+					this._hea -= dmg;
+					this._shielded = null;
+				}
+			}
 			this.HandleDestructionUpdate();
 			
 			this._regen_timeout = 60;
@@ -92,6 +106,7 @@ class sdDoor extends sdEntity
 		
 		this._armor_protection_level = 0; // Armor level defines lowest damage upgrade projectile that is able to damage this entity
 		this._reinforced_level = params._reinforced_level || 0;
+		this._shielded = null; // Is this entity protected by a base defense unit?
 		
 		this.x0 = null; // undefined
 		this.y0 = null; // undefined
@@ -123,6 +138,10 @@ class sdDoor extends sdEntity
 	}
 	onThink( GSPEED ) // Class-specific, if needed
 	{
+		if ( this._reinforced_level > 0 )
+		this._reinforced_level = 0;
+		if ( this.model === sdDoor.MODEL_ARMORED )
+		this.model = sdDoor.MODEL_BASIC;
 		if ( this._regen_timeout > 0 )
 		this._regen_timeout -= GSPEED;
 		else
@@ -368,9 +387,9 @@ class sdDoor extends sdEntity
 		if ( this.openness > 0 || typeof ctx.FakeStart !== 'undefined' )
 		{
 			if ( this.x0 === null ) // undefined
-			ctx.drawImageFilterCache( sdDoor.img_door_path, -16, -16, 32,32 );
+			ctx.drawImage( sdDoor.img_door_path, -16, -16, 32,32 );
 			else
-			ctx.drawImageFilterCache( sdDoor.img_door_path, -16 - this.x + this.x0, -16 - this.y + this.y0, 32,32 );
+			ctx.drawImage( sdDoor.img_door_path, -16 - this.x + this.x0, -16 - this.y + this.y0, 32,32 );
 		}
 	}
 	Draw( ctx, attached )
@@ -402,13 +421,13 @@ class sdDoor extends sdEntity
 			}
 		
 			if ( sdBlock.cracks[ this.destruction_frame ] !== null )
-			ctx.drawImageFilterCache( sdBlock.cracks[ this.destruction_frame ], -16, -16, 32,32 );
+			ctx.drawImage( sdBlock.cracks[ this.destruction_frame ], -16, -16, 32,32 );
 		}
 		else
 		{
 			if ( this.openness > 0 )
 			{
-				//ctx.drawImageFilterCache( sdDoor.img_door_path, -16 - this.x + this.x0, -16 - this.y + this.y0, 32,32 );
+				//ctx.drawImage( sdDoor.img_door_path, -16 - this.x + this.x0, -16 - this.y + this.y0, 32,32 );
 
 				ctx.save();
 				
@@ -429,7 +448,7 @@ class sdDoor extends sdEntity
 					}
 		
 					if ( sdBlock.cracks[ this.destruction_frame ] !== null )
-					ctx.drawImageFilterCache( sdBlock.cracks[ this.destruction_frame ], -16, -16, 32,32 );
+					ctx.drawImage( sdBlock.cracks[ this.destruction_frame ], -16, -16, 32,32 );
 				}
 				ctx.restore();
 			}
@@ -447,7 +466,7 @@ class sdDoor extends sdEntity
 				}
 		
 				if ( sdBlock.cracks[ this.destruction_frame ] !== null )
-				ctx.drawImageFilterCache( sdBlock.cracks[ this.destruction_frame ], -16, -16, 32,32 );
+				ctx.drawImage( sdBlock.cracks[ this.destruction_frame ], -16, -16, 32,32 );
 			}
 		}
 	

--- a/game/entities/sdDoor.js
+++ b/game/entities/sdDoor.js
@@ -74,12 +74,20 @@ class sdDoor extends sdEntity
 		
 		if ( this._hea > 0 )
 		{
-			if ( this._shielded === null )
+			if ( this._shielded === null || dmg === Infinity )
 			this._hea -= dmg;
 			else
 			{
-				if ( this._shielded._hea > 0 )
-				if ( sdWorld.Dist2D( this.x, this.y, this._shielded.x, this._shielded.y ) < sdBaseShieldingUnit.protect_distance )
+				let shield = sdEntity.entities_by_net_id_cache_map.get( this._shielded );
+				//console.log( shield );
+				if ( shield === undefined ) // If the shielding unit doesn't exist, act as a default entity
+				{
+					this._hea -= dmg;
+					this._shielded = null;
+				}
+				else
+				if ( shield.enabled && !shield._is_being_removed )
+				if ( sdWorld.Dist2D( this.x, this.y, shield.x, shield.y ) < sdBaseShieldingUnit.protect_distance )
 				{
 				}
 				else

--- a/game/entities/sdDrone.js
+++ b/game/entities/sdDrone.js
@@ -80,6 +80,29 @@ class sdDrone extends sdEntity
 		
 		//this.filter = 'hue-rotate(' + ~~( Math.random() * 360 ) + 'deg) saturate(0.5)';
 	}
+	CanAttackEnt( ent )
+	{
+		if ( this._current_target === ent )
+		return true;
+
+		if ( this._ai_team === 1 ) // Falkok drones
+		return true;
+		if ( this._ai_team === 2 ) // Erthal drones
+		{
+			if ( ent._ai_team === 2 )
+			return false;
+			else
+			{
+				if ( ent._ai_team === 0 && ent.matter < 200 && this._current_target !== ent )
+				return false;
+				else
+				{
+				this._current_target === ent;
+				return true;
+				}
+			}
+		}
+	}
 	SyncedToPlayer( character ) // Shortcut for enemies to react to players
 	{
 		if ( this._hea > 0 )
@@ -92,10 +115,13 @@ class sdDrone extends sdEntity
 				 ( this._current_target.hea || this._current_target._hea ) <= 0 || 
 				 di < sdWorld.Dist2D(this._current_target.x,this._current_target.y,this.x,this.y) )
 			{
-				this._current_target = character;
+				if ( this.CanAttackEnt( character ) )
+				{
+					this._current_target = character;
 				
-				if ( this.type === 2 )
-				sdSound.PlaySound({ name:'spider_welcomeC', x:this.x, y:this.y, volume: 1, pitch:2 });
+					if ( this.type === 2 )
+					sdSound.PlaySound({ name:'spider_welcomeC', x:this.x, y:this.y, volume: 1, pitch:2 });
+				}
 			}
 		}
 	}
@@ -125,10 +151,15 @@ class sdDrone extends sdEntity
 		return;
 
 		if ( initiator )
-		if ( !initiator.is( sdDrone ) && initiator._ai_team !== this._ai_team )
-		if ( !initiator.is( sdCharacter ) && initiator._ai_team !== this._ai_team )
-		this._current_target = initiator;
-	
+		{
+			if ( !initiator.is( sdDrone ) && initiator._ai_team !== this._ai_team )
+			if ( !initiator.is( sdCharacter ) && initiator._ai_team !== this._ai_team )
+			this._current_target = initiator;
+			else
+			if ( ( initiator.is( sdDrone ) || initiator.is( sdCharacter ) ) && initiator._ai_team !== this._ai_team )
+			this._current_target = initiator;
+		}
+
 		dmg = Math.abs( dmg );
 		
 		let was_alive = this._hea > 0;
@@ -474,7 +505,7 @@ class sdDrone extends sdEntity
 
 								sdSound.PlaySound({ name:'gun_pistol', x:this.x, y:this.y, volume:0.33, pitch:5 });
 							}
-							if ( this.type === 2  ) // Robot drones ( I have no name for this faction lol )
+							if ( this.type === 2  ) // Erthal drones
 							{
 								let bullet_obj = new sdBullet({ x: this.x, y: this.y });
 

--- a/game/entities/sdEnemyMech.js
+++ b/game/entities/sdEnemyMech.js
@@ -238,7 +238,7 @@ class sdEnemyMech extends sdEntity
 							gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_BUILDTOOL_UPG });
 							else
 							{
-								if ( random_value < 0.03 )
+								if ( random_value < 0.08 )
 								gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_FMECH_MINIGUN });
 								else
 								gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_RAIL_CANNON });

--- a/game/entities/sdEnemyMech.js
+++ b/game/entities/sdEnemyMech.js
@@ -423,7 +423,7 @@ class sdEnemyMech extends sdEntity
 						( targets_raw[ i ].GetClass() === 'sdCommandCentre' ) ||
 						 ( targets_raw[ i ].GetClass() === 'sdCube' && targets_raw[ i ].hea > 0 ) ||
 						 ( targets_raw[ i ].GetClass() === 'sdCube' && this.hea < ( this._hmax / 3 ) ) ||
-						 ( targets_raw[ i ].GetClass() === 'sdDrone' && targets_raw[ i ]._ai_team !== 2 && targets_raw[ i ].hea > 0 ) )
+						 ( targets_raw[ i ].GetClass() === 'sdDrone' && targets_raw[ i ]._ai_team !== 2 && targets_raw[ i ]._hea > 0 ) )
 					{
 						if ( sdWorld.CheckLineOfSight( this.x, this.y, targets_raw[ i ].x, targets_raw[ i ].y, targets_raw[ i ], [ 'sdEnemyMech' ], [ 'sdBlock', 'sdDoor', 'sdMatterContainer' ] ) )
 							targets.push( targets_raw[ i ] );

--- a/game/entities/sdGunClass.js
+++ b/game/entities/sdGunClass.js
@@ -799,10 +799,8 @@ class sdGunClass
 			ammo_capacity: -1,
 			count: 1,
 			is_sword: true,
-			min_workbench_level: 1,
-			min_build_tool_level: 2,
-			matter_cost: 1000,
 			projectile_velocity: 16 * 1.5,
+			spawnable: false,
 			projectile_properties: { time_left: 1, _damage: 35, color: 'transparent', _knock_scale:0.025 * 8, _reinforced_level: 1 }
 		};
 
@@ -1803,75 +1801,6 @@ class sdGunClass
 			projectile_properties: { _damage: 25, color:'#00aaff' }
 		};
     
-		sdGun.classes[ sdGun.CLASS_GAUSS_RIFLE = 66 ] = 
-		{
-			image: sdWorld.CreateImageFromFile( 'gauss_rifle' ),
-			image_charging: sdWorld.CreateImageFromFile( 'gauss_rifle_charging' ),
-			image0: [ sdWorld.CreateImageFromFile( 'gauss_rifle0' ), sdWorld.CreateImageFromFile( 'gauss_rifle1' ) ],
-			image1: [ sdWorld.CreateImageFromFile( 'gauss_rifle2' ), sdWorld.CreateImageFromFile( 'gauss_rifle3' ) ],
-			image2: [ sdWorld.CreateImageFromFile( 'gauss_rifle4' ), sdWorld.CreateImageFromFile( 'gauss_rifle5' ) ],
-			title: 'Gauss Rifle',
-			slot: 8,
-			reload_time: 300,
-			muzzle_x: 9,
-			ammo_capacity: -1,
-			count: 1,
-			matter_cost: 1000,
-			projectile_velocity: sdGun.default_projectile_velocity * 2,
-			min_workbench_level: 6,
-			min_build_tool_level: 3,
-			GetAmmoCost: ( gun, shoot_from_scenario )=>
-			{
-				if ( shoot_from_scenario )
-				return 0;
-			
-				if ( gun._held_by._auto_shoot_in > 0 )
-				return 0;
-				
-				return 50;
-			},
-			onShootAttempt: ( gun, shoot_from_scenario )=>
-			{
-				if ( !shoot_from_scenario )
-				{
-					if ( gun._held_by )
-					if ( gun._held_by._auto_shoot_in <= 0 )
-					{
-						
-						gun._held_by._auto_shoot_in = 1750 / 1000 * 30;
-
-						sdSound.PlaySound({ name: 'supercharge_combined2_part1', x:gun.x, y:gun.y, volume: 1.5, pitch: 0.5 });
-					}
-					return false;
-				}
-				else
-				{
-					sdSound.PlaySound({ name: 'gun_railgun_malicestorm_terrorphaser4', x:gun.x, y:gun.y, volume: 1.5, pitch: 2 });
-					
-				}
-			},
-			projectile_properties: { explosion_radius: 25, model: 'gauss_rifle_proj', _damage: 110, color:sdEffect.default_explosion_color }
-		};
-		
-		sdGun.classes[ sdGun.CLASS_COMBAT_RIFLE = 67 ] = 
-		{
-			image: sdWorld.CreateImageFromFile( 'combat_rifle' ),
-			sound: 'gun_the_ripper2',
-			sound_pitch: 2,
-			title: 'Combat Rifle',
-			slot: 2,
-			reload_time: 1.5,
-			muzzle_x: 10,
-			ammo_capacity: 30,
-			burst: 3,
-			burst_reload: 16,
-			count: 1,
-			matter_cost: 120,
-			projectile_velocity: sdGun.default_projectile_velocity * 1.3,
-			min_build_tool_level: 3,
-			projectile_properties: { _damage: 40 }
-		};
-
 		// Add new gun classes above this line //
 		
 		let index_to_const = [];

--- a/game/entities/sdGunClass.js
+++ b/game/entities/sdGunClass.js
@@ -1028,6 +1028,7 @@ class sdGunClass
 			muzzle_x: null,
 			ammo_capacity: -1,
 			count: 0,
+			min_build_tool_level: 1,
 			matter_cost: 300 / 2 * 2.5, // More DPS relative to stimpack
 			projectile_velocity: 16,
 			GetAmmoCost: ()=>

--- a/game/entities/sdSandWorm.js
+++ b/game/entities/sdSandWorm.js
@@ -112,9 +112,8 @@ class sdSandWorm extends sdEntity
 	
 	HasEnoughMatter( ent ) // sdSandWorms will actually hunt entities that have some amount of matter, for example one that is enough to buy damage upgrades. Thus won't target new players
 	{
-		return ( ent.matter >= 100 );
+		return ( ent.matter >= 200 ); // I think getting to 100 matter sets worms to hunt players while they're upgrading damage and health, this is more fair IMO - Booraz
 	}
-	
 	SyncedToPlayer( character ) // Shortcut for enemies to react to players
 	{
 		if ( this._hea > 0 )

--- a/game/game.js
+++ b/game/game.js
@@ -85,7 +85,7 @@ meSpeak.loadVoice("voices/en/en.json");
 	import sdBall from './entities/sdBall.js';
 	import sdTheatre from './entities/sdTheatre.js';
 	import sdCaption from './entities/sdCaption.js';
-	
+	import sdBaseShieldingUnit from './entities/sdBaseShieldingUnit.js';	
 
 	sdWorld.init_class();
 	sdRenderer.init_class();
@@ -147,6 +147,7 @@ meSpeak.loadVoice("voices/en/en.json");
 	sdSpider.init_class();
 	sdBall.init_class();
 	sdTheatre.init_class();
+	sdBaseShieldingUnit.init_class();
 
 	globalThis.sdCharacter = sdCharacter; // for console access
 	globalThis.sdEntity = sdEntity;

--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ import sdSpider from './game/entities/sdSpider.js';
 import sdBall from './game/entities/sdBall.js';
 import sdTheatre from './game/entities/sdTheatre.js';
 import sdCaption from './game/entities/sdCaption.js';
-
+import sdBaseShieldingUnit from './game/entities/sdBaseShieldingUnit.js';
 	
 
 
@@ -353,6 +353,7 @@ sdSpider.init_class();
 sdBall.init_class();
 sdTheatre.init_class();
 sdCaption.init_class();
+sdBaseShieldingUnit.init_class();
 
 /* Do like that later, not sure if I want to deal with path problems yet again... Add awaits where needed too
 
@@ -2223,8 +2224,6 @@ io.on("connection", (socket) =>
 				if ( sdWorld.time > socket.next_position_correction_allowed )
 				{
 					let corrected = false;
-					
-					const correction_scale = 3; // 1 should be most cheat-proof, but can be not enough for laggy servers
 
 					//if ( socket.character.hea > 0 )
 					if ( socket.character.AllowClientSideState() ) // Health and hook change
@@ -2236,39 +2235,39 @@ io.on("connection", (socket) =>
 						
 						if ( socket.character.stands || socket.character._in_air_timer < 500 / 1000 * 30 ) // Allow late jump
 						{
-							if ( dy < -27 * correction_scale )
+							if ( dy < -27 )
 							{
 								//console.log( 'dy', dy );
-								dy = -27 * correction_scale;
+								dy = -27;
 							}
 							
-							if ( dx > 30 * correction_scale )
+							if ( dx > 30 )
 							{
 								//console.log( 'dx', dx );
-								dx = 30 * correction_scale;
+								dx = 30;
 							}
 							else
-							if ( dx < -30 * correction_scale )
+							if ( dx < -30 )
 							{
 								//console.log( 'dx', dx );
-								dx = -30 * correction_scale;
+								dx = -30;
 							}
 						}
 						else
 						{
 							if ( socket.character.flying || socket.character._jetpack_allowed )
 							{
-								if ( dx > 20 * correction_scale )
-								dx = 20 * correction_scale;
+								if ( dx > 20 )
+								dx = 20;
 								else
-								if ( dx < -20 * correction_scale )
-								dx = -20 * correction_scale;
+								if ( dx < -20 )
+								dx = -20;
 						
-								if ( dy > 20 * correction_scale )
-								dy = 20 * correction_scale;
+								if ( dy > 20 )
+								dy = 20;
 								else
-								if ( dy < -20 * correction_scale )
-								dy = -20 * correction_scale;
+								if ( dy < -20 )
+								dy = -20;
 						
 								//console.log( 'flying', dx, dy );
 							}
@@ -2281,7 +2280,7 @@ io.on("connection", (socket) =>
 							}
 						}
 
-						if ( !allowed || Math.abs( dx ) > 128 * correction_scale || Math.abs( dy ) > 128 * correction_scale )
+						if ( !allowed || Math.abs( dx ) > 128 || Math.abs( dy ) > 128 )
 						{
 							dx = 0;
 							dy = 0;
@@ -2294,10 +2293,10 @@ io.on("connection", (socket) =>
 							//								arr[ 6 ] - ( socket.character.y + socket.character.sy / 30 * 100 ) );
 							
 							//if ( di > 128 )
-							if ( di > 64 * correction_scale )
+							if ( di > 64 )
 							{
-								dx = dx / di * 64 * correction_scale;
-								dy = dy / di * 64 * correction_scale;
+								dx = dx / di * 64;
+								dy = dy / di * 64;
 							}
 						//}
 						//else


### PR DESCRIPTION
A new entity type - base shielding unit.
Mechanics:
Costs around 600 matter.
It has 3000 starting health.
Can be moved around while it is turned off.
Needs 800 matter to be turned on ( right click -> turn on/off )
Doesn't consume matter when turned on.
Toggles off if below 800 matter automatically.
When turned on it scans around for nearby walls and doors and makes them indestructible ( as long as the shielding unit is near enough the walls and doors)
The walls which had been shielded by this unit cannot be overridden by other shielding units.
It can store up to 2 million matter inside itself.
Matter storing is done by dragging crystals into it ( like portals, for example )
Base shielding units can attack other base shielding units which are turned on ( right click -> attack nearby units )
Range of unit's radius is 275, 275 + 64 when attacking nearby units.
It attacks by draining matter from the other unit ( 350 matter per second, if it has enough) which forces the other unit to shut down ( and stop protecting the blocks it protected )

Sprite is placeholder.

I also temporarily removed deconstructor hammer, reinforced doors and walls. Reinforced walls and doors will be reworked sometime soon.

I'd recommend checking code, I believe there is room for improvement.

Flying mech changes
Mech will now only attack players if players shoot it first, or if the player has over 800 matter or a build tool/shop upgrade(s).
-This way it's more "optional" at the start instead of a necessity, they will target players which already acquired some upgrades while leaving the weaker / freshly spawned players alone. 
Minigun spawn chance increased to 8%. ( from 1% )
Players told me that they haven't found the minigun yet, which means it was too rare, especially since Cube overcharge cannon ( lost converter ) was frequent drop.

Erthal drone changes:
They will now target players if they have over 200 matter instead of instantly, or if a player engages with them.

Sand worms now target players if they have over 200 matter
-This was 100 matter, I changed it because once you acquire 100 matter, you start upgrading damage/hp, while worms active in ground move in to kill you. This effect was exponential when multiple worms are alive on the map. At least now you should be able to upgrade your character with basic necessities ( damage, HP, jetpack etc. ) without the worm being a major nuisance.