### PR TITLE
Cache files whenever `serviceWorker` is in `navigator`

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -1,5 +1,5 @@
 
-/* global globalThis, sdTranslationManager, sdWorld, sdRenderer, sd_events, sdShop, sdGun, sdEntity, sdByteShifter, sdChat, sdSound, LZW, sdContextMenu, sdPathFinding, sdAdminPanel, sdDatabaseEditor, sdMotherShipStorageManager, sdCodeEditor, FakeCanvasContext, sdAtlasMaterial, sdCharacter */
+/* global globalThis, sw, sdTranslationManager, sdWorld, sdRenderer, sd_events, sdShop, sdGun, sdEntity, sdByteShifter, sdChat, sdSound, LZW, sdContextMenu, sdPathFinding, sdAdminPanel, sdDatabaseEditor, sdMotherShipStorageManager, sdCodeEditor, FakeCanvasContext, sdAtlasMaterial, sdCharacter */
 
 import sdTranslationManager from './client/sdTranslationManager.js';
 sdTranslationManager.init_class();

--- a/game/index.html
+++ b/game/index.html
@@ -19,6 +19,7 @@
 
 	<link rel="icon" href="favicon.png" type="image/png">
 
+	<script src="sdInitServiceWorker.js" type="module"></script>
 	<script src="client/sdUserAgent.js"></script>
     </head>
     <body>

--- a/game/sdInitServiceWorker.js
+++ b/game/sdInitServiceWorker.js
@@ -1,0 +1,38 @@
+if ( "serviceWorker" in navigator ) {
+	// TODO: change "/" if we decide to use database URL for this
+
+	navigator.serviceWorker.onmessage = event => {
+		console.log( "sdServiceWorker sent message:", event );
+	};
+
+	navigator.serviceWorker.onmessageerror = event => {
+		console.log( "sdServiceWorker encountered an error when sending a message:", event );
+	};
+
+	let sw = await navigator.serviceWorker.getRegistration( "/" ); // "/" for main URL
+
+	if ( !sw ) {
+		// So there's no current service worker registration,
+		// let's setup one.
+
+		sw = await navigator.serviceWorker.register( "./sdServiceWorker.js",
+			{
+				updateViaCache: "none" // No HTTP Cache.
+			} );
+	}
+
+	if ( !sw ) {
+		// This can usually happen if the internet goes down.
+		throw new Error( "sdServiceWorker initialization failed :(" );
+	}
+
+	sw.addEventListener( "updatefound", event => {
+		console.log( "sdServiceWorker update found" );
+	} );
+
+	await sw.update(); // Just in case
+
+	globalThis.sw = sw;
+} else {
+	throw new Error( "Service Worker is required to run the game properly." );
+}

--- a/game/sdServiceWorker.js
+++ b/game/sdServiceWorker.js
@@ -1,0 +1,74 @@
+
+// FAQ.
+// Q. Why can't I use `window`?
+// A. In web workers, the reason for that is because it has its own separate thread,
+// you're going to use `self` if you need to access anything.
+
+// This is a file to handle caching, speaking, whatever in this file.
+// This is also a file which can't use any ES modules (for now)
+
+// TODO: fix onfetch not initiating properly (currently takes a restart to do it)
+
+self.oninstall = async event => {
+	await ( await caches.open( "sdCache-v1" ) ).addAll( [
+			"/",
+			"/index.html",
+			"/style.css",
+			"/assets/fonts/CozetteVector.ttf",
+			"/assets/fonts/Oswald-Light.ttf",
+			"/assets/bg.png",
+			"/assets/ground_8x8.png",
+			"/favicon.png",
+			"/favicon.ico",
+			"/client/sdUserAgent.js",
+			"/client/sdErrorReporter.js",
+			"/client/sdTheatreAPIs.js",
+			"/libs/coloris/coloris.min.css",
+			"/libs/coloris/coloris.min.js",
+			"/libs/localforage.nopromises.min.js",
+			"/socketio/socketio.new.js",
+			"/libs/three.js",
+			"/libs/three-examples/BufferGeometryUtils.js",
+			"/libs/three-examples/MeshLine.js",
+			"/mespeak/mespeak.js",
+			"/libs/howler.js.min.js",
+			"/libs/acorn.cjs",
+			"/client/sdTranslationManager.js",
+			"/client/sdMobileKeyboard.js",
+			"/game.js",
+			"/client/sdMusic.js"
+	] );
+};
+
+self.onfetch = async event => {
+
+	// console.log( event.request ); // Check.
+
+	if ( event.request.destination === "" || event.request.method !== "GET" ) return; // Handle it differently
+
+	event.respondWith(
+		( async () => {
+			const cache = await caches.open( "sdCache-v1" );
+			const cachedResponse = await cache.match( event.request );
+
+			if ( cachedResponse ) {
+				// Assuming it has the cached response
+
+				// Update the entry too
+				// event.waitUntil( cache.add( event.request ) );
+				return cachedResponse;
+			}
+
+			// Assuming we haven't found a cached response yet
+			const file = await fetch( event.request );
+			// await cache.put( event.request, file ); // It hates this, I hate this. No one likes this.
+			const fileClone = file.clone(); // Clone, so that it wouldn't error on the original one
+			await cache.put( event.request, fileClone );
+			return file;
+		} )() );
+};
+
+// Debug
+/* self.serviceWorker.onstatechange = event => {
+	console.log( "Current state:", event.target.state );
+}; */


### PR DESCRIPTION
This allows us to cache files more efficiently and more reliable. Before, there was no caching and the only way you would see images, hear sounds, and run scripts is when you had to refresh.

It is still unstable for now, due to the service worker not running `onfetch` events in the background.

@Eric-Gurt if you know how to solve this problem, please do contribute on this draft PR.

Thanks