### PR TITLE
Fix sdTask null executer during reward claim task load

### DIFF
--- a/game/entities/sdTask.js
+++ b/game/entities/sdTask.js
@@ -202,6 +202,7 @@ class sdTask extends sdEntity
 				return -1;
 			},
 			onTaskMade: ( task, params )=>{
+				if ( task._executer ) // _executer can be null when reconstructed from a snapshot; such tasks are removed by failure_condition below, so skipping the progress string here is harmless. Without this guard, loading a snapshot throws "Cannot read properties of null (reading '_task_reward_counter')".
 				task.SetClaimRewardsProgress( Math.floor( task._executer._task_reward_counter ) ); // Also needs to update when players complete tasks, and claim rewards.
 			},
 			failure_condition: ( task )=>


### PR DESCRIPTION
Fixes a snapshot/load-time crash path in the Claim rewards task setup when `task._executer` is null.

Summary:
- Adds a minimal guard before reading `_task_reward_counter`.
- Leaves existing failure-condition behavior unchanged.

Verification:
- Verified previously in the audit branch with boot/load errors reduced from repeated `sdTask construction error in mission functions` entries to 0 in the tested world.