### PR TITLE
Reuse ignore-class arrays for LOS class-list caching

### DIFF
--- a/game/entities/sdLandMine.js
+++ b/game/entities/sdLandMine.js
@@ -16,7 +16,10 @@ class sdLandMine extends sdEntity
 		sdLandMine.VARIATION_BASIC = 0;
 		sdLandMine.VARIATION_JUMPER = 1;
 		sdLandMine.VARIATION_BANANA = 2;
-		
+
+		sdLandMine.ignored_classes_active = [ 'sdCharacter' ]; // Reused so GetClassListByClassNameList caching can hit (avoids per-call array allocation)
+		sdLandMine.ignored_classes_none = [];
+
 		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
 	}
 	get hitbox_x1() { return -3; }
@@ -66,7 +69,7 @@ class sdLandMine extends sdEntity
 	}
 	GetIgnoredEntityClasses()
 	{
-		return ( this.activated || this.variation === sdLandMine.VARIATION_BANANA ) ? [ 'sdCharacter' ] : [ ];
+		return ( this.activated || this.variation === sdLandMine.VARIATION_BANANA ) ? sdLandMine.ignored_classes_active : sdLandMine.ignored_classes_none;
 	}
 	IsVisible( observer_character ) // Can be used to hide guns that are held, they will not be synced this way
 	{

--- a/game/entities/sdOverlord.js
+++ b/game/entities/sdOverlord.js
@@ -27,8 +27,25 @@ class sdOverlord extends sdEntity
 		sdOverlord.overlords = [];
 		
 		sdOverlord.rifle_offset_y = 14;
-		
+
+		// Per-class-name reusable single-element ignore arrays so the hot melee LOS
+		// check below doesn't allocate a fresh [ class_name ] every call and can hit
+		// the GetClassListByClassNameList ._classes cache. Keyed by class name; the
+		// returned array is only read (the LOS path attaches its cache to it), never
+		// mutated, so sharing it across calls is safe.
+		sdOverlord._self_ignore_class_arrays = new Map();
+
 		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
+	}
+	static GetSelfIgnoreClassArray( class_name )
+	{
+		let arr = sdOverlord._self_ignore_class_arrays.get( class_name );
+		if ( arr === undefined )
+		{
+			arr = [ class_name ];
+			sdOverlord._self_ignore_class_arrays.set( class_name, arr );
+		}
+		return arr;
 	}
 	get hitbox_x1() { return -13; }
 	get hitbox_x2() { return 13; }
@@ -828,7 +845,7 @@ class sdOverlord extends sdEntity
 						if ( t )
 						if ( !t._is_being_removed )
 						if ( sdWorld.inDist2D_Boolean( t.x, t.y, this.x, this.y + sdOverlord.rifle_offset_y, 50 ) )
-						if ( sdWorld.CheckLineOfSight( this.x, this.y, t.x, t.y, this, [ t.GetClass() ] ) )
+						if ( sdWorld.CheckLineOfSight( this.x, this.y, t.x, t.y, this, sdOverlord.GetSelfIgnoreClassArray( t.GetClass() ) ) )
 						{
 							if ( t === this._droppen_gun_entity )
 							{


### PR DESCRIPTION
Reduces repeated ignore-class array allocation at hot LOS callsites so existing class-list memoization can take effect.

Summary:
- Reuses static ignore arrays in `sdLandMine`.
- Adds a small per-class ignore-array cache in `sdOverlord` for target-dependent LOS checks.
- Preserves the same ignored class membership returned to LOS checks.

Verification:
- Syntax-checked with bundled Node during the audit.
- Heavy-combat verification reported no recurring `Inefficient class name list` warnings from these callsites after the change.