### PR TITLE
Short-circuit turret target checks by class first

### DIFF
--- a/game/entities/sdTurret.js
+++ b/game/entities/sdTurret.js
@@ -393,14 +393,23 @@ class sdTurret extends sdEntity
 		}
 
 		const targetable_classes = sdTurret.targetable_classes;
-						
+
+		// phase-13-lagmachine-02: bail on the cheap class check BEFORE the per-call array allocation
+		// in GetClosestPointWithinCollision + the inDist math. A moving base (sdSteeringWheel) floods
+		// every overlapping turret sensor area with movement callbacks for sdBlock/sdCrystal/sdDoor/
+		// etc. that can never be targets; this WeakSet.has was already the 2nd condition below, so
+		// hoisting it is behavior-identical (the function would otherwise fall through to its final
+		// `return false`) but skips the allocation + distance work for all non-targetable entities.
+		if ( !targetable_classes.has( e.constructor ) )
+		return false;
+
 		const range = this.GetTurretRange();
-		
+
 		let [ cx, cy ] = e.GetClosestPointWithinCollision( this.x, this.y );
-		
+
 		if ( sdWorld.inDist2D_Boolean( this.x, this.y, cx, cy, range ) )
 		if ( targetable_classes.has( e.constructor ) )
-		if ( 
+		if (
 				( !e._is_being_removed ) &&
 				( e.hea || e._hea ) > 0 && 
 				( !e.is( sdSandWorm ) || e.death_anim === 0 ) && 


### PR DESCRIPTION
## Summary

Moves the `sdTurret.IsLegitimateTarget` targetable-class check ahead of the closest-point allocation and distance check.

## Why

During a moving-base lag-machine profile, turret sensor callbacks were repeatedly evaluating non-targetable base parts such as blocks, crystals, doors, and builders. The existing class check already rejected these entities later in the condition chain, so this keeps behavior the same while avoiding unnecessary work for classes that can never be turret targets.

## Validation

- `node --check game/entities/sdTurret.js`
- Measured on VPS slot 1003 during moving-base profiling before upstream branch prep: turret sensor cascade dropped from about 16.0% to 10.8% inclusive; per-call target work dropped about 74%.

## Notes

Draft PR for case-by-case review.