### PR TITLE
Optimize sdEntity registry removals with indexed swap-and-pop

### DIFF
--- a/game/entities/sdAbomination.js
+++ b/game/entities/sdAbomination.js
@@ -439,7 +439,7 @@ class sdAbomination extends sdEntity
 
 					bullet_obj.model = 'ab_tooth';
 
-					sdEntity.entities.push( bullet_obj );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj );
 				}
 						
 				this.attack_timer = 30;

--- a/game/entities/sdAsp.js
+++ b/game/entities/sdAsp.js
@@ -523,7 +523,7 @@ class sdAsp extends sdEntity
 										return false; // Go right through everything including walls
 									};
 								}
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 							}
 							
 							this.attack_frame = 3;

--- a/game/entities/sdAsteroid.js
+++ b/game/entities/sdAsteroid.js
@@ -122,7 +122,7 @@ class sdAsteroid extends sdEntity
 					else
 					{
 						let e = new sdMimic({ x: this.x, y: this.y });
-						sdEntity.entities.push( e );
+						sdEntity.AddEntityToEntitiesArray( e );
 						this.remove();
 					}
 
@@ -214,7 +214,7 @@ class sdAsteroid extends sdEntity
 				/*if ( this.type === sdAsteroid.TYPE_FLESH )
 				{
 					let ent = new sdMimic({ x: this.x, y: this.y });
-					sdEntity.entities.push( ent );
+					sdEntity.AddEntityToEntitiesArray( ent );
 					sdWorld.UpdateHashPosition( ent, false ); // Important! Prevents memory leaks and hash tree bugs
 					
 				}
@@ -304,7 +304,7 @@ class sdAsteroid extends sdEntity
 				bullet_obj._can_hit_owner = false;
 				bullet_obj.color = '#ffff00';
 
-				sdEntity.entities.push( bullet_obj );
+				sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 				this._warhead_detonated = true;
 			}
@@ -487,11 +487,11 @@ class sdAsteroid extends sdEntity
 				let yy = -this.sy / 4 + ( -Math.random() + Math.random() );
 				
 				let e = new sdEffect({ type: sdEffect.TYPE_SPARK, x:this.x, y:this.y, sx: xx, sy: yy, color: this._eff_color });
-				sdEntity.entities.push( e );
+				sdEntity.AddEntityToEntitiesArray( e );
 				if ( this.type !== sdAsteroid.TYPE_FLESH )
 				{
 					let e2 = new sdEffect({ type: sdEffect.TYPE_SMOKE, x:this.x + xx * 2, y:this.y + yy * 2, sx: xx, sy:yy, scale:1, radius:this.scale / 200, color:sdEffect.GetSmokeColor( sdEffect.smoke_colors ), spark_color:this._eff_color });
-					sdEntity.entities.push( e2 );
+					sdEntity.AddEntityToEntitiesArray( e2 );
 				}
 					
 				this._eff_timer = 1;

--- a/game/entities/sdBadDog.js
+++ b/game/entities/sdBadDog.js
@@ -616,7 +616,7 @@ class sdBadDog extends sdEntity
 									
 									this._owner = this.master; // To make bullets pass through master
 									
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 								}
 								else
 								this._last_turret_attack_attempt = sdWorld.time;

--- a/game/entities/sdBeamProjector.js
+++ b/game/entities/sdBeamProjector.js
@@ -225,7 +225,7 @@ class sdBeamProjector extends sdEntity
 				{
 					let worm = new sdSandWorm({ x:0, y:0 , kind:3, scale:0.5 });
 
-					sdEntity.entities.push( worm );
+					sdEntity.AddEntityToEntitiesArray( worm );
 
 					{
 						let x,y;
@@ -292,7 +292,7 @@ class sdBeamProjector extends sdEntity
 				{
 					let drone = new sdDrone({ x:0, y:0 , type: 18 });
 
-					sdEntity.entities.push( drone );
+					sdEntity.AddEntityToEntitiesArray( drone );
 								
 					let x,y;
 					let tr = 100;
@@ -421,13 +421,13 @@ class sdBeamProjector extends sdEntity
 
                 //gun.sx = sx;
                 //gun.sy = sy;
-                sdEntity.entities.push( gun );
+                sdEntity.AddEntityToEntitiesArray( gun );
                 
                 gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_UNSTABLE_CORE });
 
                 //gun.sx = sx;
                 //gun.sy = sy;
-                sdEntity.entities.push( gun );
+                sdEntity.AddEntityToEntitiesArray( gun );
 
                 gun._max_dps = Math.min( gun._max_dps * pylon_mult, 450 ); // Increase core power if pylons were used
 			}, 500 );
@@ -451,7 +451,7 @@ class sdBeamProjector extends sdEntity
 
 				if ( event_type !== 0 ) // Not a Council Nullifier?
 					{
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 						let x,y;
 						let tr = 100;
 						do
@@ -525,7 +525,7 @@ class sdBeamProjector extends sdEntity
 
 				if ( event_type !== 0 ) // Not a Council Nullifier?
 					{
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 						let x,y;
 						let tr = 100;
 						do
@@ -613,7 +613,7 @@ class sdBeamProjector extends sdEntity
 
 				let character_entity = new sdCharacter({ x:this.x, y:this.y, _ai_enabled:sdCharacter.AI_MODEL_TEAMMATE });
 
-				sdEntity.entities.push( character_entity );
+				sdEntity.AddEntityToEntitiesArray( character_entity );
 				{
 					let x,y;
 					let tr = 100;

--- a/game/entities/sdBlock.js
+++ b/game/entities/sdBlock.js
@@ -549,7 +549,7 @@ class sdBlock extends sdEntity
 									ent = new sdWorld.entity_classes[ this._contains_class ]( params );
 									if ( parts.length < 2 ) // If worm is not corrupted, etc, spawn regular worm types
 									ent.kind = Math.random() < 0.15 ? 1 : 0; // 15% chance for the worm to be spiky
-									sdEntity.entities.push( ent );
+									sdEntity.AddEntityToEntitiesArray( ent );
 									sdWorld.UpdateHashPosition( ent, false ); // Important! Prevents memory leaks and hash tree bugs
 
 
@@ -601,7 +601,7 @@ class sdBlock extends sdEntity
 									}
 
 									ent = new sdWorld.entity_classes[ this._contains_class ]( params );
-									sdEntity.entities.push( ent );
+									sdEntity.AddEntityToEntitiesArray( ent );
 									sdWorld.UpdateHashPosition( ent, false ); // Important! Prevents memory leaks and hash tree bugs
 
 
@@ -653,7 +653,7 @@ class sdBlock extends sdEntity
 									}
 
 									ent = new sdWorld.entity_classes[ this._contains_class ]( params );
-									sdEntity.entities.push( ent );
+									sdEntity.AddEntityToEntitiesArray( ent );
 									sdWorld.UpdateHashPosition( ent, false ); // Important! Prevents memory leaks and hash tree bugs
 
 
@@ -704,7 +704,7 @@ class sdBlock extends sdEntity
 									}
 
 									ent = new sdWorld.entity_classes[ this._contains_class ]( params );
-									sdEntity.entities.push( ent );
+									sdEntity.AddEntityToEntitiesArray( ent );
 									sdWorld.UpdateHashPosition( ent, false ); // Important! Prevents memory leaks and hash tree bugs
 
 
@@ -749,7 +749,7 @@ class sdBlock extends sdEntity
 								}
 
 								ent = new sdWorld.entity_classes[ this._contains_class ]( params );
-								sdEntity.entities.push( ent );
+								sdEntity.AddEntityToEntitiesArray( ent );
 
 								sdWorld.UpdateHashPosition( ent, false ); // Important! Prevents memory leaks and hash tree bugs
 							}
@@ -2453,7 +2453,7 @@ class sdBlock extends sdEntity
 					let new_bg = new sdBG({ x:this.x, y:this.y, width:this.width, height:this.height, material:sdBG.MATERIAL_GROUND, hue:this.hue, br:this.br * 0.5, filter:this.filter, natural:this._natural });
 					if ( new_bg.CanMoveWithoutOverlap( this.x, this.y, 1 ) )
 					{
-						sdEntity.entities.push( new_bg );
+						sdEntity.AddEntityToEntitiesArray( new_bg );
 						sdWorld.UpdateHashPosition( new_bg, false, true );
 					}
 					else
@@ -2542,15 +2542,15 @@ class sdBlock extends sdEntity
                         
                         
                         if ( this.material === sdBlock.MATERIAL_SNOW )
-                        sdEntity.entities.push( new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_ROCK, filter:'brightness(0) invert(1)', sx: Math.sin(a)*s, sy: Math.cos(a)*s }) );
+                        sdEntity.AddEntityToEntitiesArray( new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_ROCK, filter:'brightness(0) invert(1)', sx: Math.sin(a)*s, sy: Math.cos(a)*s }) );
                         else
                         if ( this.material === sdBlock.MATERIAL_FLESH )
-                        sdEntity.entities.push( new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_GIB, sx: Math.sin(a)*s, sy: Math.cos(a)*s }) );
+                        sdEntity.AddEntityToEntitiesArray( new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_GIB, sx: Math.sin(a)*s, sy: Math.cos(a)*s }) );
                         else
                         if ( this.texture_id === sdBlock.TEXTURE_ID_GLASS )
-                        sdEntity.entities.push( new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_GLASS, sx: Math.sin(a)*s*1.5, sy: Math.cos(a)*s*1.5 }) );
+                        sdEntity.AddEntityToEntitiesArray( new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_GLASS, sx: Math.sin(a)*s*1.5, sy: Math.cos(a)*s*1.5 }) );
                         else
-                        sdEntity.entities.push( new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_ROCK, sx: Math.sin(a)*s, sy: Math.cos(a)*s }) );
+                        sdEntity.AddEntityToEntitiesArray( new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_ROCK, sx: Math.sin(a)*s, sy: Math.cos(a)*s }) );
                     }
                 }
 			}

--- a/game/entities/sdBloodDecal.js
+++ b/game/entities/sdBloodDecal.js
@@ -150,7 +150,7 @@ class sdBloodDecal extends sdEntity
 					if ( Math.random() < sdWorld.server_config.roach_spawn_rate ) // Depends on server config option, default is 50%
 					{
 						let ent = new sdRoach({ x: this.x + this._hitbox_x2 / 2, y: this.y + this._hitbox_y2 / 2, type: Math.random() < 0.05 ? sdRoach.TYPE_MOTH : sdRoach.TYPE_ROACH });
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 						
 						if ( !ent.CanMoveWithoutOverlap( ent.x, ent.y ) )
 						{

--- a/game/entities/sdBot.js
+++ b/game/entities/sdBot.js
@@ -673,7 +673,7 @@ class sdBot extends sdEntity
 
 			//this._owner = this.master; // To make bullets pass through master
 
-			sdEntity.entities.push( bullet_obj );
+			sdEntity.AddEntityToEntitiesArray( bullet_obj );
 		}
 	}
 	

--- a/game/entities/sdBotFactory.js
+++ b/game/entities/sdBotFactory.js
@@ -636,7 +636,7 @@ function BrainModelB()
 						this.matter -= 600;
 					
 						let ent = new sdBot({ x: this.x, y: this.y, owner: this, kind: this._building_kind, code: '('+this._building_brain_function_code+')()' });
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 
 						this._bot_net_ids.push( ent._net_id );
 

--- a/game/entities/sdBubbleShield.js
+++ b/game/entities/sdBubbleShield.js
@@ -197,7 +197,7 @@ class sdBubbleShield extends sdEntity
 		else
 		{
 			let new_shield = new sdBubbleShield({ x:for_entity.x, y:for_entity.y, for_ent: for_entity, type: shield_type, manual_hitbox_override: manual_override, xscale: xsize, yscale: ysize });
-			sdEntity.entities.push( new_shield );
+			sdEntity.AddEntityToEntitiesArray( new_shield );
 			
 			if ( typeof for_entity._shield_ent === 'undefined' )
 			throw new Error( 'sdBubbleShield now requires entity it is made for to have property ._shield_ent = null;' );

--- a/game/entities/sdBullet.js
+++ b/game/entities/sdBullet.js
@@ -998,7 +998,7 @@ class sdBullet extends sdEntity
 				{
 					let colors = [ '#777777', '#666666', '#555555' ]
 					let ent = new sdEffect({ x: this.x, y: this.y, sy:-1, type:sdEffect.TYPE_SMOKE, color:sdEffect.GetSmokeColor( colors )});
-					sdEntity.entities.push( ent );
+					sdEntity.AddEntityToEntitiesArray( ent );
 					
 					this._smoke_spawn_wish = 0.5;
 				}

--- a/game/entities/sdCable.js
+++ b/game/entities/sdCable.js
@@ -360,7 +360,7 @@ class sdCable extends sdEntity
                     bullet._owner._built_cables.push( ent );
                     //bullet._owner.Say( 'Start connected to ' + ( target_entity.title || target_entity.GetClass() ) );
 
-                    sdEntity.entities.push( ent );
+                    sdEntity.AddEntityToEntitiesArray( ent );
                 }
             }
 				

--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -1830,7 +1830,7 @@ THING is cosmic mic drop!`;
 
 							bullet_obj._armor_penetration_level = 0;
 
-							sdEntity.entities.push( bullet_obj );
+							sdEntity.AddEntityToEntitiesArray( bullet_obj );
 							
 							sdSound.PlaySound({ name:'sword_attack2', x:this.x, y:this.y, volume: 0.5, pitch: 1 });
 						}
@@ -1998,7 +1998,7 @@ THING is cosmic mic drop!`;
 								if ( this.s >= 249 )
 								bullet_obj._damage = 200; // Falkonian sword bot should be lethal at close range.
 
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 							}
 						}
 					}
@@ -2613,7 +2613,7 @@ THING is cosmic mic drop!`;
 			// Create temporary copy just for visuals
 			//let copy_ent = new sdCharacter({ x:this.x, y:this.y });
 			let copy_ent = new sdWorld.entity_classes[ this.GetClass() ]({ x:this.x, y:this.y });
-			sdEntity.entities.push( copy_ent );
+			sdEntity.AddEntityToEntitiesArray( copy_ent );
 			copy_ent.ApplySnapshot( this.GetSnapshot( 0, true, null ) );
 			copy_ent.hea = Math.min( copy_ent.hea, -1 );
 			copy_ent.stability = 0;
@@ -2962,7 +2962,7 @@ THING is cosmic mic drop!`;
 
             ent._held_by = null;
 
-            sdEntity.entities.push( ent );
+            sdEntity.AddEntityToEntitiesArray( ent );
 
             this._ignored_guns_infos.push( { ent: ent, until: sdWorld.time + 300 } );
             this.TriggerMovementInRange();
@@ -5374,7 +5374,7 @@ THING is cosmic mic drop!`;
 						if ( !this._hook_projectile._is_being_removed )
 						this._hook_projectile.remove();
 
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 						this._hook_projectile = bullet_obj;
 						this.hook_projectile_net_id = bullet_obj._net_id;
@@ -5809,7 +5809,7 @@ THING is cosmic mic drop!`;
 					let type = sdEffect.TYPE_SPARK;
 					
 					let e = new sdEffect({ type: type, x:this.x + offset, y:this.y, sx: this.sx / 2 + ( -Math.random() + Math.random() ) * 2, sy: this.sy / 2 + Math.random() * 4, color: '#ffff00' });
-					sdEntity.entities.push( e );
+					sdEntity.AddEntityToEntitiesArray( e );
 					
 					this._jetpack_effect_timer = 2;
 				}
@@ -8279,7 +8279,7 @@ THING is cosmic mic drop!`;
 				RequireCensorshipTest();
 				
 				let ef = new sdEffect( params );
-				sdEntity.entities.push( ef );
+				sdEntity.AddEntityToEntitiesArray( ef );
 			}
 		}
 	}

--- a/game/entities/sdCharacterRagdoll.js
+++ b/game/entities/sdCharacterRagdoll.js
@@ -803,10 +803,10 @@ class sdCharacterRagdoll
 				if ( preview_screeen_mode )
 				{
 					this.bones[ i ]._remove();
-					
-					let id = sdEntity.entities.indexOf( this.bones[ i ] );
-					if ( id !== -1 )
-					sdEntity.entities.splice( id, 1 );
+
+					// Swap-and-pop via the registry helper (keeps _entities_array_index valid); a raw
+					// indexOf()+splice() here would shift every later entity without fixing their index.
+					sdEntity.RemoveEntityFromEntitiesArray( this.bones[ i ] );
 				}
 			}
 		}
@@ -820,14 +820,14 @@ class sdCharacterRagdoll
 		//radius *= this.character.s / 100;
 	
 		let bone = new sdBone({ x:this.character.x + x - 16, y:this.character.y + y - 16, radius: ( radius > 2 ) ? radius * 0.5 : radius, ragdoll:this, sx:this.character.sx, sy:this.character.sy, bone_name:part_name, initial_x:x, initial_y:y, bounciness:bounciness, friction_remain:friction_remain, soft_bone_of:null });
-		sdEntity.entities.push( bone );
+		sdEntity.AddEntityToEntitiesArray( bone );
 		this.bones.push( bone );
 	
 		// Has side effect of mass increase. Makes impacts more interesting
 		if ( radius > 2 )
 		{
 			let soft_bone = new sdBone({ x:this.character.x + x - 16, y:this.character.y + y - 16, radius:radius, ragdoll:this, sx:this.character.sx, sy:this.character.sy, bone_name:'soft_'+part_name, initial_x:x, initial_y:y, bounciness:bounciness, friction_remain:friction_remain, soft_bone_of:bone });
-			sdEntity.entities.push( soft_bone );
+			sdEntity.AddEntityToEntitiesArray( soft_bone );
 			this.springs.push( new sdSpring( bone, soft_bone, null, 0, 0, 0, sdCharacterRagdoll.spring_both ) );
 			this.bones.push( soft_bone );
 			

--- a/game/entities/sdCom.js
+++ b/game/entities/sdCom.js
@@ -377,7 +377,7 @@ class sdCom extends sdEntity
 									type: sdCable.TYPE_MATTER
 								});
 
-								sdEntity.entities.push( cable );
+								sdEntity.AddEntityToEntitiesArray( cable );
 
 								if ( this._hacker )
 								{

--- a/game/entities/sdCommandCentre.js
+++ b/game/entities/sdCommandCentre.js
@@ -316,7 +316,7 @@ class sdCommandCentre extends sdEntity
 				a = Math.random() * 2 * Math.PI;
 				s = Math.random() * 4;
 				let ent = new sdEffect({ x: this.x + x - 16, y: this.y + y - 16, type:sdEffect.TYPE_ROCK, sx: Math.sin(a)*s, sy: Math.cos(a)*s });
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 			}
 		}
 	}

--- a/game/entities/sdConveyor.js
+++ b/game/entities/sdConveyor.js
@@ -529,7 +529,7 @@ class sdConveyor extends sdEntity
 					a = Math.random() * 2 * Math.PI;
 					s = Math.random() * 4;
 					let ent = new sdEffect({ x: this.x + x - 16, y: this.y + y - 4, type:sdEffect.TYPE_ROCK, sx: Math.sin(a)*s, sy: Math.cos(a)*s });
-					sdEntity.entities.push( ent );
+					sdEntity.AddEntityToEntitiesArray( ent );
 				}
 			}
 		}

--- a/game/entities/sdCouncilIncinerator.js
+++ b/game/entities/sdCouncilIncinerator.js
@@ -349,7 +349,7 @@ class sdCouncilIncinerator extends sdEntity
 
 				drone._ignore_collisions_with = this; // Make sure it can pass through the destroyer 
 
-				sdEntity.entities.push( drone );
+				sdEntity.AddEntityToEntitiesArray( drone );
 
 				//sdSound.PlaySound({ name:'gun_spark', x:this.x, y:this.y, volume:1.25, pitch:0.1 });
 			}*/
@@ -476,7 +476,7 @@ class sdCouncilIncinerator extends sdEntity
 
 							gun.sx = sx;
 							gun.sy = sy;
-							sdEntity.entities.push( gun );
+							sdEntity.AddEntityToEntitiesArray( gun );
 
 						}, 500 );
 					}
@@ -503,7 +503,7 @@ class sdCouncilIncinerator extends sdEntity
 
 							gun.sx = sx;
 							gun.sy = sy;
-							sdEntity.entities.push( gun );
+							sdEntity.AddEntityToEntitiesArray( gun );
 
 						}, 500 );
 					}
@@ -525,7 +525,7 @@ class sdCouncilIncinerator extends sdEntity
 
 							gun.sx = sx + Math.random() - Math.random();
 							gun.sy = sy + Math.random() - Math.random();
-							sdEntity.entities.push( gun );
+							sdEntity.AddEntityToEntitiesArray( gun );
 
 						}, 500 );
 						shards--;
@@ -564,7 +564,7 @@ class sdCouncilIncinerator extends sdEntity
 					let drone_type = ( this.hea <= this._hmax / 2 ) ? sdDrone.DRONE_COUNCIL : sdDrone.DRONE_COUNCIL_ATTACK; // If it has enough health, spawn attack drones, else spawn healers
 					
 					let drone = new sdDrone({ x: this.x - 96 + ( Math.random() * 192 ), y: this.y - 96 + ( Math.random() * 192 ), type: drone_type, _ai_team: this._ai_team, minion_of: this }); // We do a little trolling
-					sdEntity.entities.push( drone );
+					sdEntity.AddEntityToEntitiesArray( drone );
 
 					// Make sure drone has any speed when deployed so drones don't get stuck into each other
 					if ( Math.abs( drone.sx ) < 0.5 )
@@ -889,7 +889,7 @@ class sdCouncilIncinerator extends sdEntity
 									bullet_obj._damage = 30;
 									bullet_obj.color = 'ffff00';
 
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 
 									//sdSound.PlaySound({ name:'gun_rocket', x:this.x, y:this.y, volume:1, pitch:0.5 });
@@ -945,7 +945,7 @@ class sdCouncilIncinerator extends sdEntity
 						else
 						ent = new sdEffect({ x:xx, y:yy, sx:( Math.random() * 2 - 1 ) * 1, sy:( Math.random() * 2 - 1 ) * 1, type:sdEffect.TYPE_FIRE });
 
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 					}
 				}
 			}

--- a/game/entities/sdCouncilMachine.js
+++ b/game/entities/sdCouncilMachine.js
@@ -93,7 +93,7 @@ class sdCouncilMachine extends sdEntity
 			{
 				let drone = new sdDrone({ x:0, y:0 , type: 18});
 
-				sdEntity.entities.push( drone );
+				sdEntity.AddEntityToEntitiesArray( drone );
 								
 				let x,y;
 				let tr = 100;
@@ -231,7 +231,7 @@ class sdCouncilMachine extends sdEntity
 
 					//gun.sx = sx;
 					//gun.sy = sy;
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 
 					}, 500 );
 				}
@@ -258,7 +258,7 @@ class sdCouncilMachine extends sdEntity
 
 						gun.sx = sx;
 						gun.sy = sy;
-						sdEntity.entities.push( gun );
+						sdEntity.AddEntityToEntitiesArray( gun );
 
 					}, 500 );
 				}
@@ -383,7 +383,7 @@ class sdCouncilMachine extends sdEntity
 
 				setTimeout(()=>{//Just in case
 					let portal = new sdRift({x: this.x, y:this.y, type:5 });
-					sdEntity.entities.push( portal );
+					sdEntity.AddEntityToEntitiesArray( portal );
 				}, 500 );
 
 				this.remove();
@@ -410,7 +410,7 @@ class sdCouncilMachine extends sdEntity
 				bullet_obj.time_left = 90 + Math.random() * 60; // 3-5 seconds after flare spawn to summon the humanoids
 				bullet_obj._bouncy = true;
 				
-				sdEntity.entities.push( bullet_obj );
+				sdEntity.AddEntityToEntitiesArray( bullet_obj );
 									
 				sdSound.PlaySound({ name:'explosion', x:this.x, y:this.y, volume:1, pitch:0.25 });
 				sdSound.PlaySound({ name:'council_teleport', x:this.x, y:this.y, volume:0.5, pitch:2 });
@@ -421,7 +421,7 @@ class sdCouncilMachine extends sdEntity
 					{
 						let drone = new sdDrone({ x:0, y:0 , _ai_team: 3, type: 6});
 
-						sdEntity.entities.push( drone );
+						sdEntity.AddEntityToEntitiesArray( drone );
 
 						{
 							let x,y;
@@ -475,7 +475,7 @@ class sdCouncilMachine extends sdEntity
 					{
 						let worm = new sdSandWorm({ x:0, y:0 , kind:3, scale:0.5});
 
-						sdEntity.entities.push( worm );
+						sdEntity.AddEntityToEntitiesArray( worm );
 
 						{
 							let x,y;

--- a/game/entities/sdCouncilNullifier.js
+++ b/game/entities/sdCouncilNullifier.js
@@ -101,7 +101,7 @@ class sdCouncilNullifier extends sdEntity
 			{
 				let drone = new sdDrone({ x:0, y:0 , type: sdDrone.DRONE_COUNCIL_ATTACK });
 
-				sdEntity.entities.push( drone );
+				sdEntity.AddEntityToEntitiesArray( drone );
 								
 				let x,y;
 				let tr = 100;
@@ -168,7 +168,7 @@ class sdCouncilNullifier extends sdEntity
 			{
 				let drone = new sdDrone({ x:0, y:0 , type: sdDrone.DRONE_COUNCIL });
 
-				sdEntity.entities.push( drone );
+				sdEntity.AddEntityToEntitiesArray( drone );
 								
 				let x,y;
 				let tr = 100;
@@ -243,7 +243,7 @@ class sdCouncilNullifier extends sdEntity
 
 				//gun.sx = sx;
 				//gun.sy = sy;
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 
 				}, 500 );
 			}
@@ -266,7 +266,7 @@ class sdCouncilNullifier extends sdEntity
 
 					gun.sx = sx;
 					gun.sy = sy;
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 
 				}, 500 );
 			}
@@ -421,7 +421,7 @@ class sdCouncilNullifier extends sdEntity
 					bullet_obj.time_left = 90 + Math.random() * 60;
 					bullet_obj._bouncy = true;
 					
-					sdEntity.entities.push( bullet_obj );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj );
 									
 					sdSound.PlaySound({ name:'explosion', x:this.x, y:this.y, volume:1, pitch:0.25 });
 					sdSound.PlaySound({ name:'council_teleport', x:this.x, y:this.y, volume:0.5, pitch:2 });

--- a/game/entities/sdCraftingBench.js
+++ b/game/entities/sdCraftingBench.js
@@ -233,7 +233,7 @@ class sdCraftingBench extends sdEntity
         if ( craft.callback )
         craft.callback( gun );
 
-        sdEntity.entities.push( gun );
+        sdEntity.AddEntityToEntitiesArray( gun );
         gun.ApplyStatusEffect({ type: sdStatusEffect.TYPE_BUILT_ENTITY });
 	
         return true;

--- a/game/entities/sdCrystal.js
+++ b/game/entities/sdCrystal.js
@@ -146,8 +146,8 @@ class sdCrystal extends sdEntity
 							a.sy = e.sy;
 							b.sx = e.sx;
 							b.sy = e.sy;
-							sdEntity.entities.push( a );
-							sdEntity.entities.push( b );
+							sdEntity.AddEntityToEntitiesArray( a );
+							sdEntity.AddEntityToEntitiesArray( b );
 
 							let okA = false;
 							let okB = false;
@@ -371,7 +371,7 @@ class sdCrystal extends sdEntity
 								if ( yy === 0 )
 								ent.y += ent.hitbox_y1 - ent.hitbox_y2 - 0.1;
 
-								sdEntity.entities.push( ent );
+								sdEntity.AddEntityToEntitiesArray( ent );
 								sdWorld.UpdateHashPosition( ent, false ); // Optional, but will make it visible as early as possible
 
 								if ( !ent.CanMoveWithoutOverlap( ent.x, ent.y, 0 ) )
@@ -2014,7 +2014,7 @@ class sdCrystal extends sdEntity
 						ent.matter = this.matter / 4;
 						ent.matter_regen = this.matter_regen;
 
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 						sdWorld.UpdateHashPosition( ent, false ); // Optional, but will make it visible as early as possible
 
 						replacement_entity = ent;

--- a/game/entities/sdCrystalCombiner.js
+++ b/game/entities/sdCrystalCombiner.js
@@ -217,7 +217,7 @@ class sdCrystalCombiner extends sdEntity
 				else
 				ent.matter_regen = snapshot.crystal1_matter_regen;
 
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 				sdWorld.UpdateHashPosition( ent, false ); // Optional, but will make it visible as early as possible
 
 				if ( snapshot.crystals === 1 )
@@ -504,7 +504,7 @@ class sdCrystalCombiner extends sdEntity
 				this._next_steam_spawn = sdWorld.time + 1000 * 2 + 1000 * 2 * Math.random();
 
 				let ent = new sdEffect({ x: this.x + ( this.hitbox_x2 - this.hitbox_x1 ) * ( Math.random() - 0.5 ), y: this.y, sy:-2, type:sdEffect.TYPE_SMOKE, color:'#eeeeee', spark_color: false });
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 			}
 		}
 		

--- a/game/entities/sdCube.js
+++ b/game/entities/sdCube.js
@@ -838,7 +838,7 @@ class sdCube extends sdEntity
 
 							sdCube.ColorGunAccordingly( gun, this.kind );
 
-							sdEntity.entities.push( gun );
+							sdEntity.AddEntityToEntitiesArray( gun );
 
 							this._dropped_items.add( gun );
 
@@ -868,7 +868,7 @@ class sdCube extends sdEntity
 						gun.sy = sy;
 						//gun.extra = (this.kind === sdCube.KIND_PINK ? 3 : this.kind === sdCube.KIND_WHITE ? 2 : this.kind === sdCube.KIND_YELLOW ? 1 : 0 ); // Color it
 						sdCube.ColorGunAccordingly( gun, this.kind );
-						sdEntity.entities.push( gun );
+						sdEntity.AddEntityToEntitiesArray( gun );
 
 						this._dropped_items.add( gun );
 
@@ -885,7 +885,7 @@ class sdCube extends sdEntity
 						gun = new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_BUILDTOOL_UPG });
 						gun.extra = 0;
 
-						sdEntity.entities.push( gun );
+						sdEntity.AddEntityToEntitiesArray( gun );
 						//sdWorld.UpdateHashPosition( gun, false );
 						
 						this._dropped_items.add( gun );
@@ -986,7 +986,7 @@ class sdCube extends sdEntity
 			bullet_obj1._custom_target_reaction = spear_targer_reaction;
             bullet_obj1._extra_filtering_method = extra_filtering_method;
 
-			sdEntity.entities.push( bullet_obj1 );
+			sdEntity.AddEntityToEntitiesArray( bullet_obj1 );
         }
 	}
 	TeleportSomewhere( dist = 1, add_x = 0, add_y = 0 ) // Dist = distance multiplier in direction it's going, add_x is additional X, add_y is additional Y
@@ -1445,7 +1445,7 @@ class sdCube extends sdEntity
 									for ( var p in sdGun.classes[ sdGun.CLASS_LOST_CONVERTER ].projectile_properties )
 									bullet_obj[ p ] = sdGun.classes[ sdGun.CLASS_LOST_CONVERTER ].projectile_properties[ p ];
                                     bullet_obj._extra_filtering_method = extra_filtering_method;
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 									
 									sdSound.PlaySound({ name:'supercharge_combined2_part2', pitch: 1, x:this.x, y:this.y, volume:1.5 });
 								}
@@ -1585,7 +1585,7 @@ class sdCube extends sdEntity
 										sdSound.PlaySound({ name:'cube_attack', pitch: ( this.kind === sdCube.KIND_RED || this.kind === sdCube.KIND_WHITE || this.kind === sdCube.KIND_YELLOW || this.kind === sdCube.KIND_PURPLE ) ? 0.5 : 1, x:this.x, y:this.y, volume:0.5 });
 									}
 	
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 								}
 								else
 								{

--- a/game/entities/sdDeepSleep.js
+++ b/game/entities/sdDeepSleep.js
@@ -301,7 +301,7 @@ class sdDeepSleep extends sdEntity
 								type: sdDeepSleep.TYPE_SCHEDULED_SLEEP
 							});
 
-							sdEntity.entities.push( cell );
+							sdEntity.AddEntityToEntitiesArray( cell );
 							
 							sdWorld.UpdateHashPosition( cell, false, false );
 						}
@@ -669,7 +669,7 @@ class sdDeepSleep extends sdEntity
 						material: sdBlock.MATERIAL_BUGGED_CHUNK,
 						texture_id: 0
 					});
-					sdEntity.entities.push( e );
+					sdEntity.AddEntityToEntitiesArray( e );
 
 					e._hmax = 1;
 					e._hea = 1;
@@ -1733,7 +1733,7 @@ class sdDeepSleep extends sdEntity
 						let cell = new sdDeepSleep({
 							x:xx, y:yy, w:sdDeepSleep.normal_cell_size, h:sdDeepSleep.normal_cell_size, type: sdDeepSleep.TYPE_UNSPAWNED_WORLD
 						});
-						sdEntity.entities.push( cell );
+						sdEntity.AddEntityToEntitiesArray( cell );
 						
 						sdWorld.UpdateHashPosition( cell, false, false );
 					}

--- a/game/entities/sdDoor.js
+++ b/game/entities/sdDoor.js
@@ -369,7 +369,7 @@ class sdDoor extends sdEntity
 						w: 64 + this.w, 
 						h: 64 + this.h, 
 						on_movement_target: this });
-					sdEntity.entities.push( this._sensor_area );
+					sdEntity.AddEntityToEntitiesArray( this._sensor_area );
 				}
 			}
 
@@ -874,7 +874,7 @@ class sdDoor extends sdEntity
 				a = Math.random() * 2 * Math.PI;
 				s = Math.random() * 4;
 				let ent = new sdEffect({ x: this.x + x - 16, y: this.y + y - 16, type:sdEffect.TYPE_ROCK, sx: Math.sin(a)*s, sy: Math.cos(a)*s });
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 			}
 		}
 	}

--- a/game/entities/sdDrone.js
+++ b/game/entities/sdDrone.js
@@ -357,7 +357,7 @@ class sdDrone extends sdEntity
 						
 						ent.sx = dx * 0.05 + this.sx;
 						ent.sy = dy * 0.05 + this.sy - Math.abs( dx ) * 0.05;
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 
 						//sdWorld.UpdateHashPosition( ent, false ); // Important! Prevents memory leaks and hash tree bugs
 						sdWorld.UpdateHashPosition( ent, false, false ); // Important! Prevents memory leaks and hash tree bugs // UPD: onMovementInRange was making them be fed into BSUs indefinitely...
@@ -777,7 +777,7 @@ class sdDrone extends sdEntity
 					{
 						gun.sx = this.sx + Math.random() * 2 - 1;
 						gun.sy = this.sy + Math.random() * 2 - 1;
-						sdEntity.entities.push( gun );
+						sdEntity.AddEntityToEntitiesArray( gun );
 					}
 
 				}, 100 );
@@ -793,7 +793,7 @@ class sdDrone extends sdEntity
 
 					gun.sx = this.sx + Math.random() * 2 - 1;
 					gun.sy = this.sy + Math.random() * 2 - 1;
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 
 				}, 100 );
 			}
@@ -1372,7 +1372,7 @@ class sdDrone extends sdEntity
 								bullet_obj.color = '#afdfff';
 
 
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 								this.attack_frame = 2;
 								//this.attack_an = ( Math.atan2( -dy, Math.abs( dx ) ) ) * 1000;
@@ -1400,7 +1400,7 @@ class sdDrone extends sdEntity
 								bullet_obj.color = '#00aaff';
 
 
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 								this.attack_frame = 2;
 								this._burst_ammo--;
@@ -1435,7 +1435,7 @@ class sdDrone extends sdEntity
 								bullet_obj._no_explosion_smoke = true;
 								bullet_obj.model = 'sarronian_ball';
 
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 								this.attack_frame = 3;
 								this._attack_timer = 60;
@@ -1546,7 +1546,7 @@ class sdDrone extends sdEntity
 												}
 											};
 									};
-									sdEntity.entities.push( obj );
+									sdEntity.AddEntityToEntitiesArray( obj );
 									this._alt_attack_timer = 240;
 									this._attack_timer = 30;
 								}
@@ -1560,7 +1560,7 @@ class sdDrone extends sdEntity
 									drone.y += drone.sy;
 									drone._ignore_collisions_with = this; // Make sure it can pass through the detonator carrier 
 
-									sdEntity.entities.push( drone );
+									sdEntity.AddEntityToEntitiesArray( drone );
 									this._attack_timer = 90;
 								}
 								
@@ -1640,7 +1640,7 @@ class sdDrone extends sdEntity
 									bullet_obj._no_explosion_smoke = true;
 									
 									sdSound.PlaySound({ name: 'gun_railgun_malicestorm_terrorphaser4', x:this.x, y:this.y, volume: 1.5, pitch: 2 });
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 									
 									// this._alt_attack_timer = 90
 									this._attack_timer = 90; // 75 + 90 + 1
@@ -1670,7 +1670,7 @@ class sdDrone extends sdEntity
 								bullet_obj._no_explosion_smoke = true;
 								bullet_obj.model = 'ball_red';
 
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 								this.attack_frame = 1;
 								this._burst_ammo--;
@@ -1707,7 +1707,7 @@ class sdDrone extends sdEntity
 									bullet_obj.explosion_radius = 9;
 									bullet_obj._no_explosion_smoke = true;
 
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 								}
 								// bullet_obj.sx = dx;
 								// bullet_obj.sy = dy;
@@ -1783,7 +1783,7 @@ class sdDrone extends sdEntity
 									}
 
 									sdSound.PlaySound({ name:'alien_laser1', x:this.x, y:this.y, volume:1.3, pitch:0.18 });
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 									
 									this._alt_attack_timer = 156;
 									this._attack_timer = 80;
@@ -1813,7 +1813,7 @@ class sdDrone extends sdEntity
 									bullet_obj._rail_circled = true;
 									
 									sdSound.PlaySound({ name:'alien_laser1', x:this.x, y:this.y, volume:1.3, pitch:0.33 });
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 									
 									this._attack_timer = 156;
 									this._alt_attack_timer = 80;
@@ -1918,7 +1918,7 @@ class sdDrone extends sdEntity
 								bullet_obj.time_left = 10;
 
 
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 								this.attack_frame = 2;
 								//this.attack_an = ( Math.atan2( -dy, Math.abs( dx ) ) ) * 1000;
@@ -1944,7 +1944,7 @@ class sdDrone extends sdEntity
 								bullet_obj._damage = 15;
 
 
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 								let bullet_obj2 = new sdBullet({ x: this.x + ( Math.sin( -this.attack_an / 1000 ) * 3 ) , y: this.y - ( Math.cos( -this.attack_an / 1000 ) * 3 ) });
 
@@ -1961,7 +1961,7 @@ class sdDrone extends sdEntity
 								bullet_obj2._damage = 15;
 
 
-								sdEntity.entities.push( bullet_obj2 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj2 );
 
 								this.attack_frame = 2;
 								//this.attack_an = ( Math.atan2( -dy, Math.abs( dx ) ) ) * 1000;
@@ -1993,7 +1993,7 @@ class sdDrone extends sdEntity
 									bullet_obj._damage = 15;
 
 
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 								}
 
 								this.attack_frame = 2;
@@ -2025,7 +2025,7 @@ class sdDrone extends sdEntity
 								bullet_obj._rail_circled = true;
 
 
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 								this.attack_frame = 2;
 								//this.attack_an = ( Math.atan2( -dy, Math.abs( dx ) ) ) * 1000;
@@ -2052,7 +2052,7 @@ class sdDrone extends sdEntity
 								bullet_obj.color = '#ffaa00';
 
 
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 								this.attack_frame = 2;
 								this._burst_ammo--;
@@ -2099,7 +2099,7 @@ class sdDrone extends sdEntity
 								bullet_obj._temperature = 100;
 
 
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 								this.attack_frame = 2;
 								//this.attack_an = ( Math.atan2( -dy, Math.abs( dx ) ) ) * 1000;

--- a/game/entities/sdDropPod.js
+++ b/game/entities/sdDropPod.js
@@ -206,18 +206,18 @@ class sdDropPod extends sdEntity
 				{
 					let character_entity = new sdCharacter({ x:this.x, y:this.y, _ai_enabled: hostile ? sdCharacter.AI_MODEL_FALKOK : sdCharacter.AI_MODEL_TEAMMATE });
 
-					sdEntity.entities.push( character_entity );
+					sdEntity.AddEntityToEntitiesArray( character_entity );
 					sdWorld.UpdateHashPosition( character_entity, false );
 					if ( Math.random() < 0.5 ) // Random gun given to Star Defender
 					{
 						if ( Math.random() < 0.2 )
 						{
-							sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SNIPER }) );
+							sdEntity.AddEntityToEntitiesArray( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SNIPER }) );
 							character_entity._ai_gun_slot = 4;
 						}
 						else
 						{
-							sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SHOTGUN }) );
+							sdEntity.AddEntityToEntitiesArray( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SHOTGUN }) );
 							character_entity._ai_gun_slot = 3;
 						}
 					}
@@ -225,12 +225,12 @@ class sdDropPod extends sdEntity
 					{ 
 						if ( Math.random() < 0.1 )
 						{
-							sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_LMG }) );
+							sdEntity.AddEntityToEntitiesArray( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_LMG }) );
 							character_entity._ai_gun_slot = 2;
 						}
 						else
 						{
-							sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_RIFLE }) );
+							sdEntity.AddEntityToEntitiesArray( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_RIFLE }) );
 							character_entity._ai_gun_slot = 2;
 						}
 					}
@@ -321,16 +321,16 @@ class sdDropPod extends sdEntity
 				let rng = Math.random(); // Value between 0 and 1 at the moment.
 				if ( rng < 0.3 ) // 30%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_AVRS }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_AVRS }) );
 				}
 				else
 				if ( rng < 0.55 ) // 25%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_RAILCANNON }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_RAILCANNON }) );
 				}
 				else // 45%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_MMG }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_MMG }) );
 				}
 			}
 			else // Random regular weapon given to Star Defenders, 60% chance
@@ -338,19 +338,19 @@ class sdDropPod extends sdEntity
 				let rng = Math.random(); // Value between 0 and 1 at the moment.
 				if ( rng < 0.15 ) // 15%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_HANDCANNON }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_HANDCANNON }) );
 				}
 				else if ( rng < 0.40 ) // 25%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_MISSILE_LAUNCHER }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_MISSILE_LAUNCHER }) );
 				}
 				else if ( rng < 0.75 ) // 35%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_RIFLE }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_RIFLE }) );
 				}
 				else // 25%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_SMG }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_KVT_SMG }) );
 				}
 			}
 		}
@@ -368,76 +368,76 @@ class sdDropPod extends sdEntity
 				let rng = Math.random(); // Value between 0 and 1 at the moment.
 				if ( rng < 0.05 ) // 5% chance for level 3 heavy armor
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LVL3_HEAVY_ARMOR }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LVL3_HEAVY_ARMOR }) );
 				}
 				else
 				if ( rng < 0.15 ) // 10%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_ROCKET_MK2 }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_ROCKET_MK2 }) );
 				}
 				else
 				if ( rng < 0.25 ) // 10% chance for laser drill
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LASER_DRILL }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LASER_DRILL }) );
 				}
 				else
 				if ( rng < 0.35 ) // 10%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_SNIPER }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_SNIPER }) );
 				}
 				else
 				if ( rng < 0.45 ) // 10%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LASER_PISTOL }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LASER_PISTOL }) );
 				}
 				else
 				if ( rng < 0.55 ) // 10%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LMG }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LMG }) );
 				}
 				else
 				if ( rng < 0.60 ) // 5%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LVL2_ARMOR_REGEN }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LVL2_ARMOR_REGEN }) );
 				}
 				else
 				if ( rng < 0.625 ) // 2.5%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_MINING_FOCUS_CUTTER }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_MINING_FOCUS_CUTTER }) );
 				}
 				else
 				if ( rng < 0.65 ) // 2.5%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_DRAIN_RIFLE }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_DRAIN_RIFLE }) );
 				}
 				else
 				if ( rng < 0.75 ) // 10%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_GRENADE_LAUNCHER_MK2 }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_GRENADE_LAUNCHER_MK2 }) );
 				}
 				else
 				if ( rng < 0.80 ) // 5%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_CUSTOM_RIFLE }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_CUSTOM_RIFLE }) );
 				}
                 else
 				if ( rng < 0.85 ) // 5%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_BATTLE_RIFLE }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_BATTLE_RIFLE }) );
 				}
 				else
 				if ( rng < 0.90 ) // 10%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_SHOTGUN_MK2 }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_SHOTGUN_MK2 }) );
 				}
                 else
 				if ( rng < 0.95 ) // 5%
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_HEAVY_ROCKET }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_HEAVY_ROCKET }) );
 				}
 				else
 				{
-					sdEntity.entities.push( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LVL2_MEDIUM_ARMOR }) );
+					sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y, class:sdGun.CLASS_LVL2_MEDIUM_ARMOR }) );
 				}
 			}
 		}

--- a/game/entities/sdEffect.js
+++ b/game/entities/sdEffect.js
@@ -4,7 +4,7 @@
 	sdWorld.SendEffect({ x: , y: , type:sdEffect.TYPE_WALL_HIT });
 
 	Client-side effect test:
-	sdEntity.entities.push( new sdWorld.entity_classes.sdEffect({ x:bone_to.x, y:bone_to.y, type:sdWorld.entity_classes.sdEffect.TYPE_WALL_HIT }) );
+	sdEntity.AddEntityToEntitiesArray( new sdWorld.entity_classes.sdEffect({ x:bone_to.x, y:bone_to.y, type:sdWorld.entity_classes.sdEffect.TYPE_WALL_HIT }) );
 
 */
 /* global THREE, sdMusic */
@@ -718,7 +718,7 @@ class sdEffect extends sdEntity
 					if ( i > 0 )
 					{
 						let ent = new sdEffect({ x: xx, y: yy, type:sdEffect.TYPE_RAIL_TRAIL, color:this._color });
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 					}
 					
 					xx += dx;
@@ -727,7 +727,7 @@ class sdEffect extends sdEntity
 			}
 			
 			let ent = new sdEffect({ x: this._x2, y: this._y2, type:sdEffect.TYPE_RAIL_HIT, color:this._color });
-			sdEntity.entities.push( ent );
+			sdEntity.AddEntityToEntitiesArray( ent );
 		}
 		
 		let s = sdEffect.types[ this._type ].sound_to_play;
@@ -956,7 +956,7 @@ class sdEffect extends sdEntity
 				{
 					let e = new sdEffect({ type: ( this._type === sdEffect.TYPE_BLOOD ) ? sdEffect.TYPE_BLOOD_DROP : sdEffect.TYPE_BLOOD_DROP_GREEN, 
 						x:this.x+xx*2, y:this.y+yy*2, sx:this.sx+xx, sy:this.sy+yy, hue:this._hue, filter:this._filter });
-					sdEntity.entities.push( e );
+					sdEntity.AddEntityToEntitiesArray( e );
 				}
 			}
 			else
@@ -972,7 +972,7 @@ class sdEffect extends sdEntity
 						let zy = Math.cos( an ) * ( -2 * Math.random() - ( Math.random() * 0.5 * Math.max( 1, this._radius / 20 ) ) );
 					
 						let e = new sdEffect({ type: sdEffect.TYPE_SMOKE, x:this.x + zx * 2, y:this.y + zy * 2, sx: zx, sy:zy, scale:this._radius / 20, radius:this._radius / 20, color:this._smoke_color || sdEffect.GetSmokeColor( sdEffect.smoke_colors ), spark_color: this._color });
-						sdEntity.entities.push( e );
+						sdEntity.AddEntityToEntitiesArray( e );
 					}
 					
 					if ( sdRenderer.effects_quality >= 2 )
@@ -987,7 +987,7 @@ class sdEffect extends sdEntity
 						let mult = type === sdEffect.TYPE_SHRAPNEL ? 2 / 3 : 1;
 						
 						let s = new sdEffect({ type:type, x:this.x + xx * 3, y:this.y + yy * 3, sx:xx*mult, sy:yy*mult, color: this._color, scale: type === sdEffect.TYPE_SHRAPNEL ? Math.min( 1.5, Math.random() + 1 ) : 1 });
-						sdEntity.entities.push( s );
+						sdEntity.AddEntityToEntitiesArray( s );
 					}
 				}
 			}
@@ -1114,7 +1114,7 @@ class sdEffect extends sdEntity
 			if ( sdRenderer.effects_quality >= 2 && this._spark_color && Math.random() < 0.005 && this._ani < 0.5 )
 			{
 				let e = new sdEffect({ type:sdEffect.TYPE_SPARK, x:this.x, y:this.y, sx:this.sx + ( Math.random() * 3 - Math.random() * 3 ), sy:this.sy * Math.random() * 2, color: this._spark_color });
-				sdEntity.entities.push( e );
+				sdEntity.AddEntityToEntitiesArray( e );
 			}
 		}
 		
@@ -1126,7 +1126,7 @@ class sdEffect extends sdEntity
 			if ( this._extra_eff_timer <= 0 )
 			{
 				let e = new sdEffect({ type:sdEffect.TYPE_SPARK, x:this.x, y:this.y, sx:( Math.random() - 0.5) * 3, sy:( Math.random() - 0.5 ) * 3, color: this._color });
-				sdEntity.entities.push( e );
+				sdEntity.AddEntityToEntitiesArray( e );
 				
 				this._extra_eff_timer = 2;
 			}

--- a/game/entities/sdEnemyMech.js
+++ b/game/entities/sdEnemyMech.js
@@ -455,7 +455,7 @@ class sdEnemyMech extends sdEntity
 
 							gun.sx = sx;
 							gun.sy = sy;
-							sdEntity.entities.push( gun );
+							sdEntity.AddEntityToEntitiesArray( gun );
 
 						}, 500 );
 					}
@@ -476,7 +476,7 @@ class sdEnemyMech extends sdEntity
 
 							gun.sx = sx + Math.random() - Math.random();
 							gun.sy = sy + Math.random() - Math.random();
-							sdEntity.entities.push( gun );
+							sdEntity.AddEntityToEntitiesArray( gun );
 
 						}, 500 );
 						shards--;
@@ -768,7 +768,7 @@ class sdEnemyMech extends sdEntity
 							bullet_obj.color = '#ffaa00';
 						}
 
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 						this._bullets--;
 
@@ -829,7 +829,7 @@ class sdEnemyMech extends sdEntity
 							bullet_obj._damage = 50;
 							bullet_obj.color = '#ff0000';
 
-							sdEntity.entities.push( bullet_obj );
+							sdEntity.AddEntityToEntitiesArray( bullet_obj );
 							this._rail_attack_timer = 10;
 							sdSound.PlaySound({ name:'gun_railgun', pitch: 0.5, x:this.x, y:this.y, volume:0.5 });
 						}
@@ -866,7 +866,7 @@ class sdEnemyMech extends sdEntity
 						bullet_obj.explosion_radius = 10 * 1.5;
 						bullet_obj.color = '#7acaff';
 
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 						this._rockets--;
 
@@ -937,7 +937,7 @@ class sdEnemyMech extends sdEntity
 			if ( this.hea < this._hmax / 5 )
 			{
 					let e = new sdEffect({ type: sdEffect.TYPE_SMOKE, x:this.x, y:this.y - 24, sx: -Math.random() + Math.random(), sy:-1 * Math.random() * 5, scale:1, radius:0.5, color:sdEffect.GetSmokeColor( sdEffect.smoke_colors ) });
-					sdEntity.entities.push( e );
+					sdEntity.AddEntityToEntitiesArray( e );
 			}
 		}
 			

--- a/game/entities/sdEntity.js
+++ b/game/entities/sdEntity.js
@@ -156,9 +156,62 @@ class sdEntity
 		return null;
 		
 		let ent = new class_ptr( params );
-		sdEntity.entities.push( ent );
+		sdEntity.AddEntityToEntitiesArray( ent );
 		sdWorld.UpdateHashPosition( ent, false, true );
 		return ent;
+	}
+	// --- sdEntity.entities registry helpers -------------------------------------------------
+	// All membership changes to the primary sdEntity.entities array go through these so that
+	// each entity's _entities_array_index stays valid, which lets removal be O(1) swap-and-pop
+	// (native pop()) instead of an O(N) indexOf/splice scan of the (production-scale) array.
+	// Order within sdEntity.entities is NOT behavior-significant: the sim think loop iterates
+	// active_entities/global_entities (sdWorld.js), while sdEntity.entities is only used for
+	// random-pick, net_id lookup, and snapshot enumeration - none order-dependent.
+	static AddEntityToEntitiesArray( ent )
+	{
+		ent._entities_array_index = sdEntity.entities.length;
+		sdEntity.entities.push( ent );
+	}
+	static RemoveEntityFromEntitiesArrayByIndex( index ) // Caller guarantees sdEntity.entities[ index ] is the entity to remove.
+	{
+		let arr = sdEntity.entities;
+		let last = arr.length - 1;
+
+		if ( index < 0 || index > last )
+		return false;
+
+		let removed = arr[ index ];
+
+		if ( index !== last )
+		{
+			let moved = arr[ last ];
+			arr[ index ] = moved;
+			moved._entities_array_index = index;
+		}
+
+		arr.pop();
+		removed._entities_array_index = -1;
+
+		return true;
+	}
+	static RemoveEntityFromEntitiesArray( ent )
+	{
+		let index = ent._entities_array_index;
+
+		// Defensive fallback: index unset (-1) or invalidated by some external mutation. Should
+		// not happen now that all inserts go through AddEntityToEntitiesArray, but a missed/foreign
+		// push would otherwise corrupt the array, so verify before trusting the cached index.
+		if ( index < 0 || index >= sdEntity.entities.length || sdEntity.entities[ index ] !== ent )
+		{
+			index = sdEntity.entities.lastIndexOf( ent );
+			if ( index === -1 )
+			{
+				ent._entities_array_index = -1;
+				return false;
+			}
+		}
+
+		return sdEntity.RemoveEntityFromEntitiesArrayByIndex( index );
 	}
 	static AllEntityClassesLoadedAndInitiated()
 	{
@@ -3015,6 +3068,7 @@ class sdEntity
 		sdWorld.UpdateHashPosition( this, true );
 		
 		this._is_being_removed = false;
+		this._entities_array_index = -1; // Position of this entity inside sdEntity.entities, maintained by AddEntityToEntitiesArray / RemoveEntityFromEntitiesArray* for O(1) swap-and-pop removal. -1 means "not in the array". Transient runtime-only value: excluded from snapshot saving (see GetSnapshot) and never network-synced (underscore-prefixed).
 		this._broken = false; // Becomes true for statics (anything now) whenever they are really broken rather than just cut out by visibility. After removal you can set it to false to prevent particles spawned on client
 		
 		this._is_bg_entity = this.IsBGEntity();
@@ -3943,10 +3997,12 @@ class sdEntity
 
 								  prop !== '_frozen' && 
 
-								  prop !== '_anything_near_range' && 
+								  prop !== '_anything_near_range' &&
 								  prop !== '_next_anything_near_rethink' &&
 
-								  ( 
+								  prop !== '_entities_array_index' && // Transient registry index - meaningless across reloads, must not be baked into saved snapshots
+
+								  (
 									typeof this[ prop ] === 'number' || 
 									typeof this[ prop ] === 'string' || 
 									this[ prop ] === null || 
@@ -4520,7 +4576,7 @@ class sdEntity
 			throw new Error( 'How?' );
 		}*/
 		
-		sdEntity.entities.push( ret );
+		sdEntity.AddEntityToEntitiesArray( ret );
 		//sdWorld.UpdateHashPosition( ret, false ); // Will prevent sdBlock from occasionally not having collisions on client-side (it will rest in hibernated state, probably because of that. It is kind of a bug though)
 	
 		return ret;
@@ -5781,9 +5837,11 @@ class sdEntity
 		
 		while ( pos < arr.length && ( t2 - t < 1 || pos < at_least ) )
 		{
-			let id = sdEntity.entities.lastIndexOf( arr[ pos ] );
-			if ( id !== -1 )
-			sdEntity.entities.splice( id, 1 );
+			// O(1) swap-and-pop per entity via the cached _entities_array_index instead of the
+			// former lastIndexOf()+splice() which scanned/shifted the whole sdEntity.entities array
+			// for every removed entity (the #1 heavy-combat hotspot). Same time-slice / at_least /
+			// force_all backlog semantics are preserved; only the per-entity cost changes.
+			sdEntity.RemoveEntityFromEntitiesArray( arr[ pos ] );
 
             pos++;
 

--- a/game/entities/sdEssenceExtractor.js
+++ b/game/entities/sdEssenceExtractor.js
@@ -187,7 +187,7 @@ class sdEssenceExtractor extends sdEntity
 			ent.matter = snapshot.matter;
 			ent.matter_regen = snapshot.matter_regen;
 			
-			sdEntity.entities.push( ent );
+			sdEntity.AddEntityToEntitiesArray( ent );
 		}
 	}
 	onThink( GSPEED ) // Class-specific, if needed

--- a/game/entities/sdExcavator.js
+++ b/game/entities/sdExcavator.js
@@ -192,7 +192,7 @@ class sdExcavator extends sdEntity
 				crystal.matter_max = Math.max( 40, this.crystal_matter );
 				crystal.matter = this.crystal_matter;
 				
-				sdEntity.entities.push( crystal );
+				sdEntity.AddEntityToEntitiesArray( crystal );
 				
 				// Make the excavator disappear
 				this.remove();
@@ -240,7 +240,7 @@ class sdExcavator extends sdEntity
 					}
 				};
 				
-				sdEntity.entities.push( bullet_obj );
+				sdEntity.AddEntityToEntitiesArray( bullet_obj );
 				
 				let bullet_obj2 = new sdBullet({ x: this.x + 10, y: this.y - 8, time_left: 2 }); // Right
 
@@ -265,7 +265,7 @@ class sdExcavator extends sdEntity
 					}
 				};
 				
-				sdEntity.entities.push( bullet_obj2 );
+				sdEntity.AddEntityToEntitiesArray( bullet_obj2 );
 				// Center excavating point
 				let bullet_obj3 = new sdBullet({ x: this.x, y: this.y - 8, time_left: 2 }); // Center left
 
@@ -290,7 +290,7 @@ class sdExcavator extends sdEntity
 					}
 				};
 				
-				sdEntity.entities.push( bullet_obj3 );
+				sdEntity.AddEntityToEntitiesArray( bullet_obj3 );
 			}
 		}
 	}

--- a/game/entities/sdFactionSpawner.js
+++ b/game/entities/sdFactionSpawner.js
@@ -199,7 +199,7 @@ class sdFactionSpawner extends sdEntity
 					{
 						let character_entity = new sdCharacter({ x:this.x, y:this.y - 8, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-						sdEntity.entities.push( character_entity );
+						sdEntity.AddEntityToEntitiesArray( character_entity );
 						sdFactions.SetHumanoidProperties( character_entity, sdFactions.FACTION_FALKOK ); // Give them Falkok properties
 					}
 				}
@@ -215,7 +215,7 @@ class sdFactionSpawner extends sdEntity
 					{
 						let character_entity = new sdCharacter({ x:this.x, y:this.y, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-						sdEntity.entities.push( character_entity );
+						sdEntity.AddEntityToEntitiesArray( character_entity );
 						sdFactions.SetHumanoidProperties( character_entity, sdFactions.FACTION_TZYRG ); // Give them Tzyrg properties
                         character_entity.ApplyStatusEffect({ type: sdStatusEffect.TYPE_BUILT_ENTITY });
 					}
@@ -224,7 +224,7 @@ class sdFactionSpawner extends sdEntity
 				if ( drones < sdWorld.entity_classes.sdWeather.only_instance._max_drone_count ) // Check for drones
 				{
 						let drone = new sdDrone({ x:this.x, y:this.y, type: sdDrone.DRONE_TZYRG, _ai_team: this._ai_team });
-						sdEntity.entities.push( drone );
+						sdEntity.AddEntityToEntitiesArray( drone );
 						drone.sy = -2;
 						drone.sx = -3 + ( Math.random() * 6 );
                         drone.ApplyStatusEffect({ type: sdStatusEffect.TYPE_BUILT_ENTITY });

--- a/game/entities/sdFactions.js
+++ b/game/entities/sdFactions.js
@@ -46,7 +46,7 @@ class sdFactions extends sdEntity
 				if ( Math.random() < 0.2 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SNIPER }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 4;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -54,7 +54,7 @@ class sdFactions extends sdEntity
 				else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SHOTGUN }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 3;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -65,7 +65,7 @@ class sdFactions extends sdEntity
 				if ( Math.random() < 0.1 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_LMG }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 2;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -73,7 +73,7 @@ class sdFactions extends sdEntity
 				else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_RIFLE });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 2;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -89,7 +89,7 @@ class sdFactions extends sdEntity
 				if ( Math.random() < 0.2 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_FALKOK_PSI_CUTTER }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 4;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -97,7 +97,7 @@ class sdFactions extends sdEntity
 				else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_RAYGUN });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 3;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -108,7 +108,7 @@ class sdFactions extends sdEntity
 				if ( Math.random() < 0.1 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_F_MARKSMAN }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 2;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -116,7 +116,7 @@ class sdFactions extends sdEntity
 				else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_FALKOK_RIFLE });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 2;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -135,7 +135,7 @@ class sdFactions extends sdEntity
 			if ( Math.random() < 0.3 )
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_ERTHAL_BURST_RIFLE }); // Works better for vehicle scenarios
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 2;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -143,7 +143,7 @@ class sdFactions extends sdEntity
 			else
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_ERTHAL_PLASMA_PISTOL });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 1;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -157,7 +157,7 @@ class sdFactions extends sdEntity
 			if ( Math.random() < 0.2 )
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_COUNCIL_SHOTGUN });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 3;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -166,7 +166,7 @@ class sdFactions extends sdEntity
 			if ( Math.random() < 0.5 )
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_COUNCIL_BURST_RAIL });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 4;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -174,7 +174,7 @@ class sdFactions extends sdEntity
 			else
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_COUNCIL_PISTOL });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 1;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -194,7 +194,7 @@ class sdFactions extends sdEntity
 				if ( Math.random() < 0.2 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SARRONIAN_ENERGY_DISPLACER });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 5;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -202,7 +202,7 @@ class sdFactions extends sdEntity
 				else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_ZEKTARON_RAILGUN });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 4;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -212,7 +212,7 @@ class sdFactions extends sdEntity
 			if ( Math.random() < 0.65 )
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_ZEKTARON_COMBAT_RIFLE });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 2;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -220,7 +220,7 @@ class sdFactions extends sdEntity
 			else
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SARRONIAN_SMG });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 1;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -246,7 +246,7 @@ class sdFactions extends sdEntity
 				if ( Math.random() < 0.25 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_RAIL_CANNON });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 4;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -254,7 +254,7 @@ class sdFactions extends sdEntity
 				else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_VELOX_COMBAT_RIFLE });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 2;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -264,7 +264,7 @@ class sdFactions extends sdEntity
 			{ 
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class: Math.random() < 0.15 ? sdGun.CLASS_ELECTROSHOCK : sdGun.CLASS_VELOX_PISTOL });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 1;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -287,7 +287,7 @@ class sdFactions extends sdEntity
 			if ( Math.random() < 0.2 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SETR_LMG });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 2;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -295,7 +295,7 @@ class sdFactions extends sdEntity
 			else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SETR_PLASMA_SHOTGUN });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 3;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -309,7 +309,7 @@ class sdFactions extends sdEntity
 			if ( Math.random() < 0.5 )
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_TZYRG_SHOTGUN });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 3;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -317,7 +317,7 @@ class sdFactions extends sdEntity
 			else
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_TZYRG_RIFLE });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 2;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -331,7 +331,7 @@ class sdFactions extends sdEntity
 			if ( Math.random() < 0.2 )
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SHURG_SNIPER });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 4;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -339,7 +339,7 @@ class sdFactions extends sdEntity
 			else
 			{
 				gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SHURG_PISTOL });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 					
 				character_entity._ai_gun_slot = 1;
 				gun.onMovementInRange( character_entity ); // Force pickup
@@ -363,7 +363,7 @@ class sdFactions extends sdEntity
 				if ( Math.random() < 0.2 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SNIPER }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 4;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -371,7 +371,7 @@ class sdFactions extends sdEntity
 				else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SHOTGUN }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 3;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -382,7 +382,7 @@ class sdFactions extends sdEntity
 				if ( Math.random() < 0.1 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_LMG }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 2;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -390,7 +390,7 @@ class sdFactions extends sdEntity
 				else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_RIFLE });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 2;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -406,7 +406,7 @@ class sdFactions extends sdEntity
 				if ( Math.random() < 0.2 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SNIPER }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 4;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -414,7 +414,7 @@ class sdFactions extends sdEntity
 				else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SHOTGUN }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 3;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -425,7 +425,7 @@ class sdFactions extends sdEntity
 				if ( Math.random() < 0.1 )
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_LMG }); // Works better for vehicle scenarios
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 2;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -433,7 +433,7 @@ class sdFactions extends sdEntity
 				else
 				{
 					gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_RIFLE });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					character_entity._ai_gun_slot = 2;
 					gun.onMovementInRange( character_entity ); // Force pickup
@@ -448,7 +448,7 @@ class sdFactions extends sdEntity
 		if ( faction === sdFactions.FACTION_HIGH_COUNCILOR ) // High Councilor
 		{
 			let gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_HIGH_COUNCIL_SWORD });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 			
 			character_entity._ai_gun_slot = 0;
 			gun.onMovementInRange( character_entity ); // Force pickup

--- a/game/entities/sdFleshGrabber.js
+++ b/game/entities/sdFleshGrabber.js
@@ -394,7 +394,7 @@ class sdFleshGrabber extends sdEntity
 							
 					bullet_obj.model = 'ab_tooth';
 
-					sdEntity.entities.push( bullet_obj );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 					bullet_obj2.sx = dx + ( Math.random() * 0.15 ) - ( Math.random() * 0.15 );
 					bullet_obj2.sy = dy + ( Math.random() * 0.15 ) - ( Math.random() * 0.15 );
@@ -408,7 +408,7 @@ class sdFleshGrabber extends sdEntity
 							
 					bullet_obj2.model = 'ab_tooth';
 
-					sdEntity.entities.push( bullet_obj2 );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj2 );
 
 					bullet_obj3.sx = dx + ( Math.random() * 0.075 ) - ( Math.random() * 0.075 );
 					bullet_obj3.sy = dy + ( Math.random() * 0.075 ) - ( Math.random() * 0.075 );
@@ -422,7 +422,7 @@ class sdFleshGrabber extends sdEntity
 							
 					bullet_obj3.model = 'ab_tooth';
 
-					sdEntity.entities.push( bullet_obj3 );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj3 );
 					
 					this.tenta_tim = 30;
 				}

--- a/game/entities/sdGrass.js
+++ b/game/entities/sdGrass.js
@@ -302,7 +302,7 @@ class sdGrass extends sdEntity
 								yy += Math.cos( an ) * 4;
 
 								let ent = new sdCrystal({ x: xx, y: yy, tag:'deep', from_tree:this, type:sdCrystal.TYPE_CRYSTAL_BALLOON });
-								sdEntity.entities.push( ent );
+								sdEntity.AddEntityToEntitiesArray( ent );
 
 								if ( !ent.CanMoveWithoutOverlap( ent.x, ent.y ) )
 								{
@@ -374,7 +374,7 @@ class sdGrass extends sdEntity
                 if ( this.snowed )
                 filter += 'saturate(0.05) brightness(2)';
 
-                sdEntity.entities.push( new sdEffect({ x: x, y: y, type: sdEffect.TYPE_LEAF, sx: 0, sy: 0, filter: filter, hue: this.hue }) );
+                sdEntity.AddEntityToEntitiesArray( new sdEffect({ x: x, y: y, type: sdEffect.TYPE_LEAF, sx: 0, sy: 0, filter: filter, hue: this.hue }) );
                 this._leaf_spawn_timer = 10 + Math.random() * 120;
             }
         }

--- a/game/entities/sdGuanako.js
+++ b/game/entities/sdGuanako.js
@@ -698,7 +698,7 @@ class sdGuanako extends sdEntity
 
 											bullet_obj.model = 'ball';
 
-											sdEntity.entities.push( bullet_obj );
+											sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 											sdSound.PlaySound({ name:'gun_portal4', x:this.x, y:this.y, volume: 0.5, pitch:2 });
 										}

--- a/game/entities/sdGun.js
+++ b/game/entities/sdGun.js
@@ -1238,7 +1238,7 @@ class sdGun extends sdEntity
 							
 							//sdEntity.recently_build.set( ent, { by: this._held_by } );
 
-							sdEntity.entities.push( ent );
+							sdEntity.AddEntityToEntitiesArray( ent );
 							
 							// Initially object is not spawned at cursor but near it. It means that huge static objects (sdBG, sdArea) will have incorrect hash array which will cause them to not have collisions when needed)
 							if ( ent._affected_hash_arrays.length > 0 ) // Easier than checking for hiberstates
@@ -1391,14 +1391,14 @@ class sdGun extends sdEntity
 
 						if ( sdWorld.is_server )
 						{
-							sdEntity.entities.push( bullet_obj );
+							sdEntity.AddEntityToEntitiesArray( bullet_obj );
 						}
 						else
 						{
 							/*if ( sdWorld.speculative_projectiles && sdWorld.my_entity && bullet_obj._owner === sdWorld.my_entity )
 							{
 								bullet_obj._speculative = true;
-								sdEntity.entities.push( bullet_obj );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj );
 							}
 							else*/
 							{
@@ -1435,7 +1435,7 @@ class sdGun extends sdEntity
 						let offset = this._held_by.GetBulletSpawnOffset();
 
 						let ef = new sdEffect({ x: this._held_by.x + offset.x, y: this._held_by.y + offset.y, type: sdEffect.TYPE_SHELL, sx:Math.sin( an ) * vel + this._held_by.sx / 4, sy:Math.cos( an ) * vel + this._held_by.sy / 4, rotation: Math.PI / 2 - initial_an });
-						sdEntity.entities.push( ef );
+						sdEntity.AddEntityToEntitiesArray( ef );
 					}
 				}
 			
@@ -1670,7 +1670,7 @@ class sdGun extends sdEntity
 				let vel = 1 + Math.random();
 					
 				let ef = new sdEffect({ x: this.x, y: this.y, type: sdEffect.TYPE_SHELL, sx:Math.sin( an ) * vel, sy:Math.cos( an ) * vel, rotation: Math.PI / 2 - initial_an });
-				sdEntity.entities.push( ef );
+				sdEntity.AddEntityToEntitiesArray( ef );
 			}*/
 			
 			if ( this.muzzle > 0 )
@@ -1797,7 +1797,7 @@ class sdGun extends sdEntity
 				// Current iteration below seems to work without issues, however I think it would be ideal if it could check if "upgrades" section of gun class has explicitly "AddGunDefaultUpgrades"
 				{
 					let gun = new sdGun({ x:this.x, y:this.y, sx: this.sx, sy: this.sy, class:this.class }); // Remove and rebuild the weapon itself
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					this.remove(); // Not sure if it should be before or after duplicate spawns
 					return;
 				}

--- a/game/entities/sdGunClass.js
+++ b/game/entities/sdGunClass.js
@@ -3072,7 +3072,7 @@ class sdGunClass
 						bullet._owner._current_built_entity = ent;
 						//bullet._owner.Say( 'Start connected to ' + ( target_entity.title || target_entity.GetClass() ) );
 
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 					}
 				}
 				
@@ -3854,12 +3854,12 @@ class sdGunClass
 						ent.gun_slot = 4;
 						ent._matter_regeneration = 5;
 						//ent._damage_mult = 1 + 3 / 3 * 1;
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 
 						let ent2 = new sdGun({ x: ent.x, y: ent.y,
 							class: sdGun.CLASS_RAILGUN
 						});
-						sdEntity.entities.push( ent2 );
+						sdEntity.AddEntityToEntitiesArray( ent2 );
 
 						sdSound.PlaySound({ name:'teleport', x:ent.x, y:ent.y, volume:0.5 });
 						sdWorld.SendEffect({ x:ent.x, y:ent.y, type:sdEffect.TYPE_TELEPORT });
@@ -5353,7 +5353,7 @@ class sdGunClass
 									attachment_y: options[ best_i ].y,
 									orientation: options[ best_i ].orientation
 								});
-								sdEntity.entities.push( portal );
+								sdEntity.AddEntityToEntitiesArray( portal );
 
 								if ( portals_by_owner.length > 0 )
 								{
@@ -5744,12 +5744,12 @@ class sdGunClass
 						ent._matter_regeneration = 5;
 						ent._matter_regeneration_multiplier = 10;
 						//ent._damage_mult = 1 + 3 / 3 * 1;
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 
 						let ent2 = new sdGun({ x: ent.x, y: ent.y,
 							class: sdGun.CLASS_LMG
 						}); // Even with LMG it seems weak compared to power-stimpack
-						sdEntity.entities.push( ent2 );
+						sdEntity.AddEntityToEntitiesArray( ent2 );
 
 						sdSound.PlaySound({ name:'teleport', x:ent.x, y:ent.y, volume:0.5 });
 						sdWorld.SendEffect({ x:ent.x, y:ent.y, type:sdEffect.TYPE_TELEPORT });
@@ -6112,7 +6112,7 @@ class sdGunClass
 							{
 								let water_ent = new sdWater({ x:0, y:0, type: liquid.type });
 								water_ent._natural = false;
-								sdEntity.entities.push( water_ent );
+								sdEntity.AddEntityToEntitiesArray( water_ent );
 	
 								water_ent._volume = Math.min( 100, liquid.amount ) / 100;
 								let extra = liquid.extra / liquid.amount * water_ent._volume * 100;
@@ -6159,7 +6159,7 @@ class sdGunClass
 							{
 								water_ent = new sdWater( bullet._gun._held_item_snapshot );
 								water_ent._natural = false;
-								sdEntity.entities.push( water_ent );
+								sdEntity.AddEntityToEntitiesArray( water_ent );
 								sdWorld.UpdateHashPosition( water_ent, false );
 								
 								bullet._gun._held_item_snapshot = null;
@@ -8435,7 +8435,7 @@ class sdGunClass
 								bullet_obj1._dirt_mult = 1;
 								bullet_obj1._hittable_by_bullets = false;
 								bullet_obj1._no_explosion_smoke = true;
-								sdEntity.entities.push( bullet_obj1 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj1 );
 			
 					let bullet_obj2 = new sdBullet({ x: bullet.x, y: bullet.y });
 								bullet_obj2.sx = 1;
@@ -8448,7 +8448,7 @@ class sdGunClass
 								bullet_obj2._dirt_mult = 1;
 								bullet_obj2._hittable_by_bullets = false;
 								bullet_obj2._no_explosion_smoke = true;
-								sdEntity.entities.push( bullet_obj2 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj2 );
 			
 					let bullet_obj3 = new sdBullet({ x: bullet.x, y: bullet.y });
 								bullet_obj3.sx = -1;
@@ -8461,7 +8461,7 @@ class sdGunClass
 								bullet_obj3._dirt_mult = 1;
 								bullet_obj3._hittable_by_bullets = false;
 								bullet_obj3._no_explosion_smoke = true;
-								sdEntity.entities.push( bullet_obj3 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj3 );
 			
 					let bullet_obj4 = new sdBullet({ x: bullet.x, y: bullet.y });
 								bullet_obj4.sx = -1;
@@ -8474,7 +8474,7 @@ class sdGunClass
 								bullet_obj4._dirt_mult = 1;
 								bullet_obj4._hittable_by_bullets = false;
 								bullet_obj4._no_explosion_smoke = true;
-								sdEntity.entities.push( bullet_obj4 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj4 );
 				} };
 				obj._knock_scale = 0.01 * 8 * gun.extra[ sdGun.ID_DAMAGE_MULT ];
 				obj._damage = gun.extra[ sdGun.ID_DAMAGE_VALUE ]; // Damage value is set onMade
@@ -8610,7 +8610,7 @@ class sdGunClass
 								bullet_obj1._hittable_by_bullets = false;
 								bullet_obj1._no_explosion_smoke = true;
 
-								sdEntity.entities.push( bullet_obj1 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj1 );
 			
 					let bullet_obj2 = new sdBullet({ x: bullet.x, y: bullet.y });
 								bullet_obj2.sx = 1;
@@ -8624,7 +8624,7 @@ class sdGunClass
 								bullet_obj2._hittable_by_bullets = false;
 								bullet_obj2._no_explosion_smoke = true;
 
-								sdEntity.entities.push( bullet_obj2 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj2 );
 			
 					let bullet_obj3 = new sdBullet({ x: bullet.x, y: bullet.y });
 								bullet_obj3.sx = -1;
@@ -8638,7 +8638,7 @@ class sdGunClass
 								bullet_obj3._hittable_by_bullets = false;
 								bullet_obj3._no_explosion_smoke = true;
 
-								sdEntity.entities.push( bullet_obj3 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj3 );
 			
 					let bullet_obj4 = new sdBullet({ x: bullet.x, y: bullet.y });
 								bullet_obj4.sx = -1;
@@ -8652,7 +8652,7 @@ class sdGunClass
 								bullet_obj4._hittable_by_bullets = false,
 								bullet_obj4._no_explosion_smoke = true;
 								
-								sdEntity.entities.push( bullet_obj4 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj4 );
 
 					let bullet_obj5 = new sdBullet({ x: bullet.x, y: bullet.y }); // lingering damage over time AoE projectile
 								bullet_obj5.sx = 0;
@@ -8703,7 +8703,7 @@ class sdGunClass
 										}
 									}
 								}
-								sdEntity.entities.push( bullet_obj5 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj5 );
 				} };
 				obj._knock_scale = 0.01 * 8 * gun.extra[ sdGun.ID_DAMAGE_MULT ];
 				obj._damage = gun.extra[ sdGun.ID_DAMAGE_VALUE ]; // Damage value is set onMade
@@ -10316,12 +10316,12 @@ class sdGunClass
 										_owner: owner
 									});
 									ent.gun_slot = 2;
-									sdEntity.entities.push( ent );
+									sdEntity.AddEntityToEntitiesArray( ent );
 
 									let ent2 = new sdGun({ x: ent.x, y: ent.y,
 										class: sdGun.CLASS_STALKER_RIFLE
 									}); 
-									sdEntity.entities.push( ent2 );
+									sdEntity.AddEntityToEntitiesArray( ent2 );
 									
 									ent2.fire_mode = Math.random() > 0.5 ? 1 : 2;
 
@@ -10370,7 +10370,7 @@ class sdGunClass
 										bullet_obj.time_left = Number.MAX_SAFE_INTEGER;
 										bullet_obj._hea = 100;
 								
-										sdEntity.entities.push( bullet_obj );
+										sdEntity.AddEntityToEntitiesArray( bullet_obj );
 									}
 								
 									setTimeout(()=>
@@ -10990,7 +10990,7 @@ class sdGunClass
                             bullet_obj._can_hit_owner = false;
                             bullet_obj.color = '#ffff00';
 
-                            sdEntity.entities.push( bullet_obj );
+                            sdEntity.AddEntityToEntitiesArray( bullet_obj );
                         }
 					}
                 };
@@ -11721,7 +11721,7 @@ class sdGunClass
                             
                             bullet_obj._extra_filtering_method = extra_filtering_method;
 
-                            sdEntity.entities.push( bullet_obj );
+                            sdEntity.AddEntityToEntitiesArray( bullet_obj );
                         }
 					}
                 };
@@ -11925,7 +11925,7 @@ class sdGunClass
                             bullet_obj._can_hit_owner = false;
                             bullet_obj.color = '#ffff00';
 
-                            sdEntity.entities.push( bullet_obj );
+                            sdEntity.AddEntityToEntitiesArray( bullet_obj );
                         } 
                     }
                 };

--- a/game/entities/sdHover.js
+++ b/game/entities/sdHover.js
@@ -462,21 +462,21 @@ class sdHover extends sdEntity
 						let character_entity = new sdCharacter({ x:this.x + ( 4 * i ), y:this.y, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 						let gun;
 
-						sdEntity.entities.push( character_entity );
+						sdEntity.AddEntityToEntitiesArray( character_entity );
 
 						if ( Math.random() < 0.5 ) // Random gun given to Star Defender
 						{
 							if ( Math.random() < 0.2 )
 							{
 								gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SNIPER });
-								sdEntity.entities.push( gun );
+								sdEntity.AddEntityToEntitiesArray( gun );
 								character_entity._ai_gun_slot = 4;
 								gun.onMovementInRange( character_entity );
 							}
 							else
 							{
 								gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SHOTGUN });
-								sdEntity.entities.push( gun );
+								sdEntity.AddEntityToEntitiesArray( gun );
 								character_entity._ai_gun_slot = 3;
 								gun.onMovementInRange( character_entity );
 							}
@@ -486,14 +486,14 @@ class sdHover extends sdEntity
 							if ( Math.random() < 0.1 )
 							{
 								gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_LMG });
-								sdEntity.entities.push( gun );
+								sdEntity.AddEntityToEntitiesArray( gun );
 								character_entity._ai_gun_slot = 2;
 								gun.onMovementInRange( character_entity );
 							}
 							else
 							{
 								gun = new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_RIFLE });
-								sdEntity.entities.push( gun );
+								sdEntity.AddEntityToEntitiesArray( gun );
 								character_entity._ai_gun_slot = 2;
 								gun.onMovementInRange( character_entity );
 							}
@@ -556,7 +556,7 @@ class sdHover extends sdEntity
 					{
 						let character_entity = new sdCharacter({ x:this.x + ( 4 * i ), y:this.y, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-						sdEntity.entities.push( character_entity );
+						sdEntity.AddEntityToEntitiesArray( character_entity );
 						sdFactions.SetHumanoidProperties( character_entity, sdFactions.FACTION_FALKOK );
 						
 						//character_entity._potential_vehicle = this; // Select this as enterable vehicle
@@ -701,7 +701,7 @@ class sdHover extends sdEntity
 					{
 						this.matter -= cost;
 
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 						this._bullets_reload = 1.5;
 
@@ -809,7 +809,7 @@ class sdHover extends sdEntity
 					{
 						this.matter -= cost;
 						
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 						if ( this.type === sdHover.TYPE_TANK )
 						this._bullets_reload = 2;
@@ -936,7 +936,7 @@ class sdHover extends sdEntity
 					{
 						this.matter -= cost;
 						
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 						if ( this.type === sdHover.TYPE_TANK )
 						this._rockets_reload = 50;
@@ -980,7 +980,7 @@ class sdHover extends sdEntity
 				if ( this._eff_timer <= 0 )
 				{
 					let e = new sdEffect({ type: sdEffect.TYPE_SMOKE, x:this.x, y:this.y, sx: -Math.random() + Math.random(), sy:-1 * Math.random() * 3, scale:1, radius:0.25, color:sdEffect.GetSmokeColor( sdEffect.smoke_colors ) });
-					sdEntity.entities.push( e );
+					sdEntity.AddEntityToEntitiesArray( e );
 					
 					this._eff_timer = 1;
 				}

--- a/game/entities/sdJunk.js
+++ b/game/entities/sdJunk.js
@@ -305,7 +305,7 @@ class sdJunk extends sdEntity
 				{
 					let drone = new sdDrone({ x:0, y:0 , type: 18});
 
-					sdEntity.entities.push( drone );
+					sdEntity.AddEntityToEntitiesArray( drone );
 								
 					let x,y;
 					let tr = 100;
@@ -393,7 +393,7 @@ class sdJunk extends sdEntity
 				if ( Math.random() < 0.1 ) // 10% chance to stabilize/revive the cube instead, idea by Bandit
 				{
 					let cube = new sdCube({ x: this.x, y: this.y });
-					sdEntity.entities.push( cube );
+					sdEntity.AddEntityToEntitiesArray( cube );
 					this.remove();
 					return; // Prevents spawning cube shard when a cube stabilizes
 				}
@@ -416,7 +416,7 @@ class sdJunk extends sdEntity
 
 								bullet_obj1._damage = 150;
 
-								sdEntity.entities.push( bullet_obj1 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj1 );
 
 					let bullet_obj2 = new sdBullet({ x: this.x, y: this.y });
 								bullet_obj2._owner = this;
@@ -434,7 +434,7 @@ class sdJunk extends sdEntity
 								bullet_obj2.color = '#62c8f2';
 
 								bullet_obj2._damage = 150;
-								sdEntity.entities.push( bullet_obj2 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj2 );
 
 					let bullet_obj3 = new sdBullet({ x: this.x, y: this.y });
 								bullet_obj3._owner = this;
@@ -453,7 +453,7 @@ class sdJunk extends sdEntity
 
 								bullet_obj3._damage = 150;
 
-								sdEntity.entities.push( bullet_obj3 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj3 );
 
 					let bullet_obj4 = new sdBullet({ x: this.x, y: this.y });
 								bullet_obj4._owner = this;
@@ -471,7 +471,7 @@ class sdJunk extends sdEntity
 								bullet_obj4.color = '#62c8f2';	
 
 								bullet_obj4._damage = 150;
-								sdEntity.entities.push( bullet_obj4 );
+								sdEntity.AddEntityToEntitiesArray( bullet_obj4 );
 				}
 			}
 			if ( this.type === sdJunk.TYPE_ALIEN_BATTERY ) // Cube "barrels" explode
@@ -535,7 +535,7 @@ class sdJunk extends sdEntity
 						}
 					}
 				};
-				sdEntity.entities.push( bullet );
+				sdEntity.AddEntityToEntitiesArray( bullet );
 			}
 			if ( this.type === sdJunk.TYPE_PLANETARY_MATTER_DRAINER ) // Large Anti-crystal degrades into a big Anti-crystal
 			{
@@ -553,11 +553,11 @@ class sdJunk extends sdEntity
 				ent.matter_max = sdCrystal.anticrystal_value * 4;
 				ent.matter = 0;
 
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 				sdWorld.UpdateHashPosition( ent, false ); // Optional, but will make it visible as early as possible
 				
 				let ent2 = new sdCube({ x: this.x, y: ent.y + ent.hitbox_y1 - 5, sx: this.sx, sy: this.sy, kind: sdCube.KIND_MATTER_STEALER });
-				sdEntity.entities.push( ent2 );
+				sdEntity.AddEntityToEntitiesArray( ent2 );
 				sdWorld.UpdateHashPosition( ent2, false ); // Optional, but will make it visible as early as possible
 			}
 
@@ -588,7 +588,7 @@ class sdJunk extends sdEntity
 					gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_BUILDTOOL_UPG });
 					gun.extra = this.type === sdJunk.TYPE_COUNCIL_BOMB ? 2 : 1;
 
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 				}, 500 );
 				
 				if ( this.type === sdJunk.TYPE_ERTHAL_DISTRESS_BEACON && Math.random() < 0.25 ) // 25% chance for energy cell drop
@@ -597,7 +597,7 @@ class sdJunk extends sdEntity
 					let gun2;
 					gun2 = new sdGun({ x:x, y:y, class:sdGun.CLASS_ERTHAL_ENERGY_CELL });
 
-					sdEntity.entities.push( gun2 );
+					sdEntity.AddEntityToEntitiesArray( gun2 );
 				}, 500 );
 
 				/*if ( this.type === sdJunk.TYPE_COUNCIL_BOMB && Math.random() < 0.10 ) // 10% chance for Council Immolator
@@ -606,7 +606,7 @@ class sdJunk extends sdEntity
 					let gun2;
 					gun2 = new sdGun({ x:x, y:y, class:sdGun.CLASS_COUNCIL_IMMOLATOR });
 
-					sdEntity.entities.push( gun2 );
+					sdEntity.AddEntityToEntitiesArray( gun2 );
 				}, 500 );*/
 				
 				if ( this.type === sdJunk.TYPE_COUNCIL_BOMB && Math.random() < 0.03 ) // 3% chance for Exalted core
@@ -615,7 +615,7 @@ class sdJunk extends sdEntity
 					let gun2;
 					gun2 = new sdGun({ x:x, y:y, class:sdGun.CLASS_EXALTED_CORE });
 
-					sdEntity.entities.push( gun2 );
+					sdEntity.AddEntityToEntitiesArray( gun2 );
 				}, 500 );
                 
                 if ( this.type === sdJunk.TYPE_COUNCIL_BOMB && Math.random() < 0.10 ) // 10% chance for Eternal Shard
@@ -623,7 +623,7 @@ class sdJunk extends sdEntity
 
 					let gun3 = new sdGun({ x:x, y:y, class:sdGun.CLASS_ETERNAL_SHARD });
 
-					sdEntity.entities.push( gun3 );
+					sdEntity.AddEntityToEntitiesArray( gun3 );
 				}, 500 );
 			}
             
@@ -797,7 +797,7 @@ class sdJunk extends sdEntity
 					gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_CUBE_SHARD });
 					gun.sx = sx;
 					gun.sy = sy;
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 
 				}, 500 );
 			}
@@ -818,7 +818,7 @@ class sdJunk extends sdEntity
 						gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_METAL_SHARD });
 						gun.sx = sx;
 						gun.sy = sy;
-						sdEntity.entities.push( gun );
+						sdEntity.AddEntityToEntitiesArray( gun );
 						sdWorld.UpdateHashPosition( gun, false );
 
 					//}, 500 );
@@ -875,7 +875,7 @@ class sdJunk extends sdEntity
 			if ( this.type === sdJunk.TYPE_ADVANCED_MATTER_CONTAINER )
 			{
 				let container = new sdMatterContainer({x: this.x, y: this.y, matter_max: this.matter_max, matter: this.matter});
-				sdEntity.entities.push( container );
+				sdEntity.AddEntityToEntitiesArray( container );
 				this.remove();
 				this._broken = false;
 			}
@@ -1205,7 +1205,7 @@ class sdJunk extends sdEntity
 
 					setTimeout(()=>{//Just in case
 						let worm = new sdSandWorm({x: this.x, y:this.y, kind: sdSandWorm.KIND_COUNCIL_WORM, scale: 1});
-						sdEntity.entities.push( worm );
+						sdEntity.AddEntityToEntitiesArray( worm );
 					}, 500 );
 
 					// Will ignore ones who disconnected during explosion
@@ -1272,7 +1272,7 @@ class sdJunk extends sdEntity
 					bullet_obj.time_left = 90 + Math.random() * 60; // 3-5 seconds after flare spawn to summon the humanoids
 					bullet_obj._bouncy = true;
 					
-					sdEntity.entities.push( bullet_obj );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj );
 									
 					sdSound.PlaySound({ name:'explosion', x:this.x, y:this.y, volume:1, pitch:0.25 });
 					sdSound.PlaySound({ name:'council_teleport', x:this.x, y:this.y, volume:0.5, pitch:2 });
@@ -1289,7 +1289,7 @@ class sdJunk extends sdEntity
 									{
 										let drone = new sdDrone({ x:0, y:0 , _ai_team: 3, type: 6, minion_of: this });
 
-										sdEntity.entities.push( drone );
+										sdEntity.AddEntityToEntitiesArray( drone );
 										
 										let x,y;
 										let tr = 100;
@@ -1345,7 +1345,7 @@ class sdJunk extends sdEntity
 							{
 								let worm = new sdSandWorm({ x:0, y:0 , kind:3, scale:0.5});
 
-								sdEntity.entities.push( worm );
+								sdEntity.AddEntityToEntitiesArray( worm );
 
 								{
 									let x,y;
@@ -1456,7 +1456,7 @@ class sdJunk extends sdEntity
 
 							let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-							sdEntity.entities.push( character_entity );
+							sdEntity.AddEntityToEntitiesArray( character_entity );
 
 							{
 								let x,y;

--- a/game/entities/sdLandMine.js
+++ b/game/entities/sdLandMine.js
@@ -218,7 +218,7 @@ class sdLandMine extends sdEntity
 					bullet_obj._can_hit_owner = false;
 					bullet_obj.color = '#ffff00';
 
-					sdEntity.entities.push( bullet_obj );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj );
 				}
 			}
 		}

--- a/game/entities/sdLifeBox.js
+++ b/game/entities/sdLifeBox.js
@@ -373,7 +373,7 @@ class sdLifeBox extends sdEntity
 					bullet_obj.color = '#ffffff';
 					bullet_obj._shield_block_mult = 10;
 
-					sdEntity.entities.push( bullet_obj );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj );
 					*/
 					if ( this._target.is( sdBlock ) && this._target.material === sdBlock.MATERIAL_TRAPSHIELD )
 					this._target.DamageWithEffect( 300 * this.damage_mult, this ); // Bullets had a multiplier of 10 against shield blocks so it can destroy those quickly

--- a/game/entities/sdLiquidAbsorber.js
+++ b/game/entities/sdLiquidAbsorber.js
@@ -212,7 +212,7 @@ class sdLiquidAbsorber extends sdEntity
                                 let gas_y = Math.floor( this.y / 16 ) * 16;
                                 let gas = new sdWater ({ x: gas_x, y: gas_y, type: sdWater.TYPE_TOXIC_GAS });
                                 gas._natural = false;
-                                sdEntity.entities.push( gas );
+                                sdEntity.AddEntityToEntitiesArray( gas );
                             }
                             else
                             sdWorld.SendEffect({ x: this.x, y: this.y, sy: -1, type: sdEffect.TYPE_SMOKE, radius: 1, scale: 2, color: '#eeeeee', spark_color: false });

--- a/game/entities/sdLongRangeAntenna.js
+++ b/game/entities/sdLongRangeAntenna.js
@@ -202,7 +202,7 @@ class sdLongRangeAntenna extends sdEntity
 
 						let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_TEAMMATE });
 
-						sdEntity.entities.push( character_entity );
+						sdEntity.AddEntityToEntitiesArray( character_entity );
 
 						{
 							let x,y;

--- a/game/entities/sdLongRangeTeleport.js
+++ b/game/entities/sdLongRangeTeleport.js
@@ -424,7 +424,7 @@ class sdLongRangeTeleport extends sdEntity
 				a = Math.random() * 2 * Math.PI;
 				s = Math.random() * 4;
 				let ent = new sdEffect({ x: this.x + x - 16, y: this.y + y - 16, type:sdEffect.TYPE_ROCK, sx: Math.sin(a)*s, sy: Math.cos(a)*s });
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 			}*/
 		}
 	}
@@ -731,7 +731,7 @@ class sdLongRangeTeleport extends sdEntity
 				let shard = new sdGun({ x:this.x + ( -16 + i * 8 ), y:this.y - 16, class:sdGun.CLASS_CUBE_SHARD });
                 shard.sd_filter = sdWorld.CreateSDFilter();
                 shard.sd_filter.s = sdCraftingBench.cube_items_filter.s;
-				sdEntity.entities.push( shard );
+				sdEntity.AddEntityToEntitiesArray( shard );
 			}
 		}
 		else
@@ -739,77 +739,77 @@ class sdLongRangeTeleport extends sdEntity
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_TOPS_DMR });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_WEAPON_2' )
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_TOPS_SHOTGUN });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_WEAPON_3' )
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_COMBAT_INSTRUCTOR });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_WEAPON_4' )
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_ZAPPER });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_WEAPON_5' )
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_RAYRIFLE });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_WEAPON_6' )
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_AREA_AMPLIFIER });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_WEAPON_7' )
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_ILLUSION_MAKER });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_WEAPON_8' )
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_LVL4_ARMOR_REGEN });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_WEAPON_9' )
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_TOPS_PLASMA_RIFLE });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_WEAPON_10' )
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_TELEKINETICS });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
         else
 		if ( rewards === 'CLAIM_REWARD_WEAPON_11' )
 		{
 			let gun;
 			gun = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_TOPS_GRENADE_LAUNCHER });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_CRYSTALS_1x' )
@@ -817,7 +817,7 @@ class sdLongRangeTeleport extends sdEntity
 			for( let i = 0; i < 3; i++ )
 			{
 				let crystal = new sdCrystal({ x:this.x + ( -24 + i * 24 ), y:this.y - 24, matter_max: 5120, type:sdCrystal.TYPE_CRYSTAL_ARTIFICIAL });
-				sdEntity.entities.push( crystal );
+				sdEntity.AddEntityToEntitiesArray( crystal );
 			}
 		}
 		else
@@ -826,7 +826,7 @@ class sdLongRangeTeleport extends sdEntity
 			for( let i = 0; i < 3; i++ )
 			{
 				let crystal = new sdCrystal({ x:this.x + ( -24 + i * 24 ), y:this.y - 24, matter_max: 10240, type:sdCrystal.TYPE_CRYSTAL_ARTIFICIAL });
-				sdEntity.entities.push( crystal );
+				sdEntity.AddEntityToEntitiesArray( crystal );
 			}
 		}
 		else
@@ -835,7 +835,7 @@ class sdLongRangeTeleport extends sdEntity
 			for( let i = 0; i < 3; i++ )
 			{
 				let crystal = new sdCrystal({ x:this.x + ( -24 + i * 24 ), y:this.y - 24, matter_max: 20480, type:sdCrystal.TYPE_CRYSTAL_ARTIFICIAL });
-				sdEntity.entities.push( crystal );
+				sdEntity.AddEntityToEntitiesArray( crystal );
 			}
 		}
 		else
@@ -844,25 +844,25 @@ class sdLongRangeTeleport extends sdEntity
 			for( let i = 0; i < 3; i++ )
 			{
 				let crystal = new sdCrystal({ x:this.x + ( -24 + i * 24 ), y:this.y - 24, matter_max: 40960, type:sdCrystal.TYPE_CRYSTAL_ARTIFICIAL });
-				sdEntity.entities.push( crystal );
+				sdEntity.AddEntityToEntitiesArray( crystal );
 			}
 		}
 		else
 		if ( rewards === 'CLAIM_REWARD_CONTAINER' )
 		{
 			let container = new sdMatterContainer({ x:this.x, y:this.y - 32, matter_max: 5120 * 8 * 10, matter: 5120 * 8 * 10 });
-			sdEntity.entities.push( container );
+			sdEntity.AddEntityToEntitiesArray( container );
 		}
 		else
 		if ( rewards === 'CLAIM_SCANNER' )
 		{
 			let scanner = new sdLandScanner({ x:this.x, y:this.y - 32});
-			sdEntity.entities.push( scanner );
+			sdEntity.AddEntityToEntitiesArray( scanner );
 		}
 		else
 		if ( rewards === 'CLAIM_BUILD_TOOL' )
 		{
-			sdEntity.entities.push( new sdGun({ x:this.x, y:this.y - 32, class:sdGun.CLASS_BUILD_TOOL }) );
+			sdEntity.AddEntityToEntitiesArray( new sdGun({ x:this.x, y:this.y - 32, class:sdGun.CLASS_BUILD_TOOL }) );
 		}
 		else
 		if ( rewards === 'CLAIM_HOVER' )
@@ -874,7 +874,7 @@ class sdLongRangeTeleport extends sdEntity
 				
 				e.filter = 'sepia(1) hue-rotate(180deg) brightness(1.5)';
 				
-				sdEntity.entities.push( e );
+				sdEntity.AddEntityToEntitiesArray( e );
 			}
 			else
 			{
@@ -893,7 +893,7 @@ class sdLongRangeTeleport extends sdEntity
 				
 				let r = [ 640, 1280, 2560, 5120 ][ ~~( Math.pow( Math.random(), 2 ) * 4 ) ];
 				let crystal = new sdCrystal({ x:this.x, y:this.y - 24, matter_max: r, type:sdCrystal.TYPE_CRYSTAL_ARTIFICIAL });
-				sdEntity.entities.push( crystal );
+				sdEntity.AddEntityToEntitiesArray( crystal );
 			}
 		}
 		else
@@ -901,33 +901,33 @@ class sdLongRangeTeleport extends sdEntity
 		{
 			let core;
 			core = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_MERGER_CORE });
-			sdEntity.entities.push( core );
+			sdEntity.AddEntityToEntitiesArray( core );
 		}
 		else
 		if ( rewards === 'CLAIM_UPGRADE_STATION_CHIP' )
 		{
 			let chipset;
 			chipset = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_UPGRADE_STATION_CHIPSET });
-			sdEntity.entities.push( chipset );
+			sdEntity.AddEntityToEntitiesArray( chipset );
 		}
 		else
 		if ( rewards === 'CLAIM_MATTER_CONTAINER_CHIP' )
 		{
 			let chipset;
 			chipset = new sdGun({ x:this.x, y:this.y - 16, class:sdGun.CLASS_MATTER_CONTAINER_CHIPSET });
-			sdEntity.entities.push( chipset );
+			sdEntity.AddEntityToEntitiesArray( chipset );
 		}
 		else
 		if ( rewards === 'CLAIM_MATTER_MATRIX' )
 		{
 			let matrix = new sdMatterMatrix({ x:this.x, y:this.y - 32 });
-			sdEntity.entities.push( matrix );
+			sdEntity.AddEntityToEntitiesArray( matrix );
 		}
         else
 		if ( rewards === 'CLAIM_SENTRY_TURRET' )
 		{
 			const turret = new sdTurret({ x:this.x, y:this.y - 32, kind: sdTurret.KIND_SENTRY });
-			sdEntity.entities.push( turret );
+			sdEntity.AddEntityToEntitiesArray( turret );
 		}
 		
 		sdWorld.SendEffect({ x:this.x, y:this.y - 24, type:sdEffect.TYPE_TELEPORT });

--- a/game/entities/sdLost.js
+++ b/game/entities/sdLost.js
@@ -127,7 +127,7 @@ class sdLost extends sdEntity
 						filter: sdLost.filters[ f ],
 						crystal_worth: f === sdLost.FILTER_GOLDEN ? 640 : 0
 					});
-					sdEntity.entities.push( new_asp );
+					sdEntity.AddEntityToEntitiesArray( new_asp );
 					return;
 				}
 
@@ -249,7 +249,7 @@ class sdLost extends sdEntity
 			//regen_rate: ent.is( sdCrystal ) ? ent.matter_regen : 0
 			
 		});
-		sdEntity.entities.push( ent2 );
+		sdEntity.AddEntityToEntitiesArray( ent2 );
 		sdWorld.UpdateHashPosition( ent2, false ); // Optional, but will make it visible as early as possible
 
 		return ent2;

--- a/game/entities/sdManualTurret.js
+++ b/game/entities/sdManualTurret.js
@@ -248,7 +248,7 @@ class sdManualTurret extends sdEntity
 										bullet_obj._anti_shield_damage_bonus = 200000;
 									}
 
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 								}
 							}
 						}

--- a/game/entities/sdMatterAmplifier.js
+++ b/game/entities/sdMatterAmplifier.js
@@ -150,7 +150,7 @@ class sdMatterAmplifier extends sdEntity
 			ent.matter = snapshot.matter;
 			ent.matter_regen = snapshot.matter_regen;
 			
-			sdEntity.entities.push( ent );
+			sdEntity.AddEntityToEntitiesArray( ent );
 		}
 	}
 	PrioritizeGivingMatterAway() // sdNode, sdCom, sdCommandCentre, sdMaterContainer, sdMatterAmplifier all do that in order to prevent slow matter flow through cables

--- a/game/entities/sdMeow.js
+++ b/game/entities/sdMeow.js
@@ -159,7 +159,7 @@ class sdMeow extends sdEntity
 				
 				bullet_obj._extra_filtering_method = extra_filtering_method;
 
-				sdEntity.entities.push( bullet_obj );
+				sdEntity.AddEntityToEntitiesArray( bullet_obj );
 			}
 		}
 		

--- a/game/entities/sdMothershipContainer.js
+++ b/game/entities/sdMothershipContainer.js
@@ -202,7 +202,7 @@ class sdMothershipContainer extends sdEntity
 
 								let ent = new sdSolarMatterDistributor({ x:0, y:0 });
 
-								sdEntity.entities.push( ent );
+								sdEntity.AddEntityToEntitiesArray( ent );
 
 								{
 									let x,y;
@@ -290,7 +290,7 @@ class sdMothershipContainer extends sdEntity
 					{
 						let ent = new sdJunk({ x:0, y:0, type: sdJunk.TYPE_COUNCIL_BOMB });
 
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 
 						{
 							let x,y;
@@ -393,7 +393,7 @@ class sdMothershipContainer extends sdEntity
 
 							let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_TEAMMATE });
 
-							sdEntity.entities.push( character_entity );
+							sdEntity.AddEntityToEntitiesArray( character_entity );
 
 							{
 								let x,y;

--- a/game/entities/sdObelisk.js
+++ b/game/entities/sdObelisk.js
@@ -142,7 +142,7 @@ class sdObelisk extends sdEntity
 		if ( this.type === 7 ) // Obelisk which holds artifact, is destroyed and artifact can be extracted to mothership as a task.
 		{
 			let artifact = new sdJunk({ x: this.x, y: this.y + 4, type: sdJunk.TYPE_ALIEN_ARTIFACT });
-			sdEntity.entities.push( artifact );
+			sdEntity.AddEntityToEntitiesArray( artifact );
 			color = '#880000';
 		}
 		if ( this.type === 8 ) // A larger obelisk which summons 10 events of same type. ( 10 x cubes, 10x asp event, for example )

--- a/game/entities/sdOctopus.js
+++ b/game/entities/sdOctopus.js
@@ -281,7 +281,7 @@ class sdOctopus extends sdEntity
 				ent.sx = this.sx + Math.random() * 8 - 4;
 				ent.sy = this.sy + Math.random() * 8 - 4;
 				ent.ttl = sdGun.disowned_guns_ttl;
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 				
 				this._consumed_guns.shift();
 			}*/
@@ -297,7 +297,7 @@ class sdOctopus extends sdEntity
 					ent.sy = this.sy + Math.random() * 8 - 4;
 					ent.ttl = sdGun.disowned_guns_ttl;
 					ent._held_by = null;
-					sdEntity.entities.push( ent );
+					sdEntity.AddEntityToEntitiesArray( ent );
 					
 					sdWorld.UpdateHashPosition( ent, false ); // Important! Prevents memory leaks and hash tree bugs
 				}

--- a/game/entities/sdOverlord.js
+++ b/game/entities/sdOverlord.js
@@ -302,7 +302,7 @@ class sdOverlord extends sdEntity
 					gun.sx = this.sx;
 					gun.sy = this.sy;
 					
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					this._droppen_gun_entity = gun;
 					
@@ -778,7 +778,7 @@ class sdOverlord extends sdEntity
                             
                             //bullet_obj.explosion_radius = 0; // Hack
 
-                            sdEntity.entities.push( bullet_obj );
+                            sdEntity.AddEntityToEntitiesArray( bullet_obj );
                         }
 					}
 					else

--- a/game/entities/sdPlayerDrone.js
+++ b/game/entities/sdPlayerDrone.js
@@ -495,7 +495,7 @@ class sdPlayerDrone extends sdCharacter
 
 							bullet_obj.time_left *= scale;
 
-							sdEntity.entities.push( bullet_obj );
+							sdEntity.AddEntityToEntitiesArray( bullet_obj );
 						}
 					}
 				}
@@ -615,7 +615,7 @@ class sdPlayerDrone extends sdCharacter
 				
 				sdSound.PlaySound({ name:'gravity_gun', x:this.x, y:this.y, volume:1.25, pitch:0.8, _server_allowed: true });
 				
-				sdEntity.entities.push( ent, ent2 )
+				sdEntity.AddEntityToEntitiesArray( ent, ent2 )
 			}
 		}
 		

--- a/game/entities/sdPlayerOverlord.js
+++ b/game/entities/sdPlayerOverlord.js
@@ -189,7 +189,7 @@ class sdPlayerOverlord extends sdCharacter
 					gun.sx = this.sx;
 					gun.sy = this.sy;
 					
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					this._droppen_gun_entity = gun;
 					
@@ -539,7 +539,7 @@ class sdPlayerOverlord extends sdCharacter
 						
 						//bullet_obj.explosion_radius = 0; // Hack
 
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 						this.matter -= 0.5;
 					}
@@ -577,7 +577,7 @@ class sdPlayerOverlord extends sdCharacter
 
 									bullet_obj._damage = 60;
 
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 								}
 
 								if ( this.melee_anim > 30 )

--- a/game/entities/sdPresetEditor.js
+++ b/game/entities/sdPresetEditor.js
@@ -909,7 +909,7 @@ class sdPresetEditor extends sdEntity
 					if ( best_score >= old_best_score )
 					{
 						editor = new sdPresetEditor({ w:preset_data.width, h:preset_data.height, x:best_new_relative_x, y:best_new_relative_y });
-						sdEntity.entities.push( editor );
+						sdEntity.AddEntityToEntitiesArray( editor );
 						editor.LoadPreset( null, preset_name, false, true, false );
 
 						let last_inserted_entities_array = editor._last_inserted_entities_array;

--- a/game/entities/sdQuadro.js
+++ b/game/entities/sdQuadro.js
@@ -381,7 +381,7 @@ class sdQuadro extends sdEntity
 				for ( let s = -1; s <= 1; s += 2 )
 				{
 					let wheel = new sdQuadro({ x: this.x + s * 7, y: this.y + 6, part: 1 });
-					sdEntity.entities.push( wheel );
+					sdEntity.AddEntityToEntitiesArray( wheel );
 
 					wheel.p = this;
 

--- a/game/entities/sdRescueTeleport.js
+++ b/game/entities/sdRescueTeleport.js
@@ -272,7 +272,7 @@ class sdRescueTeleport extends sdEntity
 				if ( guns.indexOf( i ) !== -1 )
 				{
 					let gun = new sdGun({ x:character_entity.x, y:character_entity.y, class: i });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 
 					character_entity.onMovementInRange( gun );
 				}
@@ -685,7 +685,7 @@ class sdRescueTeleport extends sdEntity
 				a = Math.random() * 2 * Math.PI;
 				s = Math.random() * 4;
 				let ent = new sdEffect({ x: this.x + x - 16, y: this.y + y - 16, type:sdEffect.TYPE_ROCK, sx: Math.sin(a)*s, sy: Math.cos(a)*s });
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 			}*/
 		}
 	}

--- a/game/entities/sdRift.js
+++ b/game/entities/sdRift.js
@@ -341,7 +341,7 @@ class sdRift extends sdEntity
 									filter: 'invert(1) sepia(1) saturate(100) hue-rotate(270deg) opacity(0.45)',
 									crystal_worth: 160
 								});
-								sdEntity.entities.push( asp );
+								sdEntity.AddEntityToEntitiesArray( asp );
 								sdWorld.UpdateHashPosition( asp, false ); // Prevent intersection with other ones
 							}
 						}
@@ -358,7 +358,7 @@ class sdRift extends sdEntity
 								//sdWorld.ReplaceColorInSDFilter_v2( quickie_filter, '#000000', '#ff00ff' ) // Pink, stronger quickies
 							//quickie.sd_filter = quickie_filter;
 							quickie.filter = 'invert(1) sepia(1) saturate(100) hue-rotate(270deg) opacity(0.45)';
-							sdEntity.entities.push( quickie );
+							sdEntity.AddEntityToEntitiesArray( quickie );
 							sdWorld.UpdateHashPosition( quickie, false ); // Prevent intersection with other ones
 						}
 					}
@@ -376,7 +376,7 @@ class sdRift extends sdEntity
 							cube.sy += ( 10 - ( Math.random() * 20 ) );
 							cube.sx += ( 10 - ( Math.random() * 20 ) );
 
-							sdEntity.entities.push( cube );
+							sdEntity.AddEntityToEntitiesArray( cube );
 
 							if ( !cube.CanMoveWithoutOverlap( cube.x, cube.y, 0 ) )
 							{
@@ -397,7 +397,7 @@ class sdRift extends sdEntity
 							asteroid.sy += ( 10 - ( Math.random() * 20 ) );
 							asteroid.sx += ( 10 - ( Math.random() * 20 ) );
 
-							sdEntity.entities.push( asteroid );
+							sdEntity.AddEntityToEntitiesArray( asteroid );
 
 							/*if ( !asteroid.CanMoveWithoutOverlap( cube.x, cube.y, 0 ) )
 							{
@@ -434,7 +434,7 @@ class sdRift extends sdEntity
 
 							let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_AGGRESSIVE });
 
-							sdEntity.entities.push( character_entity );
+							sdEntity.AddEntityToEntitiesArray( character_entity );
 							character_entity.s = 110;
 							{
 								let x,y;
@@ -559,7 +559,7 @@ class sdRift extends sdEntity
 
 						//gun.sx = sx;
 						//gun.sy = sy;
-						sdEntity.entities.push( gun );
+						sdEntity.AddEntityToEntitiesArray( gun );
 						
 						
 						while ( this._consumed_guns_snapshots.length > 0 )
@@ -574,7 +574,7 @@ class sdRift extends sdEntity
 								ent.sy = 0 + Math.random() * 8 - 4;
 								ent.ttl = sdGun.disowned_guns_ttl;
 								ent._held_by = null;
-								sdEntity.entities.push( ent );
+								sdEntity.AddEntityToEntitiesArray( ent );
 
 								sdWorld.UpdateHashPosition( ent, false ); // Important! Prevents memory leaks and hash tree bugs
 							}

--- a/game/entities/sdSampleBuilder.js
+++ b/game/entities/sdSampleBuilder.js
@@ -540,7 +540,7 @@ class sdSampleBuilder extends sdEntity
 				a = Math.random() * 2 * Math.PI;
 				s = Math.random() * 4;
 				let ent = new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_ROCK, sx: Math.sin(a)*s, sy: Math.cos(a)*s });
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 			}
 		}
 	}

--- a/game/entities/sdSandWorm.js
+++ b/game/entities/sdSandWorm.js
@@ -402,7 +402,7 @@ class sdSandWorm extends sdEntity
 					wyrmhide.sx = sx;
 					wyrmhide.sy = sy;
 					wyrmhide.extra = this.filter + ' brightness(0.5)';
-					sdEntity.entities.push( wyrmhide );
+					sdEntity.AddEntityToEntitiesArray( wyrmhide );
 				}, 500 );
 			}
 			if ( this.kind === sdSandWorm.KIND_COUNCIL_WORM ) // Council mecha worms spawn metal shards on death
@@ -417,7 +417,7 @@ class sdSandWorm extends sdEntity
 					let shard = new sdGun({ x:x, y:y, class:sdGun.CLASS_METAL_SHARD });
 					shard.sx = sx;
 					shard.sy = sy;
-					sdEntity.entities.push( shard );
+					sdEntity.AddEntityToEntitiesArray( shard );
 
 				}, 500 );
 
@@ -429,7 +429,7 @@ class sdSandWorm extends sdEntity
 
 				//gun.sx = sx;
 				//gun.sy = sy;
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 
 				}, 500 );
 				
@@ -441,7 +441,7 @@ class sdSandWorm extends sdEntity
 
 				//gun.sx = sx;
 				//gun.sy = sy;
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 
 				}, 500 );
 			}
@@ -610,7 +610,7 @@ class sdSandWorm extends sdEntity
 						wyrmhide.sx = sx;
 						wyrmhide.sy = sy;
 						wyrmhide.extra = this.filter + ' brightness(0.5)';
-						sdEntity.entities.push( wyrmhide );
+						sdEntity.AddEntityToEntitiesArray( wyrmhide );
 
 					}, 500 );
 				}
@@ -626,7 +626,7 @@ class sdSandWorm extends sdEntity
 						let shard = new sdGun({ x:x, y:y, class:sdGun.CLASS_METAL_SHARD });
 						shard.sx = sx;
 						shard.sy = sy;
-						sdEntity.entities.push( shard );
+						sdEntity.AddEntityToEntitiesArray( shard );
 
 					}, 500 );
 				}
@@ -681,7 +681,7 @@ class sdSandWorm extends sdEntity
 					let a = Math.random() * 2 * Math.PI;
 					let s = Math.random() * 4;
 					let ent = new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_ROCK, sx: this.sx + Math.sin(a)*s, sy: this.sy + Math.cos(a)*s });
-					sdEntity.entities.push( ent );
+					sdEntity.AddEntityToEntitiesArray( ent );
 				}
 			}
 		}
@@ -733,7 +733,7 @@ class sdSandWorm extends sdEntity
 
 					ent.towards_head = arr[ i - 1 ];
 					arr[ i - 1 ].towards_tail = ent;
-					sdEntity.entities.push( ent );
+					sdEntity.AddEntityToEntitiesArray( ent );
 
 					arr[ i ] = ent;
 				}
@@ -996,7 +996,7 @@ class sdSandWorm extends sdEntity
 
 							bullet_obj.color = '#ffff00'; // Yellow color
 
-							sdEntity.entities.push( bullet_obj );
+							sdEntity.AddEntityToEntitiesArray( bullet_obj );
 							this._last_attack = sdWorld.time;
 
 							sdSound.PlaySound({ name:'cube_attack', pitch: 4, x:this.x, y:this.y, volume:0.8 });
@@ -1458,7 +1458,7 @@ class sdSandWorm extends sdEntity
 			/*if ( Math.random() < 0.9 ) Improper placement, no use
 			{
 				let ent = new sdCrystal({ x: this.x, y: this.y });
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 				sdWorld.UpdateHashPosition( ent, false ); // Optional, but will make it visible as early as possible
 			}*/
 		}

--- a/game/entities/sdSetrBeholder.js
+++ b/game/entities/sdSetrBeholder.js
@@ -250,7 +250,7 @@ class sdSetrBeholder extends sdEntity
 			{
 				let character_entity = new sdCharacter({ x:this.x, y:this.y, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-				sdEntity.entities.push( character_entity );
+				sdEntity.AddEntityToEntitiesArray( character_entity );
 				
 				sdFactions.SetHumanoidProperties( character_entity, sdFactions.FACTION_SETR );
 				character_entity._potential_vehicle = this;
@@ -405,7 +405,7 @@ class sdSetrBeholder extends sdEntity
 					{
 						this.matter -= cost;
 
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 						this._bullets_reload = 2;
 

--- a/game/entities/sdSetrDestroyer.js
+++ b/game/entities/sdSetrDestroyer.js
@@ -165,7 +165,7 @@ class sdSetrDestroyer extends sdEntity
 					bullet_obj1._dirt_mult = 1;
 					bullet_obj1._no_explosion_smoke = true; 
 		
-					sdEntity.entities.push( bullet_obj1 );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj1 );
 		}
 	}
 	CanAttackEnt( ent )
@@ -274,7 +274,7 @@ class sdSetrDestroyer extends sdEntity
 				bullet_obj._bouncy = true;
 									
 				sdSound.PlaySound({ name:'explosion', x:this.x, y:this.y, volume:1, pitch:0.25 });
-				sdEntity.entities.push( bullet_obj );
+				sdEntity.AddEntityToEntitiesArray( bullet_obj );
 			}
 			
 			if ( sdWorld.time > this._last_damage + 50 )
@@ -400,7 +400,7 @@ class sdSetrDestroyer extends sdEntity
 
 							gun.sx = sx;
 							gun.sy = sy;
-							sdEntity.entities.push( gun );
+							sdEntity.AddEntityToEntitiesArray( gun );
 
 						}, 500 );
 					}
@@ -421,7 +421,7 @@ class sdSetrDestroyer extends sdEntity
 
 							gun.sx = sx + Math.random() - Math.random();
 							gun.sy = sy + Math.random() - Math.random();
-							sdEntity.entities.push( gun );
+							sdEntity.AddEntityToEntitiesArray( gun );
 
 						}, 500 );
 						shards--;
@@ -734,7 +734,7 @@ class sdSetrDestroyer extends sdEntity
 
 						bullet_obj.time_left = 30 * 5;
 
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 						this._rockets--;
 
@@ -804,7 +804,7 @@ class sdSetrDestroyer extends sdEntity
 			if ( this.hea < this._hmax / 5 )
 			{
 					let e = new sdEffect({ type: sdEffect.TYPE_SMOKE, x:this.x, y:this.y, sx: -Math.random() + Math.random(), sy:-1 * Math.random() * 5, scale:1, radius:0.5, color:sdEffect.GetSmokeColor( sdEffect.smoke_colors ) });
-					sdEntity.entities.push( e );
+					sdEntity.AddEntityToEntitiesArray( e );
 			}
 		}
 			

--- a/game/entities/sdShurgConverter.js
+++ b/game/entities/sdShurgConverter.js
@@ -198,7 +198,7 @@ class sdShurgConverter extends sdEntity
 
 					//gun.sx = sx;
 					//gun.sy = sy;
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 
 					}, 500 );
 				}

--- a/game/entities/sdShurgExcavator.js
+++ b/game/entities/sdShurgExcavator.js
@@ -268,7 +268,7 @@ class sdShurgExcavator extends sdEntity
 					bullet_obj._damage = 30;
 					bullet_obj._dirt_mult = 1;
 	
-					sdEntity.entities.push( bullet_obj );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj );
 								
 					sdSound.PlaySound({ name:'cut_droid_attack', x:this.x, y:this.y, volume: 0.1, pitch:2 });
 				}

--- a/game/entities/sdShurgManualTurret.js
+++ b/game/entities/sdShurgManualTurret.js
@@ -234,7 +234,7 @@ class sdShurgManualTurret extends sdEntity
 			{
 				let character_entity = new sdCharacter({ x:this.x, y:this.y, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-				sdEntity.entities.push( character_entity );
+				sdEntity.AddEntityToEntitiesArray( character_entity );
 				
 				sdFactions.SetHumanoidProperties( character_entity, sdFactions.FACTION_SHURG );
 				character_entity._potential_vehicle = this;
@@ -490,10 +490,10 @@ class sdShurgManualTurret extends sdEntity
 					{
 						this.matter -= cost;
 
-						sdEntity.entities.push( bullet_obj );
-						sdEntity.entities.push( bullet_obj2 );
-						sdEntity.entities.push( bullet_obj3 );
-						sdEntity.entities.push( bullet_obj4 );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj2 );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj3 );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj4 );
 
 						this._bullets_reload = 7;
 

--- a/game/entities/sdShurgTurret.js
+++ b/game/entities/sdShurgTurret.js
@@ -286,7 +286,7 @@ class sdShurgTurret extends sdEntity
 							bullet_obj._damage = 35;
 
 
-							sdEntity.entities.push( bullet_obj );
+							sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 							this.attack_frame = 1;
 							//this.attack_an = ( Math.atan2( dy, Math.abs( dx ) ) ) * 1000;

--- a/game/entities/sdSolarMatterDistributor.js
+++ b/game/entities/sdSolarMatterDistributor.js
@@ -231,7 +231,7 @@ class sdSolarMatterDistributor extends sdEntity
 
 						let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_TEAMMATE });
 
-						sdEntity.entities.push( character_entity );
+						sdEntity.AddEntityToEntitiesArray( character_entity );
 
 						{
 							let x,y;

--- a/game/entities/sdSpider.js
+++ b/game/entities/sdSpider.js
@@ -234,7 +234,7 @@ class sdSpider extends sdEntity
 
 				gun.sx = sx;
 				gun.sy = sy;
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 			}
 
 		}, 500 );
@@ -505,7 +505,7 @@ class sdSpider extends sdEntity
 
 					this.attack_anim = 10;
 
-					sdEntity.entities.push( bullet_obj );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj );
 					
 					
 					this._burst_shots--;

--- a/game/entities/sdStalker.js
+++ b/game/entities/sdStalker.js
@@ -130,7 +130,7 @@ class sdStalker extends sdEntity
 		for ( let i = 0; i < count; i++ )
 		{
 			let character_entity = new sdCharacter({ x:this.x, y:this.y + 16, _ai_enabled:sdCharacter.AI_MODEL_AGGRESSIVE });
-			sdEntity.entities.push( character_entity );
+			sdEntity.AddEntityToEntitiesArray( character_entity );
 		
 			character_entity.hea = 1000;
 			character_entity.hmax = 1000;
@@ -198,7 +198,7 @@ class sdStalker extends sdEntity
 					character_entity.ApplyStatusEffect({ type: sdStatusEffect.TYPE_PSYCHOSIS }); // Permanent
 					
 					let gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_STALKER_RIFLE });
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 					
 					gun.fire_mode = Math.random() > 0.5 ? 1 : 2;
 					
@@ -239,7 +239,7 @@ class sdStalker extends sdEntity
 						bullet_obj.time_left = Number.MAX_SAFE_INTEGER;
 						bullet_obj._hea = 100;
 
-						sdEntity.entities.push( bullet_obj )
+						sdEntity.AddEntityToEntitiesArray( bullet_obj )
 					}
 					break;
 				}
@@ -435,7 +435,7 @@ class sdStalker extends sdEntity
 
 							gun.sx = sx;
 							gun.sy = sy;
-							sdEntity.entities.push( gun );
+							sdEntity.AddEntityToEntitiesArray( gun );
 
 						}, 500 );
 					}
@@ -456,7 +456,7 @@ class sdStalker extends sdEntity
 
 							gun.sx = sx + Math.random() - Math.random();
 							gun.sy = sy + Math.random() - Math.random();
-							sdEntity.entities.push( gun );
+							sdEntity.AddEntityToEntitiesArray( gun );
 
 						}, 500 );
 						shards--;
@@ -729,7 +729,7 @@ class sdStalker extends sdEntity
 								}
 							}
 						
-							sdEntity.entities.push( bullet_obj );
+							sdEntity.AddEntityToEntitiesArray( bullet_obj );
 						
 							//sdSound.PlaySound({ name:'alien_laser1', x:this.x, y:this.y, volume:2, pitch: 0.2 });
 						}, 200 )
@@ -802,7 +802,7 @@ class sdStalker extends sdEntity
 							}
 						} 
 
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 						
 						sdSound.PlaySound({ name:'alien_laser1', x:this.x, y:this.y, volume:1, pitch: 0.2 });
 						

--- a/game/entities/sdStatusEffect.js
+++ b/game/entities/sdStatusEffect.js
@@ -239,7 +239,7 @@ class sdStatusEffect extends sdEntity
 						let yy = status_entity.for.y + y_offset + Math.cos( a ) * r;
 
 						let ent = new sdEffect({ x: xx, y: yy, type:sdEffect.TYPE_HEARTS, sx: 0, sy: up_velocity });
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 						
 						status_entity._effects.push( ent );
 					}
@@ -398,7 +398,7 @@ class sdStatusEffect extends sdEntity
 
 						let s = new sdEffect({ type: sdEffect.TYPE_SMOKE, x:xx, y:yy, sx: -Math.random() + Math.random(), sy:-1 - Math.random() * 2, scale:1, radius: Math.random() * 1.5 + 1 / 3, color:sdEffect.GetSmokeColor( sdEffect.smoke_colors ), spark_color: '#FF8800'});
 						status_entity._next_smoke_spawn = 1;
-						sdEntity.entities.push( s );
+						sdEntity.AddEntityToEntitiesArray( s );
 					}
 
 					if ( status_entity._next_spawn <= 0 )
@@ -430,7 +430,7 @@ class sdStatusEffect extends sdEntity
 
 							let ent = new sdEffect({ x: xx, y: yy, type: ( status_entity.t >= temperature_fire ) ? sdEffect.TYPE_FIRE : sdEffect.TYPE_FROZEN, sx: 0, sy: up_velocity * ( 0.5 + 0.5 * Math.random() ) });
 						
-							sdEntity.entities.push( ent );
+							sdEntity.AddEntityToEntitiesArray( ent );
 
 							status_entity._effects.push( ent );
 						}
@@ -1055,7 +1055,7 @@ class sdStatusEffect extends sdEntity
 						let yy = status_entity.for.y + ( status_entity.for._hitbox_y1 + status_entity.for._hitbox_y2 ) / 2 + Math.cos( a ) * r;
 
 						let ent = new sdEffect({ x: xx, y: yy, type:sdEffect.TYPE_SPEED, sx: 0, sy: -0.5 });
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 					}
 				}
 				
@@ -1256,7 +1256,7 @@ class sdStatusEffect extends sdEntity
 							status_entity.for._ai_gun_slot = -1;
 							status_entity.for.gun_slot = -1; // Hide the equipped weapon
 							status_entity.for._ai_allow_weapon_switch = false;
-							sdEntity.entities.push( new sdGun({ x:status_entity.for.x, y:status_entity.for.y, sx: status_entity.for.sx, sy: status_entity.for.sy, class:sdGun.CLASS_TELEPORT_SWORD }) );
+							sdEntity.AddEntityToEntitiesArray( new sdGun({ x:status_entity.for.x, y:status_entity.for.y, sx: status_entity.for.sx, sy: status_entity.for.sy, class:sdGun.CLASS_TELEPORT_SWORD }) );
 						}
 						else
 						status_entity.time_to_defeat = 30 * 5; // Teleport away in 5 seconds
@@ -1523,7 +1523,7 @@ class sdStatusEffect extends sdEntity
 						let s = new sdEffect({ type: sdEffect.TYPE_SMOKE, x:status_entity.for.x, y:status_entity.for.y, sx: -Math.random() + Math.random(), sy:-1 - Math.random() * 3, scale:1, radius:1/3, color: Math.random() > 0.5 ? '#000000' : '#200000' });
 						s._spark_color = s._color; 
 						status_entity._next_smoke_spawn = 2;
-						sdEntity.entities.push( s );
+						sdEntity.AddEntityToEntitiesArray( s );
 					}
 
 					if ( status_entity._next_spawn <= 0 )
@@ -1541,7 +1541,7 @@ class sdStatusEffect extends sdEntity
 						let yy = status_entity.for.y + ( status_entity.for._hitbox_y1 + status_entity.for._hitbox_y2 ) / 2 + Math.cos( a ) * r;
 
 						let ent = new sdEffect({ x: xx, y: yy, type:sdEffect.TYPE_VOID_FIRE, sx: 0, sy: -0.5 });
-						sdEntity.entities.push( ent );
+						sdEntity.AddEntityToEntitiesArray( ent );
 					}
 				}
 
@@ -1788,7 +1788,7 @@ class sdStatusEffect extends sdEntity
 								let ent2 = new sdEffect({ type: sdEffect.TYPE_LENS_FLARE, x:status_entity.for.x - 8, y:status_entity.for.y - 48, sx:0, sy:10, scale:5, radius:1, color:'#FF0000' });
 							
 								let ent3 = new sdEffect({ type: sdEffect.TYPE_LENS_FLARE, x:status_entity.for.x + 8, y:status_entity.for.y - 48, sx:0, sy:10, scale:5, radius:1, color:'#FF0000' });
-								sdEntity.entities.push( ent1, ent2, ent3 );
+								sdEntity.AddEntityToEntitiesArray( ent1, ent2, ent3 );
 							
 								break;
 							}
@@ -1805,7 +1805,7 @@ class sdStatusEffect extends sdEntity
 							case 4:
 							{
 								let ent = new sdEffect({ type: sdEffect.TYPE_LENS_FLARE, x:status_entity.for.x, y:status_entity.for.y - 32, sx:0, sy:-5, scale:5, radius:5, color:'#00FFFF' });
-								sdEntity.entities.push( ent );
+								sdEntity.AddEntityToEntitiesArray( ent );
 							
 								break;
 							}
@@ -1835,7 +1835,7 @@ class sdStatusEffect extends sdEntity
 									}
 								});
 								
-								sdEntity.entities.push( chat_ent );
+								sdEntity.AddEntityToEntitiesArray( chat_ent );
 								
 								break;
 							}
@@ -2323,7 +2323,7 @@ class sdStatusEffect extends sdEntity
 							bullet_obj.time_left = 90 + Math.random() * 60;
 							bullet_obj._bouncy = true;
 							
-							sdEntity.entities.push( bullet_obj );
+							sdEntity.AddEntityToEntitiesArray( bullet_obj );
 											
 							sdSound.PlaySound({ name:'explosion', x:ent.x, y:ent.y, volume:1, pitch:0.25 });
 							sdSound.PlaySound({ name:'council_teleport', x:ent.x, y:ent.y, volume:0.5, pitch:2 });
@@ -2384,7 +2384,7 @@ class sdStatusEffect extends sdEntity
 							status_entity.for._ai_gun_slot = -1;
 							status_entity.for.gun_slot = -1; // Hide the equipped weapon
 							status_entity.for._ai_allow_weapon_switch = false;
-							sdEntity.entities.push( new sdGun({ x:status_entity.for.x, y:status_entity.for.y, sx: status_entity.for.sx, sy: status_entity.for.sy, class:sdGun.CLASS_HIGH_COUNCIL_SWORD }) );
+							sdEntity.AddEntityToEntitiesArray( new sdGun({ x:status_entity.for.x, y:status_entity.for.y, sx: status_entity.for.sx, sy: status_entity.for.sy, class:sdGun.CLASS_HIGH_COUNCIL_SWORD }) );
 						}
 						else
 						status_entity.time_to_defeat = 30 * 5; // Teleport away in 5 seconds
@@ -2820,7 +2820,7 @@ class sdStatusEffect extends sdEntity
 		if ( !status_type.onNotMergedAndAboutToBeMade || status_type.onNotMergedAndAboutToBeMade( params ) )
 		{
 			let task = new sdStatusEffect( params );
-			sdEntity.entities.push( task );
+			sdEntity.AddEntityToEntitiesArray( task );
 
 			task.onThink( 0 ); // Assign .for property instantly so sdStatusEffect.entity_to_status_effects is updated in case of multiple effects are going to be applied during same frame
 		}

--- a/game/entities/sdStealer.js
+++ b/game/entities/sdStealer.js
@@ -110,7 +110,7 @@ class sdStealer extends sdEntity
 					let artifact = new sdJunk({ x:this.x, y:this.y, type: sdJunk.TYPE_STEALER_ARTIFACT });
 					artifact.sx = this.sx;
 					artifact.sy = this.sy;
-					sdEntity.entities.push( artifact );
+					sdEntity.AddEntityToEntitiesArray( artifact );
 
 				}, 500 );
 				

--- a/game/entities/sdTask.js
+++ b/game/entities/sdTask.js
@@ -682,7 +682,7 @@ class sdTask extends sdEntity
 		}
 	
 		let task = new sdTask( params );
-		sdEntity.entities.push( task );
+		sdEntity.AddEntityToEntitiesArray( task );
 		
 		return true;
 	}

--- a/game/entities/sdTeleport.js
+++ b/game/entities/sdTeleport.js
@@ -304,7 +304,7 @@ class sdTeleport extends sdEntity
 				a = Math.random() * 2 * Math.PI;
 				s = Math.random() * 4;
 				let ent = new sdEffect({ x: this.x + x - 16, y: this.y + y - 16, type:sdEffect.TYPE_ROCK, sx: Math.sin(a)*s, sy: Math.cos(a)*s });
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 			}
 		}
 	}

--- a/game/entities/sdTurret.js
+++ b/game/entities/sdTurret.js
@@ -682,7 +682,7 @@ class sdTurret extends sdEntity
 				else
 				{
 					this._sensor_area = new sdSensorArea({ x: this.x-range, y: this.y-range, w: range*2, h: range*2, on_movement_target: this });
-					sdEntity.entities.push( this._sensor_area );
+					sdEntity.AddEntityToEntitiesArray( this._sensor_area );
 				}
 				if ( this._seek_timer <= 0 && this.disabled === false )
 				{
@@ -914,7 +914,7 @@ class sdTurret extends sdEntity
                             bullet_obj._damage *= 1 + this.lvl / 3;
                             bullet_obj._temperature_addition *= 1 + this.lvl / 3;
 
-                            sdEntity.entities.push( bullet_obj );
+                            sdEntity.AddEntityToEntitiesArray( bullet_obj );
                         }
                     }
                     //else

--- a/game/entities/sdTzyrgAbsorber.js
+++ b/game/entities/sdTzyrgAbsorber.js
@@ -112,7 +112,7 @@ class sdTzyrgAbsorber extends sdEntity
 
 					//gun.sx = sx;
 					//gun.sy = sy;
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 
 					}, 500 );
 				}
@@ -241,7 +241,7 @@ class sdTzyrgAbsorber extends sdEntity
 							bullet_obj._damage = 15;
 
 
-							sdEntity.entities.push( bullet_obj );
+							sdEntity.AddEntityToEntitiesArray( bullet_obj );
 						}
 
 						this.attack_frame = 1;

--- a/game/entities/sdTzyrgMortar.js
+++ b/game/entities/sdTzyrgMortar.js
@@ -209,7 +209,7 @@ class sdTzyrgMortar extends sdEntity
                     if ( Math.random() < 0.1 )
                     {
                         const gun = new sdGun({ x:x, y:y, class:sdGun.CLASS_TZYRG_GRENADE_LAUNCHER });
-                        sdEntity.entities.push( gun );
+                        sdEntity.AddEntityToEntitiesArray( gun );
                     }
                 }, 500 );
 
@@ -326,7 +326,7 @@ class sdTzyrgMortar extends sdEntity
 									
 									this._last_attack = 0; // Reset "last seen" timer
 		
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 								}
 
 								this.attack_frame = 1;

--- a/game/entities/sdUpgradeStation.js
+++ b/game/entities/sdUpgradeStation.js
@@ -133,7 +133,7 @@ class sdUpgradeStation extends sdEntity
 			for ( let i = 0; i < items.length; i++ )
 			{
 				let gun = new sdGun({ x:character.x, y:character.y, class:items[ i ] });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 			}
 		}, 500 );
 		this.cooldown = 900; // 30 second cooldown so it does not get spammed.

--- a/game/entities/sdVeloxFortifier.js
+++ b/game/entities/sdVeloxFortifier.js
@@ -102,7 +102,7 @@ class sdVeloxFortifier extends sdEntity
 
 			//gun.sx = sx;
 			//gun.sy = sy;
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 
 			}, 500 );
 			
@@ -175,7 +175,7 @@ class sdVeloxFortifier extends sdEntity
 
 						let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-						sdEntity.entities.push( character_entity );
+						sdEntity.AddEntityToEntitiesArray( character_entity );
 
 						{
 							let x,y;

--- a/game/entities/sdVeloxMiner.js
+++ b/game/entities/sdVeloxMiner.js
@@ -239,7 +239,7 @@ class sdVeloxMiner extends sdEntity
 									bullet_obj._rail_circled = true;
 
 
-									sdEntity.entities.push( bullet_obj );
+									sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 									//this.attack_frame = 2;
 									//this.attack_an = ( Math.atan2( -dy, Math.abs( dx ) ) ) * 1000;

--- a/game/entities/sdVirus.js
+++ b/game/entities/sdVirus.js
@@ -226,7 +226,7 @@ class sdVirus extends sdEntity
 						y: this.y
 					});
 					
-					sdEntity.entities.push( virus );
+					sdEntity.AddEntityToEntitiesArray( virus );
 
 					let placed = false;
 					

--- a/game/entities/sdWater.js
+++ b/game/entities/sdWater.js
@@ -574,7 +574,7 @@ class sdWater extends sdEntity
 									if ( Math.random() < 0.3 )
 									{
 										let ent = new sdEffect({ x: e.x, y: this.y, type:sdEffect.TYPE_GLOW_HIT, color:'#FFAA33' });
-										sdEntity.entities.push( ent );
+										sdEntity.AddEntityToEntitiesArray( ent );
 									}
 								}
 							}
@@ -664,11 +664,11 @@ class sdWater extends sdEntity
 				if ( Math.random() < 0.1 )
 				{
 					ent = new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_GIB_GREEN, sx: Math.sin(a)*s, sy: Math.cos(a)*s, filter:'hue-rotate(-90deg) saturate(1.5)' });
-					sdEntity.entities.push( ent );
+					sdEntity.AddEntityToEntitiesArray( ent );
 				}
 				
 				ent = new sdEffect({ x: this.x + x, y: this.y + y, type:sdEffect.TYPE_BLOOD_GREEN, sx: Math.sin(a)*s, sy: Math.cos(a)*s, filter:'hue-rotate(-90deg) saturate(1.5)' });
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 			}
 			
 			if ( this.type === sdWater.TYPE_ESSENCE ) // Apparently water entites are removed before this can execute on client most of the time
@@ -677,7 +677,7 @@ class sdWater extends sdEntity
 				for ( let i = 0; i < Math.ceil( this._volume * 4 ); i++ )
 				{
 					let ent = new sdEffect({ x: this.x + Math.random() * this.hitbox_x2, y: this.y + Math.random() * ( this.hitbox_y2 - this.hitbox_y1 ), sy:-2, type:sdEffect.TYPE_GLOW_HIT, color:sdWater.reference_colors[ this.type ] });
-					sdEntity.entities.push( ent );
+					sdEntity.AddEntityToEntitiesArray( ent );
 				}
 
 				this.v = 0;
@@ -1001,7 +1001,7 @@ class sdWater extends sdEntity
 						water_ent._natural = this._natural;
 						water_ent._volume = subtract;
 						water_ent.v = Math.ceil( water_ent._volume * 100 );
-						sdEntity.entities.push( water_ent );
+						sdEntity.AddEntityToEntitiesArray( water_ent );
 						sdWorld.UpdateHashPosition( water_ent, false );
 						
 						this.AwakeSelfAndNear();
@@ -1021,7 +1021,7 @@ class sdWater extends sdEntity
 						water_ent._natural = this._natural;
 						water_ent._volume = subtract;
 						water_ent.v = Math.ceil( water_ent._volume * 100 );
-						sdEntity.entities.push( water_ent );
+						sdEntity.AddEntityToEntitiesArray( water_ent );
 						sdWorld.UpdateHashPosition( water_ent, false );
 						
 						this.AwakeSelfAndNear();
@@ -1188,7 +1188,7 @@ class sdWater extends sdEntity
 					
 							if ( e )
 							{
-								sdEntity.entities.push( e );
+								sdEntity.AddEntityToEntitiesArray( e );
 							}
 						}
 					}
@@ -1212,7 +1212,7 @@ class sdWater extends sdEntity
 								let yy = this.y + 8;
 								
 								let ent = new sdShark({ x: xx, y: yy });
-								sdEntity.entities.push( ent );
+								sdEntity.AddEntityToEntitiesArray( ent );
 
 								if ( !ent.CanMoveWithoutOverlap( ent.x, ent.y ) )
 								{

--- a/game/entities/sdWeaponBench.js
+++ b/game/entities/sdWeaponBench.js
@@ -694,7 +694,7 @@ class sdWeaponBench extends sdEntity
 				
 					let keycard = new sdGun({ x:executer_character.x, y:executer_character.y, access_id: this._access_id, class:sdGun.CLASS_ACCESS_KEY });
 					
-					sdEntity.entities.push( keycard );
+					sdEntity.AddEntityToEntitiesArray( keycard );
 				
 					keycard.sd_filter = sdWorld.CreateSDFilter( true );
 					sdWorld.ReplaceColorInSDFilter_v2( keycard.sd_filter, '#00ff00', this._key_color );

--- a/game/entities/sdWeather.js
+++ b/game/entities/sdWeather.js
@@ -618,7 +618,7 @@ class sdWeather extends sdEntity
 			
 			let dog = new ( params.class )( spawn_params );
 
-			sdEntity.entities.push( dog );
+			sdEntity.AddEntityToEntitiesArray( dog );
 
 			{
 				let x,y,i;
@@ -966,25 +966,25 @@ class sdWeather extends sdEntity
 				x = init_x;
 				{
 					let block = new sdBlock({ x:x, y:y , material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-					sdEntity.entities.push( block );
+					sdEntity.AddEntityToEntitiesArray( block );
 
 					if ( j === 4 || j === 5 )
 					potential_doors.push( block ); // Left-middle side is a potential door entrance
 
 					let bg = new sdBG({ x:x, y:y , width: 32, height: 32 });
-					sdEntity.entities.push( bg );
+					sdEntity.AddEntityToEntitiesArray( bg );
 				}
 				for ( let i = 0; i < 8; i++ )
 				{
 					x += 32;
 
 					let bg = new sdBG({ x:x, y:y , width: 32, height: 32 });
-					sdEntity.entities.push( bg );
+					sdEntity.AddEntityToEntitiesArray( bg );
 
 					if ( j === 0 || j === 9 )
 					{
 						let block = new sdBlock({ x:x, y:y , material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-						sdEntity.entities.push( block );
+						sdEntity.AddEntityToEntitiesArray( block );
 
 						if ( i === 3 || i === 4 )
 						potential_doors.push( block ); // Top-middle and bottom-middle side is a potential door entrance
@@ -993,13 +993,13 @@ class sdWeather extends sdEntity
 				x += 32;
 				{
 					let block = new sdBlock({ x:x, y:y , material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-					sdEntity.entities.push( block );
+					sdEntity.AddEntityToEntitiesArray( block );
 
 					if ( j === 4 || j === 5 )
 					potential_doors.push( block ); // Right-middle side is a potential door entrance
 
 					let bg = new sdBG({ x:x, y:y , width: 32, height: 32});
-					sdEntity.entities.push( bg );
+					sdEntity.AddEntityToEntitiesArray( bg );
 				}
 			}
 			// Interior types
@@ -1011,46 +1011,46 @@ class sdWeather extends sdEntity
 				// Lamps
 
 				let lamp = new sdLamp({ x:x + 64 + 16, y:y + 64 + 16 });
-				sdEntity.entities.push( lamp );
+				sdEntity.AddEntityToEntitiesArray( lamp );
 
 				let lamp2 = new sdLamp({ x:x + ( 32 * 8 ) - 32 + 16, y:y + 64 + 16 });
-				sdEntity.entities.push( lamp2 );
+				sdEntity.AddEntityToEntitiesArray( lamp2 );
 
 				let lamp3 = new sdLamp({ x:x + ( 32 * 8 ) - 32 + 16, y:y + ( 32 * 8 ) - 32 + 16 });
-				sdEntity.entities.push( lamp3 );
+				sdEntity.AddEntityToEntitiesArray( lamp3 );
 
 				let lamp4 = new sdLamp({ x:x + 64 + 16, y:y + ( 32 * 8 ) - 32 + 16 });
-				sdEntity.entities.push( lamp4 );
+				sdEntity.AddEntityToEntitiesArray( lamp4 );
 
 				// Turrets
 
 				let turret = new sdTurret({ x:x + 64 + 32, y:y + 64 + 16, type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret );
+				sdEntity.AddEntityToEntitiesArray( turret );
 				turret.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
 				let turret2 = new sdTurret({ x:x + 64 + 16, y:y + 64 + 32, type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret2 );
+				sdEntity.AddEntityToEntitiesArray( turret2 );
 				turret2.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret2.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
 				let turret3 = new sdTurret({ x:x + ( 32 * 8 ) - 32, y:y + 64 + 16, type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret3 );
+				sdEntity.AddEntityToEntitiesArray( turret3 );
 				turret3.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret3.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
 				let turret4 = new sdTurret({ x:x + ( 32 * 8 ) - 32 + 16, y:y + 64 + 32, type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret4 );
+				sdEntity.AddEntityToEntitiesArray( turret4 );
 				turret4.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret4.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
 				let turret5 = new sdTurret({ x:x + ( 32 * 8 ) - 32, y:y + ( 32 * 8 ) - 32 + 16 , type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret5 );
+				sdEntity.AddEntityToEntitiesArray( turret5 );
 				turret5.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret5.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
 				let turret6 = new sdTurret({ x:x + 64 + 32, y:y + ( 32 * 8 ) - 32 + 16 , type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret6 );
+				sdEntity.AddEntityToEntitiesArray( turret6 );
 				turret6.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret6.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
@@ -1059,51 +1059,51 @@ class sdWeather extends sdEntity
 				// Blocks
 
 				let block = new sdBlock({ x:x + 32, y:y + 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block );
+				sdEntity.AddEntityToEntitiesArray( block );
 
 				let block2 = new sdBlock({ x:x + 64, y:y + 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block2 );
+				sdEntity.AddEntityToEntitiesArray( block2 );
 
 				let block3 = new sdBlock({ x:x + 32, y:y + 64, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block3 );
+				sdEntity.AddEntityToEntitiesArray( block3 );
 
 				let block4 = new sdBlock({ x:x + ( 32 * 8 ), y:y + 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block4 );
+				sdEntity.AddEntityToEntitiesArray( block4 );
 
 				let block5 = new sdBlock({ x:x + ( 32 * 8 ) - 32, y:y + 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block5 );
+				sdEntity.AddEntityToEntitiesArray( block5 );
 
 				let block6 = new sdBlock({ x:x + ( 32 * 8 ), y:y + 64, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block6 );
+				sdEntity.AddEntityToEntitiesArray( block6 );
 
 				let block7 = new sdBlock({ x:x + ( 32 * 8 ), y:y + ( 32 * 8 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block7 );
+				sdEntity.AddEntityToEntitiesArray( block7 );
 
 				let block8 = new sdBlock({ x:x + ( 32 * 8 ) - 32, y:y + ( 32 * 8 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block8 );
+				sdEntity.AddEntityToEntitiesArray( block8 );
 
 				let block9 = new sdBlock({ x:x + ( 32 * 8 ), y:y + ( 32 * 8 ) - 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block9 );
+				sdEntity.AddEntityToEntitiesArray( block9 );
 
 				let block10 = new sdBlock({ x:x + 32, y:y + ( 32 * 8 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block10 );
+				sdEntity.AddEntityToEntitiesArray( block10 );
 
 				let block11 = new sdBlock({ x:x + 64, y:y + ( 32 * 8 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block11 );
+				sdEntity.AddEntityToEntitiesArray( block11 );
 
 				let block12 = new sdBlock({ x:x + 32, y:y + ( 32 * 8 ) - 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block12 );
+				sdEntity.AddEntityToEntitiesArray( block12 );
 
 				let block13 = new sdBlock({ x:x + 128, y:y + ( 32 * 5 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block13 );
+				sdEntity.AddEntityToEntitiesArray( block13 );
 
 				let block14 = new sdBlock({ x:x + 160, y:y + ( 32 * 5 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block14 );
+				sdEntity.AddEntityToEntitiesArray( block14 );
 
 				//Spawner
 					
 				let spawner = new sdFactionSpawner({ x:x + 160, y:y + ( 32 * 8 ) + 16, type:ai_team });
-				sdEntity.entities.push( spawner );
+				sdEntity.AddEntityToEntitiesArray( spawner );
 
 				// Doors
 
@@ -1116,7 +1116,7 @@ class sdWeather extends sdEntity
 
 
 					let door = new sdDoor({ x:door_x, y:door_y, open_type:1, model: sdDoor.MODEL_ARMORED, _reinforced_level: 1, filter: filter, _ai_team:ai_team });
-					sdEntity.entities.push( door );
+					sdEntity.AddEntityToEntitiesArray( door );
 
 					door.Damage( 1 ); // Enable sdSensorArea so it can actually be opened by AI
 				}
@@ -1129,13 +1129,13 @@ class sdWeather extends sdEntity
 				// Lamps
 
 				let lamp = new sdLamp({ x:x + 64 + 16, y:y + 64 + 16 });
-				sdEntity.entities.push( lamp );
+				sdEntity.AddEntityToEntitiesArray( lamp );
 
 				let lamp2 = new sdLamp({ x:x + ( 32 * 8 ) - 32 + 16, y:y + 64 + 16 });
-				sdEntity.entities.push( lamp2 );
+				sdEntity.AddEntityToEntitiesArray( lamp2 );
 
 				let lamp3 = new sdLamp({ x:x + ( 32 * 5 ), y:y + ( 32 * 6 ) + 48 });
-				sdEntity.entities.push( lamp3 );
+				sdEntity.AddEntityToEntitiesArray( lamp3 );
 
 				//let lamp4 = new sdLamp({ x:x + 64 + 16, y:y + ( 32 * 8 ) - 32 + 16 });
 				//sdEntity.entities.push( lamp4 );
@@ -1143,32 +1143,32 @@ class sdWeather extends sdEntity
 				// Turrets
 
 				let turret = new sdTurret({ x:x + 64 + 32, y:y + 64 + 16, type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret );
+				sdEntity.AddEntityToEntitiesArray( turret );
 				turret.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
 				let turret2 = new sdTurret({ x:x + 64 + 16, y:y + 64 + 32, type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret2 );
+				sdEntity.AddEntityToEntitiesArray( turret2 );
 				turret2.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret2.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
 				let turret3 = new sdTurret({ x:x + ( 32 * 8 ) - 32, y:y + 64 + 16, type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret3 );
+				sdEntity.AddEntityToEntitiesArray( turret3 );
 				turret3.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret3.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
 				let turret4 = new sdTurret({ x:x + ( 32 * 8 ) - 32 + 16, y:y + 64 + 32, type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret4 );
+				sdEntity.AddEntityToEntitiesArray( turret4 );
 				turret4.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret4.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
 				let turret5 = new sdTurret({ x:x + ( 32 * 8 ) - 64, y:y + ( 32 * 8 ) - 32 + 16 , type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret5 );
+				sdEntity.AddEntityToEntitiesArray( turret5 );
 				turret5.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret5.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
 				let turret6 = new sdTurret({ x:x + 64 + 64, y:y + ( 32 * 8 ) - 32 + 16 , type:1, _ai_team:ai_team });
-				sdEntity.entities.push( turret6 );
+				sdEntity.AddEntityToEntitiesArray( turret6 );
 				turret6.lvl = Math.round( Math.random() * 3 ); // Randomize turret level
 				turret6.kind = Math.round( Math.random() * 3 );	// Randomize turret kind
 
@@ -1177,57 +1177,57 @@ class sdWeather extends sdEntity
 				// Blocks
 
 				let block = new sdBlock({ x:x + 32, y:y + 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block );
+				sdEntity.AddEntityToEntitiesArray( block );
 
 				let block2 = new sdBlock({ x:x + 64, y:y + 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block2 );
+				sdEntity.AddEntityToEntitiesArray( block2 );
 
 				let block3 = new sdBlock({ x:x + 32, y:y + 64, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block3 );
+				sdEntity.AddEntityToEntitiesArray( block3 );
 
 				let block4 = new sdBlock({ x:x + ( 32 * 8 ), y:y + 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block4 );
+				sdEntity.AddEntityToEntitiesArray( block4 );
 
 				let block5 = new sdBlock({ x:x + ( 32 * 8 ) - 32, y:y + 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block5 );
+				sdEntity.AddEntityToEntitiesArray( block5 );
 
 				let block6 = new sdBlock({ x:x + ( 32 * 8 ), y:y + 64, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block6 );
+				sdEntity.AddEntityToEntitiesArray( block6 );
 
 				let block7 = new sdBlock({ x:x + ( 32 * 8 ), y:y + ( 32 * 8 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block7 );
+				sdEntity.AddEntityToEntitiesArray( block7 );
 
 				let block8 = new sdBlock({ x:x + ( 32 * 8 ), y:y + ( 32 * 8 ) - 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block8 );
+				sdEntity.AddEntityToEntitiesArray( block8 );
 
 				let block9 = new sdBlock({ x:x + ( 32 * 8 ), y:y + ( 32 * 8 ) - 64, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block9 );
+				sdEntity.AddEntityToEntitiesArray( block9 );
 
 				let block10 = new sdBlock({ x:x + 32, y:y + ( 32 * 8 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block10 );
+				sdEntity.AddEntityToEntitiesArray( block10 );
 
 				let block11 = new sdBlock({ x:x + 32, y:y + ( 32 * 8 ) - 32, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block11 );
+				sdEntity.AddEntityToEntitiesArray( block11 );
 
 				let block12 = new sdBlock({ x:x + 32, y:y + ( 32 * 8 ) - 64, material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block12 );
+				sdEntity.AddEntityToEntitiesArray( block12 );
 
 				let block13 = new sdBlock({ x:x + 128, y:y + ( 32 * 6 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block13 );
+				sdEntity.AddEntityToEntitiesArray( block13 );
 
 				let block14 = new sdBlock({ x:x + 160, y:y + ( 32 * 6 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block14 );
+				sdEntity.AddEntityToEntitiesArray( block14 );
 
 				let block15 = new sdBlock({ x:x + 96, y:y + ( 32 * 6 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block15 );
+				sdEntity.AddEntityToEntitiesArray( block15 );
 
 				let block16 = new sdBlock({ x:x + 192, y:y + ( 32 * 6 ), material: sdBlock.MATERIAL_WALL, filter:filter, _ai_team:ai_team, width: 32, height: 32 });
-				sdEntity.entities.push( block16 );
+				sdEntity.AddEntityToEntitiesArray( block16 );
 
 				//Spawner
 					
 				let spawner = new sdFactionSpawner({ x:x + 160, y:y + ( 32 * 8 ) + 16, type:ai_team });
-				sdEntity.entities.push( spawner );
+				sdEntity.AddEntityToEntitiesArray( spawner );
 
 				// Doors
 
@@ -1240,17 +1240,17 @@ class sdWeather extends sdEntity
 
 
 					let door = new sdDoor({ x:door_x, y:door_y, open_type:1, model: sdDoor.MODEL_ARMORED, _reinforced_level: 1, filter: filter, _ai_team:ai_team });
-					sdEntity.entities.push( door );
+					sdEntity.AddEntityToEntitiesArray( door );
 
 					door.Damage( 1 ); // Enable sdSensorArea so it can actually be opened by AI
 				}
 
 				let door = new sdDoor({ x:x + 96 - 16, y:y + ( 32 * 6 ) + 16, open_type:1, model: sdDoor.MODEL_ARMORED, _reinforced_level: 1, filter: filter, _ai_team:ai_team });
-				sdEntity.entities.push( door );
+				sdEntity.AddEntityToEntitiesArray( door );
 				door.Damage( 1 );
 
 				let door2 = new sdDoor({ x:x + 224 + 16, y:y + ( 32 * 6 ) + 16, open_type:1, model: sdDoor.MODEL_ARMORED, _reinforced_level: 1, filter: filter, _ai_team:ai_team });
-				sdEntity.entities.push( door2 );
+				sdEntity.AddEntityToEntitiesArray( door2 );
 				door2.Damage( 1 );
 			}
 		}
@@ -1380,7 +1380,7 @@ class sdWeather extends sdEntity
 					kind:   sdCube.GetRandomKind() // _kind = 1 -> is_huge = true , _kind = 2 -> is_white = true , _kind = 3 -> is_pink = true
 				});
 				cube.sy += 10;
-				sdEntity.entities.push( cube );
+				sdEntity.AddEntityToEntitiesArray( cube );
 
 				if ( !cube.CanMoveWithoutOverlap( cube.x, cube.y, 0 ) )
 				{
@@ -1451,7 +1451,7 @@ class sdWeather extends sdEntity
 
 					let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-					sdEntity.entities.push( character_entity );
+					sdEntity.AddEntityToEntitiesArray( character_entity );
 
 					{
 						if ( !sdWeather.SetRandomSpawnLocation( character_entity ) )
@@ -1536,7 +1536,7 @@ class sdWeather extends sdEntity
 					y:sdWorld.world_bounds.y1 + 32
 				});
 				//asp.sy += 10;
-				sdEntity.entities.push( asp );
+				sdEntity.AddEntityToEntitiesArray( asp );
 
 				if ( !asp.CanMoveWithoutOverlap( asp.x, asp.y, 0 ) )
 				{
@@ -1575,7 +1575,7 @@ class sdWeather extends sdEntity
 
 				let virus_entity = new sdVirus({ x:0, y:0, _is_big:true });
 				//virus_entity._is_big = true;
-				sdEntity.entities.push( virus_entity );
+				sdEntity.AddEntityToEntitiesArray( virus_entity );
 				//sdVirus.big_viruses++;
 				{
 					if ( !sdWeather.SetRandomSpawnLocation( virus_entity ) )
@@ -1673,7 +1673,7 @@ class sdWeather extends sdEntity
 
 					let portal = new sdRift({ x:0, y:0 });
 
-					sdEntity.entities.push( portal );
+					sdEntity.AddEntityToEntitiesArray( portal );
 
 					{
 						let x,y,i;
@@ -1827,7 +1827,7 @@ class sdWeather extends sdEntity
 
 					let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-					sdEntity.entities.push( character_entity );
+					sdEntity.AddEntityToEntitiesArray( character_entity );
 
 					{
 						if ( !sdWeather.SetRandomSpawnLocation( character_entity ) )
@@ -1869,7 +1869,7 @@ class sdWeather extends sdEntity
 				let obelisk = new sdObelisk({ x:0, y:0 });
 				obelisk.type = Math.round( 1 + Math.random() * 7 );
 
-				sdEntity.entities.push( obelisk );
+				sdEntity.AddEntityToEntitiesArray( obelisk );
 
 				{
 					let x,y,i;
@@ -2031,7 +2031,7 @@ class sdWeather extends sdEntity
 				{
 					let anticrystal = new sdJunk({ x:0, y:0, type: 3 });
 
-					sdEntity.entities.push( anticrystal );
+					sdEntity.AddEntityToEntitiesArray( anticrystal );
 
 					let x,y,i;
 					let tr = 1000;
@@ -2148,7 +2148,7 @@ class sdWeather extends sdEntity
 
 					let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-					sdEntity.entities.push( character_entity );
+					sdEntity.AddEntityToEntitiesArray( character_entity );
 
 					{
 						if ( !sdWeather.SetRandomSpawnLocation( character_entity ) )
@@ -2239,7 +2239,7 @@ class sdWeather extends sdEntity
 				{
 					let council_bomb = new sdJunk({ x:0, y:0, type: 4 });
 
-					sdEntity.entities.push( council_bomb );
+					sdEntity.AddEntityToEntitiesArray( council_bomb );
 
 					let x,y,i;
 					let tr = 1000;
@@ -2351,7 +2351,7 @@ class sdWeather extends sdEntity
 				{
 					let erthal_beacon = new sdJunk({ x:0, y:0, type: 5 });
 
-					sdEntity.entities.push( erthal_beacon );
+					sdEntity.AddEntityToEntitiesArray( erthal_beacon );
 
 					let x,y,i;
 					let tr = 1000;
@@ -2466,7 +2466,7 @@ class sdWeather extends sdEntity
 
 					let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-					sdEntity.entities.push( character_entity );
+					sdEntity.AddEntityToEntitiesArray( character_entity );
 
 					{
 						if ( !sdWeather.SetRandomSpawnLocation( character_entity ) )
@@ -2586,12 +2586,12 @@ class sdWeather extends sdEntity
 						{
 							if ( Math.random() < 0.2 )
 							{
-								sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SNIPER }) );
+								sdEntity.AddEntityToEntitiesArray( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SNIPER }) );
 								character_entity._ai_gun_slot = 4;
 							}
 							else
 							{
-								sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SHOTGUN }) );
+								sdEntity.AddEntityToEntitiesArray( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_SHOTGUN }) );
 								character_entity._ai_gun_slot = 3;
 							}
 						}
@@ -2599,12 +2599,12 @@ class sdWeather extends sdEntity
 						{ 
 							if ( Math.random() < 0.1 )
 							{
-								sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_LMG }) );
+								sdEntity.AddEntityToEntitiesArray( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_LMG }) );
 								character_entity._ai_gun_slot = 2;
 							}
 							else
 							{
-								sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_RIFLE }) );
+								sdEntity.AddEntityToEntitiesArray( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_RIFLE }) );
 								character_entity._ai_gun_slot = 2;
 							}
 						}
@@ -2775,7 +2775,7 @@ class sdWeather extends sdEntity
 
 					let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_FALKOK });
 
-					sdEntity.entities.push( character_entity );
+					sdEntity.AddEntityToEntitiesArray( character_entity );
 
 					{
 						if ( !sdWeather.SetRandomSpawnLocation( character_entity ) )
@@ -2861,7 +2861,7 @@ class sdWeather extends sdEntity
 
 				let destroyer_entity = new sdSetrDestroyer({ x:0, y:0 });
 
-				sdEntity.entities.push( destroyer_entity );
+				sdEntity.AddEntityToEntitiesArray( destroyer_entity );
 
 				{
 					let x,y;
@@ -2927,7 +2927,7 @@ class sdWeather extends sdEntity
 
 				let amphid = new sdAmphid({ x:0, y:0 });
 
-				sdEntity.entities.push( amphid );
+				sdEntity.AddEntityToEntitiesArray( amphid );
 
 				{
 					var ax,ay;
@@ -3018,7 +3018,7 @@ class sdWeather extends sdEntity
 					y:sdWorld.world_bounds.y1 + 32
 				});
 				//asp.sy += 10;
-				sdEntity.entities.push( biter );
+				sdEntity.AddEntityToEntitiesArray( biter );
 
 				if ( !biter.CanMoveWithoutOverlap( biter.x, biter.y, 0 ) )
 				{
@@ -3156,7 +3156,7 @@ class sdWeather extends sdEntity
 										let yy = e.y - 16;
 
 										let water_ent = new sdWater({ x: xx, y: yy, type: e.type, volume: grow_left });
-										sdEntity.entities.push( water_ent );
+										sdEntity.AddEntityToEntitiesArray( water_ent );
 										sdWorld.UpdateHashPosition( water_ent, false );
 
 										expirations.set( water_ent, expiration_in );
@@ -3297,7 +3297,7 @@ class sdWeather extends sdEntity
 
 				/*let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_AGGRESSIVE, s:250 });
 
-				sdEntity.entities.push( character_entity );*/
+				sdEntity.AddEntityToEntitiesArray( character_entity );*/
 				let [ character_entity, gun ] = sdFactionTools.SpawnCharacter( sdFactionTools.FT_FSB, { x:0,y:0 } );
 
 				{
@@ -3415,7 +3415,7 @@ class sdWeather extends sdEntity
 
 					let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_AGGRESSIVE });
 
-					sdEntity.entities.push( character_entity );
+					sdEntity.AddEntityToEntitiesArray( character_entity );
 
 					{
 						if ( !sdWeather.SetRandomSpawnLocation( character_entity ) )
@@ -3593,7 +3593,7 @@ class sdWeather extends sdEntity
 				{
 					let ent = new sdTzyrgAbsorber({ x:0, y:0});
 
-					sdEntity.entities.push( ent );
+					sdEntity.AddEntityToEntitiesArray( ent );
 
 					let x,y,i;
 					let tr = 1000;
@@ -3701,7 +3701,7 @@ class sdWeather extends sdEntity
 
 					let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_AGGRESSIVE });
 
-					sdEntity.entities.push( character_entity );
+					sdEntity.AddEntityToEntitiesArray( character_entity );
 
 					{
 						if ( !sdWeather.SetRandomSpawnLocation( character_entity ) )
@@ -3797,7 +3797,7 @@ class sdWeather extends sdEntity
 
 					let character_entity = new sdCharacter({ x:0, y:0, _ai_enabled:sdCharacter.AI_MODEL_AGGRESSIVE });
 
-					sdEntity.entities.push( character_entity );
+					sdEntity.AddEntityToEntitiesArray( character_entity );
 
 					{
 						if ( !sdWeather.SetRandomSpawnLocation( character_entity ) )
@@ -3811,7 +3811,7 @@ class sdWeather extends sdEntity
 							let character_settings;
 							{
 								{ 
-									sdEntity.entities.push( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_TELEPORT_SWORD }) );
+									sdEntity.AddEntityToEntitiesArray( new sdGun({ x:character_entity.x, y:character_entity.y, class:sdGun.CLASS_TELEPORT_SWORD }) );
 									character_entity._ai_gun_slot = 0;
 								}
 
@@ -4498,7 +4498,7 @@ class sdWeather extends sdEntity
 					layer:spawn_layer,
 					model: ent_model
 				});
-				sdEntity.entities.push( ent );
+				sdEntity.AddEntityToEntitiesArray( ent );
 				
 			}
 
@@ -4812,7 +4812,7 @@ class sdWeather extends sdEntity
 												/*let snow_block = new sdBlock({ x:xx, y:e.y - 4, width: 16, height: 4, material: sdBlock.MATERIAL_SNOW, filter:'saturate(0.1)', br:400, hue:180 });
 												snow_block._hea = snow_block._hmax = 10;
 
-												sdEntity.entities.push( snow_block );
+												sdEntity.AddEntityToEntitiesArray( snow_block );
 												sdWorld.UpdateHashPosition( snow_block, false );*/
 
 												let snow_block = sdEntity.Create( sdBlock, { x:xx, y:e.y - 4, width: 16, height: 4, material: sdBlock.MATERIAL_SNOW, filter:'saturate(0.1)', br:400, hue:180 } );
@@ -4827,7 +4827,7 @@ class sdWeather extends sdEntity
 									if ( !this.matter_rain )
 									{
 										/*let water = new sdWater({ x:xx, y:Math.floor(e.y/16)*16 - 16, type: this.acid_rain ? sdWater.TYPE_ACID : sdWater.TYPE_WATER });
-										sdEntity.entities.push( water );
+										sdEntity.AddEntityToEntitiesArray( water );
 										sdWorld.UpdateHashPosition( water, false ); // Without this, new water objects will only discover each other after one first think event (and by that time multiple water objects will overlap each other). This could be called at sdEntity super constructor but some entities don't know their bounds by that time
 										*/
 										sdEntity.Create( sdWater, { 
@@ -5445,7 +5445,7 @@ class sdWeather extends sdEntity
 						    else
 						    e = new sdEffect({ x:xx, y:yy, type:sdEffect.TYPE_BLOOD_GREEN, filter:'hue-rotate(90deg) opacity('+(~~((ctx.globalAlpha * 0.5)*10))/10+')' });
 						
-						    sdEntity.entities.push( e );
+						    sdEntity.AddEntityToEntitiesArray( e );
 						}
 					}
 				}

--- a/game/entities/sdZektaronDreadnought.js
+++ b/game/entities/sdZektaronDreadnought.js
@@ -163,7 +163,7 @@ class sdZektaronDreadnought extends sdEntity
 						}
 					};
 
-					sdEntity.entities.push( bullet_obj1 );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj1 );
 
 		let bullet_obj2 = new sdBullet({ x: this.x, y: this.y + 55 });
 					bullet_obj2._owner = this;
@@ -203,7 +203,7 @@ class sdZektaronDreadnought extends sdEntity
 						}
 					};
 
-					sdEntity.entities.push( bullet_obj2 );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj2 );
 
 		let bullet_obj3 = new sdBullet({ x: this.x + 10, y: this.y + 50 });
 					bullet_obj3._owner = this;
@@ -243,7 +243,7 @@ class sdZektaronDreadnought extends sdEntity
 						}
 					};
 
-					sdEntity.entities.push( bullet_obj3 );
+					sdEntity.AddEntityToEntitiesArray( bullet_obj3 );
 	}
 	CanAttackEnt( ent )
 	{
@@ -346,7 +346,7 @@ class sdZektaronDreadnought extends sdEntity
 				sdSound.PlaySound({ name:'enemy_mech_hurt', x:this.x, y:this.y, volume:3, pitch:1.7 });
 
 				let drone = new sdDrone({ x: this.x - ( 75 * 4 * Math.random() ), y: this.y - ( 30 * 4 * Math.random() ), type: sdDrone.DRONE_ZEKTARON_HUNTER, _ai_team: this._ai_team, minion_of: this }); // We do a little trolling
-				sdEntity.entities.push( drone );
+				sdEntity.AddEntityToEntitiesArray( drone );
 
 				// Make sure drone has any speed when deployed so drones don't get stuck into each other
 				if ( Math.abs( drone.sx ) < 0.5 )
@@ -376,7 +376,7 @@ class sdZektaronDreadnought extends sdEntity
 				
 
 				let drone2 = new sdDrone({ x: this.x + 75 * 4 * Math.random(), y: this.y - 30 * 4 * Math.random(), type: sdDrone.DRONE_ZEKTARON_HUNTER, _ai_team: this._ai_team, minion_of: this }); // We do a little trolling
-				sdEntity.entities.push( drone2 );
+				sdEntity.AddEntityToEntitiesArray( drone2 );
 
 				// Make sure drone has any speed when deployed so drones don't get stuck into each other
 				if ( Math.abs( drone2.sx ) < 0.5 )
@@ -509,7 +509,7 @@ class sdZektaronDreadnought extends sdEntity
 
 					gun.sx = sx;
 					gun.sy = sy;
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 
 				}, 500 );
 			}
@@ -529,7 +529,7 @@ class sdZektaronDreadnought extends sdEntity
 
 					gun.sx = sx + Math.random() - Math.random();
 					gun.sy = sy + Math.random() - Math.random();
-					sdEntity.entities.push( gun );
+					sdEntity.AddEntityToEntitiesArray( gun );
 
 				}, 500 );
 				shards--;
@@ -779,7 +779,7 @@ class sdZektaronDreadnought extends sdEntity
 							drone.sy *= 0.1;
 							drone._ignore_collisions_with = this; // Make sure it can pass through the dreadnought 
 			
-							sdEntity.entities.push( drone );
+							sdEntity.AddEntityToEntitiesArray( drone );
 							
 							let potential_target = drone.GetRandomTarget();
 							
@@ -805,7 +805,7 @@ class sdZektaronDreadnought extends sdEntity
 			
 							drone2._ignore_collisions_with = this; // Make sure it can pass through the dreadnought 
 							
-							sdEntity.entities.push( drone2 );
+							sdEntity.AddEntityToEntitiesArray( drone2 );
 							
 							potential_target = drone2.GetRandomTarget();
 							
@@ -839,7 +839,7 @@ class sdZektaronDreadnought extends sdEntity
 			
 							drone._ignore_collisions_with = this; // Make sure it can pass through the dreadnought 
 			
-							sdEntity.entities.push( drone );
+							sdEntity.AddEntityToEntitiesArray( drone );
 
 							let drone2 = new sdDrone({ x: this.x + 60, y: this.y + 25, type: ( Math.random() < 0.60 ) ? 15 /*Zektaron Corvette*/ : 14 /*Zektaron*/, _ai_team: this._ai_team, minion_of: this }); // We do a little trolling
 			
@@ -854,7 +854,7 @@ class sdZektaronDreadnought extends sdEntity
 			
 							drone2._ignore_collisions_with = this; // Make sure it can pass through the dreadnought 
 			
-							sdEntity.entities.push( drone2 );
+							sdEntity.AddEntityToEntitiesArray( drone2 );
 							
 							//this._current_minions_count++;
 							//this._current_minions_count++;
@@ -936,7 +936,7 @@ class sdZektaronDreadnought extends sdEntity
 						// bullet_obj._homing_mult = 0.04;
 						// bullet_obj.ac = 0.12;
 
-						sdEntity.entities.push( bullet_obj );
+						sdEntity.AddEntityToEntitiesArray( bullet_obj );
 
 						this._lasers--;
 

--- a/game/game.js
+++ b/game/game.js
@@ -1154,7 +1154,7 @@ let enf_once = true;
 								
 							   
 								ent = new entity_class( params );
-								sdEntity.entities.push( ent );
+								sdEntity.AddEntityToEntitiesArray( ent );
 							}
 							
 							//let props = ent.GetSnapshot( -2, false, null );

--- a/game/sdWorld.js
+++ b/game/sdWorld.js
@@ -941,7 +941,7 @@ class sdWorld
 				if ( Math.random() < 0.2 && !will_break_on_touch )
 				{
 					let bush = new sdGrass({ x:x + 16 / 2, y:y, filter:f, variation:sdGrass.VARIATION_BUSH });
-					sdEntity.entities.push( bush );
+					sdEntity.AddEntityToEntitiesArray( bush );
 
 					plants.push( bush._net_id );
 					plants_objs.push( bush );
@@ -949,7 +949,7 @@ class sdWorld
 				else
 				{
 					let grass = new sdGrass({ x:x, y:y - 16, filter:f, variation:sdWorld.GetFinalGrassHeight( x ) });
-					sdEntity.entities.push( grass );
+					sdEntity.AddEntityToEntitiesArray( grass );
 
 					plants.push( grass._net_id );
 					plants_objs.push( grass );
@@ -958,7 +958,7 @@ class sdWorld
 					{
 						let tree_variation = ( Math.random() < 0.35 ) ? ( ( Math.random() < 0.2 ) ? sdGrass.VARIATION_TREE_LARGE_BARREN : sdGrass.VARIATION_TREE_LARGE ) : ( ( Math.random() < 0.2 ) ? sdGrass.VARIATION_TREE_BARREN : sdGrass.VARIATION_TREE );
 						let tree = new sdGrass({ x:x + 16 / 2, y:y, filter:f, variation: tree_variation });
-						sdEntity.entities.push( tree );
+						sdEntity.AddEntityToEntitiesArray( tree );
 
 						plants.push( tree._net_id );
 						plants_objs.push( tree );
@@ -1007,14 +1007,14 @@ class sdWorld
 			if ( y % 16 === 0 )
 			{
 				let ent2 = new sdWater({ x:x, y:y, volume:1, type:allow_lava ? sdWater.TYPE_LAVA : sdWater.TYPE_WATER });
-				sdEntity.entities.push( ent2 );
+				sdEntity.AddEntityToEntitiesArray( ent2 );
 				sdWorld.UpdateHashPosition( ent2, false ); // Without this, new water objects will only discover each other after one first think event (and by that time multiple water objects will overlap each other). This could be called at sdEntity super constructor but some entities don't know their bounds by that time
 				
 				if ( !allow_lava )
 				if ( Math.random() < 0.01 )
 				{
 					let ent3 = new sdShark({ x:x + 8, y:y + 8 });
-					sdEntity.entities.push( ent3 );
+					sdEntity.AddEntityToEntitiesArray( ent3 );
 				}
 			}
 
@@ -1040,7 +1040,7 @@ class sdWorld
 
 		if ( ent )
 		{
-			sdEntity.entities.push( ent );
+			sdEntity.AddEntityToEntitiesArray( ent );
 			sdWorld.UpdateHashPosition( ent, false ); // Prevent intersection with other ones
 		}
 		
@@ -1099,7 +1099,7 @@ class sdWorld
 				
 				for ( let xx = x; xx < xx2; xx += sdDeepSleep.normal_cell_size )
 				for ( let yy = y; yy < yy2; yy += sdDeepSleep.normal_cell_size )
-				sdEntity.entities.push( new sdDeepSleep({
+				sdEntity.AddEntityToEntitiesArray( new sdDeepSleep({
 					x:xx, y:yy, w:sdDeepSleep.normal_cell_size, h:sdDeepSleep.normal_cell_size, type: sdDeepSleep.TYPE_UNSPAWNED_WORLD
 				}) );
 			}
@@ -1279,7 +1279,11 @@ class sdWorld
 
 
 
-						sdEntity.entities.splice( i, 1 );
+						// Swap-and-pop instead of splice(i,1): a forward splice would shift every later
+						// entity down without updating their _entities_array_index, corrupting the
+						// O(1)-removal invariant. The helper moves the last entity into slot i and fixes
+						// its index; i-- re-examines that swapped-in entity on the next iteration.
+						sdEntity.RemoveEntityFromEntitiesArrayByIndex( i );
 						i--;
 						continue;
 					}
@@ -1355,7 +1359,7 @@ class sdWorld
 				}
 			}
 
-			sdEntity.entities.push( gib );
+			sdEntity.AddEntityToEntitiesArray( gib );
 			//gib.s = scale;
 			
 			sdWorld.UpdateHashPosition( gib, false ); // Make it appear instantly for clients
@@ -1541,7 +1545,7 @@ class sdWorld
 
 						//water_ent.extra = extra;
 						
-						sdEntity.entities.push( water_ent );
+						sdEntity.AddEntityToEntitiesArray( water_ent );
 						sdWorld.UpdateHashPosition( water_ent, false );
 
 						if ( liquid_to_modify )
@@ -1685,7 +1689,7 @@ class sdWorld
 					bullet_obj._anti_shield_damage_bonus = bullet_obj._damage * 10;
 				}
 				
-				sdEntity.entities.push( bullet_obj );
+				sdEntity.AddEntityToEntitiesArray( bullet_obj );
 			}
             if ( !params.screen_shake && params.damage_scale > 0.01 )
             params.screen_shake = params.radius / 20;
@@ -1744,7 +1748,7 @@ class sdWorld
 								filter: params.filter,
 								hue: params.hue
 							});
-							sdEntity.entities.push( ent );
+							sdEntity.AddEntityToEntitiesArray( ent );
 							//sdWorld.UpdateHashPosition( ent, false ); // Prevent inersection with other ones
 
 							/*if ( bg._decals === null )
@@ -4416,7 +4420,7 @@ class sdWorld
 				
 				//console.log( 'BasicEntityBreakEffect', that.sx, k, a, s );
 
-				sdEntity.entities.push( new sdEffect({ x: x, y: y, type:type, sx: ( that.sx || 0 )*k + Math.sin(a)*s, sy: ( that.sy || 0 )*k + Math.cos(a)*s, filter: filter || that.GetBleedEffectFilter(), hue: that.hue || 0 }) );
+				sdEntity.AddEntityToEntitiesArray( new sdEffect({ x: x, y: y, type:type, sx: ( that.sx || 0 )*k + Math.sin(a)*s, sy: ( that.sy || 0 )*k + Math.cos(a)*s, filter: filter || that.GetBleedEffectFilter(), hue: that.hue || 0 }) );
 			}
 		}
 	}
@@ -5017,7 +5021,7 @@ class sdWorld
 			}
 
 			var ef = new sdEffect( params );
-			sdEntity.entities.push( ef );
+			sdEntity.AddEntityToEntitiesArray( ef );
 			
 			//if ( ef._type === sdEffect.TYPE_EXPLOSION || ef._type === sdEffect.TYPE_EXPLOSION_NON_ADDITIVE )
 			//debugger;
@@ -5135,7 +5139,7 @@ class sdWorld
 					if ( arr[ 0 ] === 'EFF' )
 					{
 						let e = new sdEffect( arr[ 1 ] );
-						sdEntity.entities.push( e );
+						sdEntity.AddEntityToEntitiesArray( e );
 					}
 					else
 					if ( arr[ 0 ] === 'CARRY_END' )
@@ -5332,7 +5336,7 @@ class sdWorld
 							if ( sdWorld.server_config.PlayerSpawnPointSeeker )
 							sdWorld.server_config.PlayerSpawnPointSeeker( character_entity, socket );
 
-							sdEntity.entities.push( character_entity );
+							sdEntity.AddEntityToEntitiesArray( character_entity );
 							
 							if ( sdWorld.server_config.onRespawn )
 							sdWorld.server_config.onRespawn( character_entity, player_settings );
@@ -5361,7 +5365,7 @@ class sdWorld
 					if ( sdShop.options[ i ]._min_workbench_level === 0 )
 					{
 						let gun = new sdGun({ x: character_entity.x, y: character_entity.y, class: sdShop.options[ i ].class });
-						sdEntity.entities.push( gun );
+						sdEntity.AddEntityToEntitiesArray( gun );
 					}*/
 				}
 				else

--- a/game/server/sdModeration.js
+++ b/game/server/sdModeration.js
@@ -652,11 +652,11 @@ class sdModeration
 						//for ( let i = 0; i < sdWorld.sockets.length; i++ )
 						//sdWorld.sockets[ i ].SDServiceMessage( socket.character.title + ' has entered "godmode".' );
 
-						sdEntity.entities.push( new sdGun({ x:socket.character.x, y:socket.character.y, class:sdGun.CLASS_ADMIN_REMOVER }) );
-						sdEntity.entities.push( new sdGun({ x:socket.character.x, y:socket.character.y, class:sdGun.CLASS_ADMIN_TELEPORTER }) );
-						sdEntity.entities.push( new sdGun({ x:socket.character.x, y:socket.character.y, class:sdGun.CLASS_ADMIN_DAMAGER }) );
-						sdEntity.entities.push( new sdGun({ x:socket.character.x, y:socket.character.y, class:sdGun.CLASS_BUILD_TOOL }) );
-						sdEntity.entities.push( new sdGun({ x:socket.character.x, y:socket.character.y, class:sdGun.CLASS_ADMIN_MASS_DELETER }) );
+						sdEntity.AddEntityToEntitiesArray( new sdGun({ x:socket.character.x, y:socket.character.y, class:sdGun.CLASS_ADMIN_REMOVER }) );
+						sdEntity.AddEntityToEntitiesArray( new sdGun({ x:socket.character.x, y:socket.character.y, class:sdGun.CLASS_ADMIN_TELEPORTER }) );
+						sdEntity.AddEntityToEntitiesArray( new sdGun({ x:socket.character.x, y:socket.character.y, class:sdGun.CLASS_ADMIN_DAMAGER }) );
+						sdEntity.AddEntityToEntitiesArray( new sdGun({ x:socket.character.x, y:socket.character.y, class:sdGun.CLASS_BUILD_TOOL }) );
+						sdEntity.AddEntityToEntitiesArray( new sdGun({ x:socket.character.x, y:socket.character.y, class:sdGun.CLASS_ADMIN_MASS_DELETER }) );
 
 						//socket.character.InstallUpgrade( 'upgrade_jetpack' );
 						//socket.character.InstallUpgrade( 'upgrade_hook' );

--- a/game/server/sdServerConfig.js
+++ b/game/server/sdServerConfig.js
@@ -359,7 +359,7 @@ class sdServerConfigFull extends sdServerConfigShort
 		if ( guns.indexOf( i ) !== -1 )
 		{
 			let gun = new sdGun({ x:character_entity.x, y:character_entity.y, class: i });
-			sdEntity.entities.push( gun );
+			sdEntity.AddEntityToEntitiesArray( gun );
 
 			//if ( i !== sdGun.CLASS_BUILD_TOOL )
 			//character_entity.gun_slot = sdGun.classes[ i ].slot;
@@ -429,7 +429,7 @@ class sdServerConfigFull extends sdServerConfigShort
 			hover.doors_locked = true;
 			hover.nick = 'Extraction Hover';
 			
-			sdEntity.entities.push( hover );
+			sdEntity.AddEntityToEntitiesArray( hover );
 			
 			for ( let rise = 0; rise < 10; rise++ )
 			{
@@ -465,7 +465,7 @@ class sdServerConfigFull extends sdServerConfigShort
 				pilot.matter = 1;
 				pilot.matter_max = 1;
 				
-				sdEntity.entities.push( pilot );
+				sdEntity.AddEntityToEntitiesArray( pilot );
 				
 				hover.AddDriver( pilot, true );
 			}
@@ -812,13 +812,13 @@ class sdServerConfigFull extends sdServerConfigShort
 			}, 5500 );
 			
 			
-			sdEntity.entities.push( instructor_entity );
-			sdEntity.entities.push( instructor_gun );
+			sdEntity.AddEntityToEntitiesArray( instructor_entity );
+			sdEntity.AddEntityToEntitiesArray( instructor_gun );
 			
 			if ( Math.random() < 0.25 )
 			{
 				let instructor_gun2 = new sdGun({ x:instructor_entity.x, y:instructor_entity.y, class:sdGun.CLASS_EMERGENCY_INSTRUCTOR });
-				sdEntity.entities.push( instructor_gun2 );
+				sdEntity.AddEntityToEntitiesArray( instructor_gun2 );
 				
 				instructor_entity.onMovementInRange( instructor_gun2 );
 			}

--- a/index.js
+++ b/index.js
@@ -716,7 +716,7 @@ if ( sdEntity.global_entities.length === 0 )
 {
 	console.log( 'Recreating sdWeather' );
 	//sdEntity.global_entities.push( new sdWeather({}) );
-	sdEntity.entities.push( new sdWeather({}) );
+	sdEntity.AddEntityToEntitiesArray( new sdWeather({}) );
 }
 
 if ( sdWorld.server_config.onAfterSnapshotLoad )
@@ -1784,7 +1784,7 @@ io.on( 'connection', ( socket )=>
 				socket.respawn_block_until = sdWorld.time + ( 1000 * 60 * 2 ); // 2 minutes respawn wait time
 				// Not sure if this is ideal solution. - Booraz149
 			}
-			sdEntity.entities.push( character_entity );
+			sdEntity.AddEntityToEntitiesArray( character_entity );
 			
 			if ( sdWorld.server_config.PlayerSpawnPointSeeker )
 			if ( sdWorld.server_config.PlayerSpawnPointSeeker( character_entity, socket ) )
@@ -1984,7 +1984,7 @@ io.on( 'connection', ( socket )=>
 			if ( guns.indexOf( i ) !== -1 )
 			{
 				let gun = new sdGun({ x:character_entity.x, y:character_entity.y, class: i });
-				sdEntity.entities.push( gun );
+				sdEntity.AddEntityToEntitiesArray( gun );
 
 				if ( i !== sdGun.CLASS_BUILD_TOOL )
 				character_entity.gun_slot = sdGun.classes[ i ].slot;


### PR DESCRIPTION
Reworks removals from `sdEntity.entities` to avoid repeated full-array scans during entity cleanup.

Summary:
- Adds `_entities_array_index` bookkeeping for entities in the global registry.
- Centralizes registry add/remove helpers.
- Replaces `lastIndexOf` + `splice` removal in bulk cleanup with indexed swap-and-pop.
- Routes direct registry pushes through the helper so the index invariant remains valid.

Verification:
- Syntax-checked changed files with bundled Node during the audit.
- Heavy-world audit reported no duplicate entity refs and no stale registry indices.
- Heavy-combat profile showed `BulkRemoveEntitiesFromEntitiesArray` dropped from a top hotspot to below measurable threshold in the captured profile.