### PR TITLE
Potential events being displayed in skybox/background

### DIFF
--- a/game/client/sdRenderer.js
+++ b/game/client/sdRenderer.js
@@ -128,6 +128,13 @@ class sdRenderer
 			//window.onresize();
 			
 			sdRenderer.img_dark_lands = sdWorld.CreateImageFromFile( 'dark_lands' );
+			//Insert images to draw in sky below
+			sdRenderer.img_cube = sdWorld.CreateImageFromFile( 'cube_idle' ); // Cube
+			sdRenderer.img_asp = sdWorld.CreateImageFromFile( 'asp_idle' ); // Asp
+			sdRenderer.img_fmech = sdWorld.CreateImageFromFile( 'fmech2' ); //Flying Mech
+			sdRenderer.img_drone_falkok = sdWorld.CreateImageFromFile( 'drone_falkok' ); // Falkok drone
+			sdRenderer.img_drone_robot = sdWorld.CreateImageFromFile( 'drone_robot2' ); // Erthal drone
+			sdRenderer.img_drone_alien = sdWorld.CreateImageFromFile( 'drone_alien' ); // Sarronian drone
 		}
 		
 		sdRenderer.image_filter_cache = new Map();
@@ -518,8 +525,86 @@ class sdRenderer
 			
 				//ctx.drawImage( sdRenderer.img_dark_lands, 0,0, sdRenderer.screen_width, sdRenderer.screen_height );
 				ctx.drawImageFilterCache( sdRenderer.img_dark_lands, 0,0, sdRenderer.screen_width, sdRenderer.screen_height );
+
+				if ( sdWeather.only_instance.draw_events.length > 0 ) // A very rough implementation of entities roaming in the sky, could do with many improvements - Booraz149
+				{
+					let n = 0;
+					for( let i = 0; i < sdWeather.only_instance.draw_events.length; i++)
+					{
+						n = sdWeather.only_instance.draw_events[ i ];
+						// Cubes
+						if ( n === 1 || n === 4 )
+						{
+							ctx.drawImageFilterCache( sdRenderer.img_cube, - 32 + ( ( 8 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 64 ) , 150, 32, 32 );
+							ctx.drawImageFilterCache( sdRenderer.img_cube, - 60 + ( ( 6 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 64 ) , 190, 32, 32 );
+							ctx.drawImageFilterCache( sdRenderer.img_cube, - 32 + ( ( 4 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 64 ) , 230, 32, 32 );
+						}
+						if ( n === 2 || n === 4 )
+						{
+							ctx.drawImageFilterCache( sdRenderer.img_cube, - 32 + ( ( 4 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 64 ) , 270, 32, 32 );
+							ctx.drawImageFilterCache( sdRenderer.img_cube, sdRenderer.screen_width + 64 - ( ( 3 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 128 ) , 310, 32, 32 );
+							ctx.drawImageFilterCache( sdRenderer.img_cube, sdRenderer.screen_width + 32 - ( ( 2 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 64 ) , 350, 32, 32 );
+						}
+						if ( n === 3 || n === 4 )
+						{
+							ctx.drawImageFilterCache( sdRenderer.img_cube, - 32 + ( ( 7 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 64 ) , 390, 32, 32 );
+							ctx.drawImageFilterCache( sdRenderer.img_cube, - 32 + ( ( 5 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 64 ) , 430, 32, 32 );
+							ctx.drawImageFilterCache( sdRenderer.img_cube, sdRenderer.screen_width + 32 - ( ( 6 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 64 ) , 470, 32, 32 );
+						}
+
+						// Asps
+						if ( n === 5 || n === 7 )
+						{
+							ctx.drawImageFilterCache( sdRenderer.img_asp, sdRenderer.screen_width + 320 - ( ( 7 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 640 ) , 120, 32, 32 );
+							ctx.drawImageFilterCache( sdRenderer.img_asp, sdRenderer.screen_width + 320 - ( ( 4 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 640 ) , 100, 32, 32 );
+							ctx.drawImageFilterCache( sdRenderer.img_asp, sdRenderer.screen_width + 320 - ( ( 6 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 640 ) , 80, 32, 32 );
+						}
+						if ( n === 6 || n === 7 )
+						{
+							ctx.drawImageFilterCache( sdRenderer.img_asp, sdRenderer.screen_width + 640 - ( ( 6 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 1280 ) , 60, 32, 32 );
+							ctx.drawImageFilterCache( sdRenderer.img_asp, sdRenderer.screen_width + 640 - ( ( 5 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 1280 ) , 40, 32, 32 );
+							ctx.drawImageFilterCache( sdRenderer.img_asp, sdRenderer.screen_width + 640 - ( ( 8 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 1280 ) , 20, 32, 32 );
+						}
+						
+						// Falkok invasion
+						if ( n === 8 )
+						{
+							ctx.drawImageFilterCache( sdRenderer.img_drone_falkok, sdRenderer.screen_width + 640 - ( ( 6 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 1280 ) , 500, 32, 32 );
+						}
+						// Flying mech
+						if ( n === 9 )
+						{
+							ctx.drawImageFilterCache( sdRenderer.img_fmech, sdRenderer.screen_width + 1920 - ( ( 3 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 3840 ) , 550, 64, 96 );
+						}
+						// Sarrorian faction spawn
+						if ( n === 12 )
+						{
+							ctx.drawImageFilterCache( sdRenderer.img_drone_alien, 1920 + ( ( 3 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 3840 ) , 600, -32, 32 );
+						}
+					}
+				}
 				
 				ctx.globalAlpha = 1;
+				if ( sdWeather.only_instance.draw_events.length > 0 ) // Same as above, only closer
+				{
+					let n = 0;
+					for( let i = 0; i < sdWeather.only_instance.draw_events.length; i++)
+					{
+						n = sdWeather.only_instance.draw_events[ i ];
+						// Flying mech
+						if ( n === 10 )
+						{
+							ctx.drawImageFilterCache( sdRenderer.img_fmech, sdRenderer.screen_width + 3840 - ( ( 3 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 3840 ) , 320, 128, 192 );
+						}
+						// Erthal faction spawn
+						if ( n === 11 )
+						{
+							ctx.drawImageFilterCache( sdRenderer.img_drone_robot, sdRenderer.screen_width + 640 - ( ( 5 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 640 ) , 280, 64, 64 );
+							ctx.drawImageFilterCache( sdRenderer.img_drone_robot, - 1280 + ( ( 5 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 1280 ) , 250, -64, 64 );
+							ctx.drawImageFilterCache( sdRenderer.img_drone_robot, - 1920 + ( ( 4 * sdWeather.only_instance.day_time % ( 30 * 60 * 24 ) ) / ( 30 * 60 * 24 ) ) * ( sdRenderer.screen_width + 1920 ) , 220, -64, 64 );
+						}
+					}
+				}
 				
 			}
 			

--- a/game/entities/sdWeather.js
+++ b/game/entities/sdWeather.js
@@ -137,6 +137,7 @@ class sdWeather extends sdEntity
 		//this._rain_offset = 0;
 		this._time_until_event = 30 * 30; // 30 seconds since world reset
 		this._daily_events = [ 8 ];
+		this.draw_events = []; // Used for sdRender to draw stuff in the background (cubes, drones, etc) to tell player these can spawn during that planet day.
 		
 		this._asteroid_timer = 0; // 60 * 1000 / ( ( sdWorld.world_bounds.x2 - sdWorld.world_bounds.x1 ) / 800 )
 		this._asteroid_timer_scale_next = 0;
@@ -158,6 +159,7 @@ class sdWeather extends sdEntity
 	GetDailyEvents() // Basically this function selects 4 random allowed events + earthquakes
 	{
 		this._daily_events = [ 8 ]; // Always enable earthquakes so ground can regenerate
+		this.draw_events = [];
 		let allowed_event_ids = ( sdWorld.server_config.GetAllowedWorldEvents ? sdWorld.server_config.GetAllowedWorldEvents() : undefined ) || [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ];
 				
 		let disallowed_ones = ( sdWorld.server_config.GetDisallowedWorldEvents ? sdWorld.server_config.GetDisallowedWorldEvents() : [] );
@@ -186,11 +188,42 @@ class sdWeather extends sdEntity
 				{
 					this._daily_events.push( n );
 					daily_event_count--;
+					// Select what to draw in skybox/background
+					if ( n === 2 )
+					{
+						let num = 1 + Math.round( Math.random() * 3 ); // 1 - 4
+						this.draw_events.push( num );
+					}
+					if ( n === 4 )
+					{
+						let num = 5 + Math.round( Math.random() * 2 ); // 5 - 7
+						this.draw_events.push( num );
+					}
+					if ( n === 5 )
+					{
+						let num = 8;
+						this.draw_events.push( num );
+					}
+					if ( n === 7 )
+					{
+						let num = 9 + Math.round( Math.random() * 1 ); // 9 - 10
+						this.draw_events.push( num );
+					}
+					if ( n === 11 )
+					{
+						let num = 11;
+						this.draw_events.push( num );
+					}
+					if ( n === 12 )
+					{
+						let num = 12;
+						this.draw_events.push( num );
+					}
 				}
 				time--;
 			}
+			//console.log( this.draw_events );
 		}
-		//console.log( this._daily_events );
 	}
 	TraceDamagePossibleHere( x,y, steps_max=Infinity, sun_light_tracer=false )
 	{


### PR DESCRIPTION
This is made as a pull request since this could be an experimental change.
This is a very rough version of this implementation, so improvements are always needed.

Basically what this pull request is about:
When a game rolls event which can spawn, it displays such a mob/entity in the sky background roaming around letting the player know that - that specific event can spawn.
Basically:
If cubes roam around in the sky, they can spawn as event aswell.
If falkonian drone can be seen roaming around, it means a falkok invasion can occur on map.
Flying mech? Same.
Erthal drone(s) means Erthal faction can spawn on the map aswell.
Same for (currently unfinished) Sarronian faction.