### PR TITLE
Bugfixes and additions, Event spawning system rework

### DIFF
--- a/game/entities/sdAsp.js
+++ b/game/entities/sdAsp.js
@@ -160,7 +160,7 @@ class sdAsp extends sdEntity
 		if ( this._hea <= 0 )
 		{
 			if ( this._tier !== 2 )
-			if ( this.death_anim < sdQuickie.death_duration + sdQuickie.post_death_ttl )
+			if ( this.death_anim < sdAsp.death_duration + sdAsp.post_death_ttl )
 			this.death_anim += GSPEED;
 			else
 			this.remove();

--- a/game/entities/sdAsp.js
+++ b/game/entities/sdAsp.js
@@ -50,8 +50,10 @@ class sdAsp extends sdEntity
 		
 		this.sx = 0;
 		this.sy = 0;
+
+		this._tier = params._tier || 1; // Used determine it's HP and damage
 		
-		this._hmax = 80;
+		this._hmax = 80 * this._tier;
 		this._hea = this._hmax;
 		
 		this.death_anim = 0;
@@ -157,7 +159,8 @@ class sdAsp extends sdEntity
 		
 		if ( this._hea <= 0 )
 		{
-			if ( this.death_anim < sdAsp.death_duration + sdAsp.post_death_ttl )
+			if ( this._tier !== 2 )
+			if ( this.death_anim < sdQuickie.death_duration + sdQuickie.post_death_ttl )
 			this.death_anim += GSPEED;
 			else
 			this.remove();
@@ -429,9 +432,17 @@ class sdAsp extends sdEntity
 				y = this.y + this._hitbox_y1 + Math.random() * ( this._hitbox_y2 - this._hitbox_y1 );
 				
 				//console.warn( { x: this.x, y: this.y, type:sdEffect.TYPE_GIB, sx: this.sx + Math.sin(a)*s, sy: this.sy + Math.cos(a)*s } )
-				
-				sdWorld.SendEffect({ x: x, y: y, type:sdEffect.TYPE_BLOOD_GREEN, filter:this.GetBleedEffectFilter() });
-				sdWorld.SendEffect({ x: x, y: y, type:sdEffect.TYPE_GIB_GREEN, sx: this.sx*k + Math.sin(a)*s, sy: this.sy*k + Math.cos(a)*s, filter:this.GetBleedEffectFilter() });
+				if ( this._tier !== 2 )
+				{
+					sdWorld.SendEffect({ x: x, y: y, type:sdEffect.TYPE_BLOOD_GREEN, filter:this.GetBleedEffectFilter() });
+					sdWorld.SendEffect({ x: x, y: y, type:sdEffect.TYPE_GIB_GREEN, sx: this.sx*k + Math.sin(a)*s, sy: this.sy*k + Math.cos(a)*s, filter:this.GetBleedEffectFilter() });
+				}
+				else
+				{
+					let value_mult = 4;
+					
+					sdWorld.DropShards( this.x,this.y,this.sx,this.sy, 3, value_mult, 3 );
+				}
 			}
 		}
 	}

--- a/game/entities/sdBeamProjector.js
+++ b/game/entities/sdBeamProjector.js
@@ -66,8 +66,8 @@ class sdBeamProjector extends sdEntity
 		this.sx = 0;
 		this.sy = 0;
 		
-		this.hmax = 30000;
-		this.hea = this.hmax / 20;
+		this.hmax = 1000;
+		this.hea = this.hmax;
 		this._regen_timeout = 0;
 		this._cooldown = 0;
 		this.has_anticrystal = false;
@@ -79,7 +79,7 @@ class sdBeamProjector extends sdEntity
 		//this.matter = 100;
 		
 		this._armor_protection_level = 0;
-		this._regen_mult = this._armor_protection_level + 1; // To prevent build HP upgrade actually increase the length of charging up the beam, this is needed.
+		this._regen_mult = 1;
 	}
 
 	IsEarlyThreat() // Used during entity build & placement logic - basically turrets, barrels, bombs should have IsEarlyThreat as true or else players would be able to spawn turrets through closed doors & walls. Coms considered as threat as well because their spawn can cause damage to other players
@@ -111,7 +111,7 @@ class sdBeamProjector extends sdEntity
 		if (!sdWorld.is_server)
 		return;
 
-		if ( this.hea === this.hmax )
+		if ( this.hea === this.hmax && this.has_anticrystal )
 		{
 			sdWorld.SendEffect({ 
 				x:this.x, 
@@ -382,6 +382,8 @@ class sdBeamProjector extends sdEntity
 		if ( !this.has_anticrystal )
 		{
 			this.has_anticrystal = true;
+			this.hmax = 30000;
+			this.hea = 1000;
 			from_entity.remove();
 			//this._update_version++;
 		}
@@ -431,12 +433,14 @@ class sdBeamProjector extends sdEntity
 		sdEntity.Tooltip( ctx, "Dark matter beam projector ( disabled )", 0, -10 );
 
 		let w = 40;
-	
-		ctx.fillStyle = '#000000';
-		ctx.fillRect( 0 - w / 2, 0 - 23, w, 3 );
+		if ( this.has_anticrystal )
+		{
+			ctx.fillStyle = '#000000';
+			ctx.fillRect( 0 - w / 2, 0 - 23, w, 3 );
 
-		ctx.fillStyle = '#FF0000';
-		ctx.fillRect( 1 - w / 2, 1 - 23, ( w - 2 ) * Math.max( 0, this.hea / this.hmax ), 1 );
+			ctx.fillStyle = '#FF0000';
+			ctx.fillRect( 1 - w / 2, 1 - 23, ( w - 2 ) * Math.max( 0, this.hea / this.hmax ), 1 );
+		}
 	}
 	
 	onRemove() // Class-specific, if needed

--- a/game/entities/sdEnemyMech.js
+++ b/game/entities/sdEnemyMech.js
@@ -239,7 +239,7 @@ class sdEnemyMech extends sdEntity
 					let r = Math.random();
 					let shards = 2 + Math.round( Math.random() * 3);
 			
-					if ( r < 0.25 )
+					if ( r < 0.35 )
 					{
 						let x = this.x;
 						let y = this.y;
@@ -252,11 +252,11 @@ class sdEnemyMech extends sdEntity
 
 							let gun;
 
-							if ( random_value < 0.35 )
+							if ( random_value < 0.45 )
 							gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_BUILDTOOL_UPG });
 							else
 							{
-								if ( random_value < 0.08 )
+								if ( random_value > 0.92 ) // ( random value < 0.08 ) couldn't occur because if it's below 0.5 it drops BT upgrade instead 
 								gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_FMECH_MINIGUN });
 								else
 								gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_RAIL_CANNON });

--- a/game/entities/sdQuickie.js
+++ b/game/entities/sdQuickie.js
@@ -89,7 +89,10 @@ class sdQuickie extends sdEntity
 	}
 	GetBleedEffectFilter()
 	{
+		if ( this._tier !== 2 )
 		return 'hue-rotate(-56deg)'; // Yellow
+		else
+		return this.filter;
 	}
 	Damage( dmg, initiator=null )
 	{

--- a/game/entities/sdQuickie.js
+++ b/game/entities/sdQuickie.js
@@ -62,8 +62,8 @@ class sdQuickie extends sdEntity
 		this.side = 1;
 
 		sdQuickie.quickies_tot++;
-		this.sd_filter = params.sd_filter || null; // Custom per-pixel filter
-		//this.filter = 'hue-rotate(' + ~~( Math.random() * 360 ) + 'deg)';
+		//this.sd_filter = params.sd_filter || null; // Custom per-pixel filter
+		this.filter = null;
 	}
 	SyncedToPlayer( character ) // Shortcut for enemies to react to players
 	{
@@ -139,6 +139,7 @@ class sdQuickie extends sdEntity
 		
 		if ( this._hea <= 0 )
 		{
+			if ( this._tier !== 2 )
 			if ( this.death_anim < sdQuickie.death_duration + sdQuickie.post_death_ttl )
 			this.death_anim += GSPEED;
 			else
@@ -271,8 +272,8 @@ class sdQuickie extends sdEntity
 	}
 	Draw( ctx, attached )
 	{
-		//ctx.filter = this.filter;
-		ctx.sd_filter = this.sd_filter;
+		ctx.filter = this.filter;
+		//ctx.sd_filter = this.sd_filter;
 		ctx.scale( this.side, 1 );
 		
 		if ( this.death_anim > 0 )
@@ -294,8 +295,8 @@ class sdQuickie extends sdEntity
 		}
 		
 		ctx.globalAlpha = 1;
-		ctx.sd_filter = null;
-		//ctx.filter = 'none';
+		//ctx.sd_filter = null;
+		ctx.filter = 'none';
 	}
 	/*onMovementInRange( from_entity )
 	{
@@ -325,9 +326,17 @@ class sdQuickie extends sdEntity
 				y = this.y + this._hitbox_y1 + Math.random() * ( this._hitbox_y2 - this._hitbox_y1 );
 				
 				//console.warn( { x: this.x, y: this.y, type:sdEffect.TYPE_GIB, sx: this.sx + Math.sin(a)*s, sy: this.sy + Math.cos(a)*s } )
-				
-				sdWorld.SendEffect({ x: x, y: y, type:sdEffect.TYPE_BLOOD_GREEN, filter:this.GetBleedEffectFilter() });
-				sdWorld.SendEffect({ x: x, y: y, type:sdEffect.TYPE_GIB_GREEN, sx: this.sx*k + Math.sin(a)*s, sy: this.sy*k + Math.cos(a)*s, filter:this.GetBleedEffectFilter() });
+				if ( this._tier !== 2 )
+				{
+					sdWorld.SendEffect({ x: x, y: y, type:sdEffect.TYPE_BLOOD_GREEN, filter:this.GetBleedEffectFilter() });
+					sdWorld.SendEffect({ x: x, y: y, type:sdEffect.TYPE_GIB_GREEN, sx: this.sx*k + Math.sin(a)*s, sy: this.sy*k + Math.cos(a)*s, filter:this.GetBleedEffectFilter() });
+				}
+				else
+				{
+					let value_mult = 4;
+					
+					sdWorld.DropShards( this.x,this.y,this.sx,this.sy, 3, value_mult, 3 );
+				}
 			}
 		}
 	}

--- a/game/entities/sdRift.js
+++ b/game/entities/sdRift.js
@@ -134,8 +134,10 @@ class sdRift extends sdEntity
 							{
 								let asp = new sdAsp({ 
 									x:this.x,
-									y:this.y
+									y:this.y,
+									_tier: 2
 								});
+								asp.filter = 'invert(1) sepia(1) saturate(100) hue-rotate(270deg) opacity(0.45)';
 								sdEntity.entities.push( asp );
 								sdWorld.UpdateHashPosition( asp, false ); // Prevent intersection with other ones
 							}
@@ -149,9 +151,10 @@ class sdRift extends sdEntity
 								_tier:2
 							});
 							//let quickie_filter = {};
-							let quickie_filter = sdWorld.CreateSDFilter();
-								sdWorld.ReplaceColorInSDFilter_v2( quickie_filter, '#000000', '#ff00ff' ) // Pink, stronger quickies
-							quickie.sd_filter = quickie_filter;
+							//let quickie_filter = sdWorld.CreateSDFilter();
+								//sdWorld.ReplaceColorInSDFilter_v2( quickie_filter, '#000000', '#ff00ff' ) // Pink, stronger quickies
+							//quickie.sd_filter = quickie_filter;
+							quickie.filter = 'invert(1) sepia(1) saturate(100) hue-rotate(270deg) opacity(0.45)';
 							sdEntity.entities.push( quickie );
 							sdWorld.UpdateHashPosition( quickie, false ); // Prevent intersection with other ones
 						}
@@ -234,7 +237,7 @@ class sdRift extends sdEntity
 			{
 				let r = Math.random();
 
-				if ( r < ( 0.13 + ( 0.05 * this.type ) ) )
+				if ( r < ( 0.23 + ( 0.05 * this.type ) ) )
 				{
 					let x = this.x;
 					let y = this.y;

--- a/game/entities/sdWeather.js
+++ b/game/entities/sdWeather.js
@@ -97,6 +97,7 @@ class sdWeather extends sdEntity
 		
 		//this._rain_offset = 0;
 		this._time_until_event = 30 * 30; // 30 seconds since world reset
+		this._daily_events = this.GetDailyEvents();
 		
 		this._asteroid_timer = 0; // 60 * 1000 / ( ( sdWorld.world_bounds.x2 - sdWorld.world_bounds.x1 ) / 800 )
 		this._asteroid_timer_scale_next = 0;
@@ -110,6 +111,43 @@ class sdWeather extends sdEntity
 		this.y2 = 0;
 		
 		//this.SetHiberState( sdEntity.HIBERSTATE_HIBERNATED_NO_COLLISION_WAKEUP, false );
+	}
+	GetDailyEvents() // Basically this function selects 4 random allowed events + earthquakes
+	{
+		this._daily_events = [ 8 ]; // Always enable earthquakes so ground can regenerate
+		let allowed_event_ids = ( sdWorld.server_config.GetAllowedWorldEvents ? sdWorld.server_config.GetAllowedWorldEvents() : undefined ) || [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ];
+				
+		let disallowed_ones = ( sdWorld.server_config.GetDisallowedWorldEvents ? sdWorld.server_config.GetDisallowedWorldEvents() : [] );
+				
+		//allowed_event_ids = [ 8 ]; // Hack
+				
+		for ( let d = 0; d < allowed_event_ids.length; d++ )
+		if ( disallowed_ones.indexOf( allowed_event_ids[ d ] ) !== -1 )
+		{
+			allowed_event_ids.splice( d, 1 );
+			d--;
+			continue;
+		}
+				
+		if ( allowed_event_ids.length > 0 )
+		{
+			let n = allowed_event_ids[ ~~( Math.random() * allowed_event_ids.length ) ];
+			let old_n = n;
+			let daily_event_count = Math.min( allowed_event_ids.length, 4 );
+			let time = 1000;
+			while ( daily_event_count > 0 && time > 0 )
+			{
+				old_n = n;
+				n = allowed_event_ids[ ~~( Math.random() * allowed_event_ids.length ) ];
+				if ( old_n !== n )
+				{
+					this._daily_events.push( n );
+					daily_event_count--;
+				}
+				time--;
+			}
+		}
+		//console.log( this._daily_events );
 	}
 	TraceDamagePossibleHere( x,y, steps_max=Infinity )
 	{
@@ -132,7 +170,10 @@ class sdWeather extends sdEntity
 			
 			this.day_time += GSPEED;
 			if ( this.day_time > 30 * 60 * 24 )
+			{
 			this.day_time = 0;
+			this.GetDailyEvents();
+			}
 			
 			if ( this._invasion ) // Invasion event
 			{
@@ -584,9 +625,9 @@ class sdWeather extends sdEntity
 			if ( this._time_until_event < 0 )
 			{
 				//this._time_until_event = Math.random() * 30 * 60 * 8; // once in an ~4 minutes (was 8 but more event kinds = less events sort of)
-				//this._time_until_event = Math.random() * 30 * 60 * 7; // once in an ~4 minutes (was 8 but more event kinds = less events sort of)
-				this._time_until_event = Math.random() * 30 * 60 * 3; // Changed after sdWeather logic was being called twice, which caused events to happen twice as frequently
-				let allowed_event_ids = ( sdWorld.server_config.GetAllowedWorldEvents ? sdWorld.server_config.GetAllowedWorldEvents() : undefined ) || [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ];
+				//this._time_until_event = Math.random() * 30 * 60 * 3; // Changed after sdWeather logic was being called twice, which caused events to happen twice as frequently
+				this._time_until_event = Math.random() * 30 * 60 * 3 * ( 12 / 5 ); // Changed after introducing "daily events" since there is only up to 5 events that can happen to prevent their overflow
+				/*let allowed_event_ids = ( sdWorld.server_config.GetAllowedWorldEvents ? sdWorld.server_config.GetAllowedWorldEvents() : undefined ) || [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ];
 				
 				let disallowed_ones = ( sdWorld.server_config.GetDisallowedWorldEvents ? sdWorld.server_config.GetDisallowedWorldEvents() : [] );
 				
@@ -598,11 +639,13 @@ class sdWeather extends sdEntity
 					allowed_event_ids.splice( d, 1 );
 					d--;
 					continue;
-				}
-				
+				}*/
+
+				let allowed_event_ids = this._daily_events;
 				if ( allowed_event_ids.length > 0 )
 				{
 					let r = allowed_event_ids[ ~~( Math.random() * allowed_event_ids.length ) ];
+					//console.log( r );
 
 					//r = 3; // Hack
 

--- a/game/entities/sdWeather.js
+++ b/game/entities/sdWeather.js
@@ -97,7 +97,7 @@ class sdWeather extends sdEntity
 		
 		//this._rain_offset = 0;
 		this._time_until_event = 30 * 30; // 30 seconds since world reset
-		this._daily_events = this.GetDailyEvents();
+		this._daily_events = [ 8 ];
 		
 		this._asteroid_timer = 0; // 60 * 1000 / ( ( sdWorld.world_bounds.x2 - sdWorld.world_bounds.x1 ) / 800 )
 		this._asteroid_timer_scale_next = 0;


### PR DESCRIPTION
Fixed beam projector instantly destroying after placing it.

Pink portals now dispense "crystal" quickies and asps.
They are transparent pink color and when killed, they shatter into crystal shards.

Since players were frequently bringing up the "mob horde" issue, I've decided to (at least temporarily) address it.
I've made a unique solution - upon every game's day/night cycle, it selects 4 random events which are enabled in server configuration (if possible), alongside with earthquakes ( they are guaranteed to appear every day ) and only those 4 selected spawn through the day cycle, until next day appears in-game ( 24 minutes if I remember correctly) when the new events get chosen. Same events can occur next day if RNG happens to choose them like that.
This way it won't stack mobs randomly and instead spawn a preset faction/mob set for 24 minutes.
This also means I had to change time_until_event from Math.random()*30*60*3 to Math.random()*30*60*3*(12/5) so it doesn't overflow the map with same mobs too quickly.

Portals and mechs had their chances to drop build tool upgrades increased. Mostly because they will be more rare due to the system above