### PR TITLE
Sarronian changes/revamp

### DIFF
--- a/game/entities/sdDrone.js
+++ b/game/entities/sdDrone.js
@@ -1007,11 +1007,11 @@ class sdDrone extends sdEntity
 			if ( this.type === sdDrone.DRONE_ERTHAL )
 			sdEntity.Tooltip( ctx, "Erthal Drone" );
 			if ( this.type === sdDrone.DRONE_SARRORIAN )
-			sdEntity.Tooltip( ctx, "Sarronian Drone" );
+			sdEntity.Tooltip( ctx, "Sarronian Fighter E3" );
 			if ( this.type === sdDrone.DRONE_SARRORIAN_DETONATOR_CONTAINER )
-			sdEntity.Tooltip( ctx, "Sarronian Detonator Container" );
+			sdEntity.Tooltip( ctx, "Sarronian Carrier D7" );
 			if ( this.type === sdDrone.DRONE_SARRORIAN_DETONATOR )
-			sdEntity.Tooltip( ctx, "Sarronian Detonator" );
+			sdEntity.Tooltip( ctx, "Sarronian Detonator D7" );
 			if ( this.type === sdDrone.DRONE_COUNCIL )
 			sdEntity.Tooltip( ctx, "Council Support Drone" );
 			if ( this.type === sdDrone.DRONE_SETR )

--- a/game/entities/sdGunClass.js
+++ b/game/entities/sdGunClass.js
@@ -3640,16 +3640,17 @@ class sdGunClass
 			image0: [ sdWorld.CreateImageFromFile( 'gauss_rifle0' ), sdWorld.CreateImageFromFile( 'gauss_rifle1' ) ],
 			image1: [ sdWorld.CreateImageFromFile( 'gauss_rifle2' ), sdWorld.CreateImageFromFile( 'gauss_rifle3' ) ],
 			image2: [ sdWorld.CreateImageFromFile( 'gauss_rifle4' ), sdWorld.CreateImageFromFile( 'gauss_rifle5' ) ],
-			title: 'Gauss Rifle',
+			title: 'Sarronian Gauss Cannon',
 			slot: 8,
 			reload_time: 30 * 3, // 225,
 			muzzle_x: 9,
 			ammo_capacity: -1,
 			count: 1,
-			matter_cost: 1000,
+			// matter_cost: 1000,
+			spawnable: false,
 			projectile_velocity: sdGun.default_projectile_velocity * 2,
-			min_workbench_level: 6,
-			min_build_tool_level: 5,
+			// min_workbench_level: 6,
+			// min_build_tool_level: 5,
 			GetAmmoCost: ( gun, shoot_from_scenario )=>
 			{
 				if ( shoot_from_scenario )
@@ -3680,10 +3681,10 @@ class sdGunClass
 					
 				}
 			},
-			projectile_properties: { explosion_radius: 25, model: 'gauss_rifle_proj', _damage: 140, color:sdEffect.default_explosion_color },
+			projectile_properties: { explosion_radius: 24, model: 'gauss_rifle_proj', _damage: 128, color:sdEffect.default_explosion_color },
 			projectile_properties_dynamic: ( gun )=>{ 
 				
-				let obj = { explosion_radius: 25, model: 'gauss_rifle_proj', color:sdEffect.default_explosion_color };
+				let obj = { explosion_radius: 24, model: 'gauss_rifle_proj', color:sdEffect.default_explosion_color };
 				obj._knock_scale = 0.01 * 8 * gun.extra[ ID_DAMAGE_MULT ];
 				obj._damage = gun.extra[ ID_DAMAGE_VALUE ]; // Damage value is set onMade
 				obj._damage *= gun.extra[ ID_DAMAGE_MULT ];
@@ -3702,7 +3703,7 @@ class sdGunClass
 					//gun.extra[ ID_FIRE_RATE ] = 1;
 					gun.extra[ ID_RECOIL_SCALE ] = 1;
 					//gun.extra[ ID_SLOT ] = 1;
-					gun.extra[ ID_DAMAGE_VALUE ] = 140; // Damage value of the bullet, needs to be set here so it can be seen in weapon bench stats
+					gun.extra[ ID_DAMAGE_VALUE ] = 128; // Damage value of the bullet, needs to be set here so it can be seen in weapon bench stats
 					//UpdateCusomizableGunProperties( gun );
 				}
 			},
@@ -4271,15 +4272,15 @@ class sdGunClass
 			sound_pitch: 0.5,
 			title: 'Sarronian Energy Rifle',
 			slot: 8,
-			reload_time: 50,
+			reload_time: 45,
 			muzzle_x: 7,
 			ammo_capacity: -1,
 			count: 1,
 			spawnable: false,
-			projectile_properties: { model: 'ball_orange', color: '#ffc080', _damage: 20, explosion_radius: 32 },
+			projectile_properties: { model: 'ball_orange', color: '#ffc080', _damage: 32, explosion_radius: 12 },
 			projectile_properties_dynamic: ( gun )=>{ 
 				
-				let obj = { model: 'ball_orange', color: '#ffc080', explosion_radius: 32 };
+				let obj = { model: 'ball_orange', color: '#ffc080', explosion_radius: 12 };
 				obj._knock_scale = 0.01 * 8 * gun.extra[ ID_DAMAGE_MULT ];
 				obj._damage = gun.extra[ ID_DAMAGE_VALUE ]; // Damage value is set onMade
 				obj._damage *= gun.extra[ ID_DAMAGE_MULT ];
@@ -4298,7 +4299,7 @@ class sdGunClass
 					//gun.extra[ ID_FIRE_RATE ] = 1;
 					gun.extra[ ID_RECOIL_SCALE ] = 1;
 					//gun.extra[ ID_SLOT ] = 1;
-					gun.extra[ ID_DAMAGE_VALUE ] = 20; // Damage value of the bullet, needs to be set here so it can be seen in weapon bench stats
+					gun.extra[ ID_DAMAGE_VALUE ] = 32; // Damage value of the bullet, needs to be set here so it can be seen in weapon bench stats
 					//UpdateCusomizableGunProperties( gun );
 				}
 			},

--- a/game/entities/sdWeather.js
+++ b/game/entities/sdWeather.js
@@ -218,7 +218,7 @@ class sdWeather extends sdEntity
 				
 		let disallowed_ones = ( sdWorld.server_config.GetDisallowedWorldEvents ? sdWorld.server_config.GetDisallowedWorldEvents() : [] );
 				
-		//allowed_event_ids = [ 8 ]; // Hack
+		// allowed_event_ids = [ 8 ]; // Hack
 				
 		for ( let d = 0; d < allowed_event_ids.length; d++ )
 		if ( disallowed_ones.indexOf( allowed_event_ids[ d ] ) !== -1 )
@@ -1593,14 +1593,21 @@ class sdWeather extends sdEntity
 						{
 
 							//sdWorld.UpdateHashPosition( ent, false );
-								{ 
+								if ( Math.random() < 0.3 )
+								{
+									sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_GAUSS_RIFLE }) );
+									character_entity._ai_gun_slot = 8;
+								}
+								else
+								{
 									sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_ALIEN_ENERGY_RIFLE }) );
 									character_entity._ai_gun_slot = 8;
 								}
+
 								let char_settings;
 
 								if ( character_entity._ai_gun_slot === 8 )
-								char_settings = {"hero_name":"Sarronian Soldier","color_bright":"#202020","color_dark":"#101010","color_bright3":"#000000","color_dark3":"#101010","color_visor":"#FFA000","color_suit":"#202020","color_suit2":"#101010","color_dark2":"#101010","color_shoes":"#000000","color_skin":"#FFFF00","color_extra1":"#00FF00","helmet1":false,"helmet77":true,"voice1":false,"voice2":false,"voice3":false,"voice4":false,"voice10":true,"body18":true, "legs36":true};
+								char_settings = {"hero_name":"Sarronian E2 Unit","color_bright":"#202020","color_dark":"#101010","color_bright3":"#000000","color_dark3":"#101010","color_visor":"#FFA000","color_suit":"#202020","color_suit2":"#101010","color_dark2":"#101010","color_shoes":"#000000","color_skin":"#FFFF00","color_extra1":"#00FF00","helmet1":false,"helmet77":true,"voice1":false,"voice2":false,"voice3":false,"voice4":false,"voice10":true,"body18":true, "legs36":true};
 
 								character_entity.sd_filter = sdWorld.ConvertPlayerDescriptionToSDFilter_v2( char_settings );
 								character_entity._voice = sdWorld.ConvertPlayerDescriptionToVoice( char_settings );
@@ -3473,7 +3480,7 @@ class sdWeather extends sdEntity
 				}
 			}
 			
-			//this._time_until_event = 0; // Hack
+			// this._time_until_event = 0; // Hack
 			
 			this._time_until_event -= GSPEED;
 			if ( this._time_until_event < 0 )


### PR DESCRIPTION
Changed naming conventions to make them more unique with the help of THJ, tweaked the Sarronian energy rifle's stats and added the Gauss rifle which is now called the 'Sarronian Gauss Cannon' to the Sarronian weapon roster and also changed it's stats to fit the faction, which will be used by an unique Sarronian unit soon but for now will be used by the Sarronian E2 Unit (soldier).