### PR TITLE
Throttle snapshot sync under server frame pressure

### DIFF
--- a/game/sdWorld.js
+++ b/game/sdWorld.js
@@ -65,6 +65,14 @@ class sdWorld
 	{
 		//console.log('sdWorld class initiated');
 		sdWorld.logic_rate = 16; // for server
+
+		// Adaptive snapshot backpressure: when the previous frame's simulation-only
+		// time (sdWorld.last_frame_time) exceeds this many ms, the per-frame client
+		// snapshot scheduler backs off (only_do_nth_connection_per_frame ramps up) so
+		// per-client snapshot generation can not collapse simulation FPS under heavy
+		// player load. Above the bundled logic_rate (16ms) so healthy servers are
+		// unaffected; engages once simulation alone drops below ~20 FPS. Tunable live.
+		sdWorld.sync_backpressure_ms = 50;
 		
 		//sdWorld.SERVER_EXPECTED_GSPEED = 1;
 		sdWorld.SERVER_AVERAGE_GSPEED_VALUES = []; // arr of { time, GSPEED, EXPECTED_GSPEED }, last second only

--- a/game/server/sdByteShifter.js
+++ b/game/server/sdByteShifter.js
@@ -42,7 +42,19 @@ class sdByteShifter
 		sdByteShifter.simulate_packet_delay = false;
 		
 		sdByteShifter.events_overflow_warning_next_time = 0;
-		
+
+		// Adaptive .sd_events drain (phase-12-events-04). Base drain per sync (10) is the
+		// historical floor and is what runs whenever there is no backlog, so the common
+		// case is unchanged. Under backlog the drain scales up to events_drain_max so the
+		// queue is cleared before it reaches events_overflow_cap (important now that sync
+		// cadence can slow under the adaptive sync budget). At the hard cap only the OLDEST
+		// cosmetic sound/effect events are shed; control events (position corrections etc.)
+		// are always kept, fixing the old "drop the whole queue" behavior. All tunable live.
+		sdByteShifter.events_drain_base = 10;
+		sdByteShifter.events_drain_max = 60;
+		sdByteShifter.events_overflow_cap = 100;
+		sdByteShifter.droppable_event_commands = new Set([ 'EFF', 'S', 'P' ]); // cosmetic-only: effect, sound, projectile-ragdoll-push
+
 		if ( sdByteShifter.simulate_packet_shuffle || sdByteShifter.simulate_packet_delay )
 		console.warn( 'sdByteShifter debug features are enabled' );
 		
@@ -175,7 +187,15 @@ class sdByteShifter
 			const SyncDataToPlayer = async ()=>
 			{
 				socket.sync_busy = true;
-				
+
+				// Per-socket snapshot-sync instrumentation (phase-12-sync-01). Zero cost
+				// unless globalThis.DEBUG_SYNC_PROFILE is set live on the inspector console.
+				// Captures the per-build shape (cost, entities listed, static reuse, full vs
+				// partial vs deletion entries, event backlog/drain/drop, payload size) so the
+				// dominant multiplier behind sdByteShifter.AddEntity can be confirmed per socket.
+				const SYNC_DBG = globalThis.DEBUG_SYNC_PROFILE;
+				const _dbg = SYNC_DBG ? { t0: Date.now(), add_calls: 0, listed: 0, static_reuse: 0, full_create: 0, partial_update: 0 } : null;
+
 				let allow_silent_event_skip = ( sdWorld.time > socket.last_sync + 1000 );
 				
 				socket.last_sync = sdWorld.time;
@@ -229,14 +249,18 @@ class sdByteShifter
 					
 					const AddEntity = ( ent )=>//, forced )=>
 					{
+						if ( SYNC_DBG ) _dbg.add_calls++;
+
 						if ( ent._flag < visited_ent_flag )
 						{
 							ent._near_player_until = near_player_until_time;
-							
+
 							if ( ( ent.IsVisible === default_IsVisible || ent.IsVisible( socket.character ) ) && !ent._is_being_removed )
 							{
 								ent._flag = listed_ent_flag;
-							
+
+								if ( SYNC_DBG ) _dbg.listed++;
+
 								//current_snapshot_entities.push( ent );
 								current_snapshot_entities_by_net_id.set( ent._net_id, ent );
 								
@@ -258,6 +282,8 @@ class sdByteShifter
 										
 										if ( snap )
 										{
+											if ( SYNC_DBG ) _dbg.static_reuse++;
+
 											//replacement_for_confirmed_snapshot.set( ent, snap );
 											replacement_for_confirmed_snapshot.set( ent._net_id, snap );
 
@@ -274,7 +300,8 @@ class sdByteShifter
 									
 								if ( confirmed_state === undefined )
 								{
-									
+									if ( SYNC_DBG ) _dbg.full_create++;
+
 									let class_info = ent._class_id; // Number or string if class has initial type/class/mission properties
 									
 									for ( let i = 0; i < sdEntity.properties_important_upon_creation.length; i++ )
@@ -416,13 +443,17 @@ class sdByteShifter
 									}
 									
 									if ( prop_ids !== null )
-									snapshot.push([
+									{
+										if ( SYNC_DBG ) _dbg.partial_update++;
 
-										ent._net_id, // 0
-										prop_ids, // 1 - list of indexes of properties to update OR class name if it is a first sync OR -1 if removal OR -2 if broken
-										...values_array_partial // 2... - values of properties
+										snapshot.push([
 
-									]);
+											ent._net_id, // 0
+											prop_ids, // 1 - list of indexes of properties to update OR class name if it is a first sync OR -1 if removal OR -2 if broken
+											...values_array_partial // 2... - values of properties
+
+										]);
+									}
 								}
 								
 								let snap_stored_copy = null;
@@ -808,26 +839,64 @@ class sdByteShifter
 
 					let sd_events = [];
 
-					if ( socket.sd_events.length > 100 )
+					let _events_backlog = socket.sd_events.length;
+
+					if ( SYNC_DBG ) { _dbg.events_backlog = _events_backlog; _dbg.events_dropped = 0; }
+
+					// Adaptive drain budget: with no backlog this stays at the historical base
+					// (10), so normal play is unchanged. Under backlog it scales up (drain ~half
+					// the queue, capped at events_drain_max) so the queue is cleared before it can
+					// reach the hard cap, instead of letting it grow until a mass drop.
+					let _drain_budget = sdByteShifter.events_drain_base;
+					if ( _events_backlog > _drain_budget )
+					_drain_budget = Math.min( sdByteShifter.events_drain_max, Math.ceil( _events_backlog / 2 ) );
+
+					// Hard cap: if production still outruns even the raised drain, shed load
+					// WITHOUT dropping gameplay-critical control events. Drop only the oldest
+					// cosmetic sound/effect events; keep every control event ('C' position
+					// corrections, 'UI_REPLY', 'ONLINE', ...) and the newest cosmetic events.
+					// This replaces the old behavior of clearing the entire queue (which could
+					// drop position corrections and cause rubber-banding).
+					if ( _events_backlog > sdByteShifter.events_overflow_cap )
 					{
-						if ( !allow_silent_event_skip )
-						if ( Date.now() > sdByteShifter.events_overflow_warning_next_time )
+						let target_drop = _events_backlog - sdByteShifter.events_overflow_cap;
+						let dropped = 0;
+						let kept = [];
+
+						for ( let e = 0; e < socket.sd_events.length; e++ )
 						{
-							// Once in 6 hours
-							sdByteShifter.events_overflow_warning_next_time = Date.now() + 1000 * 60 * 60 * 6;
-							trace( '.sd_events overflow: ' + JSON.stringify( socket.sd_events ) );
+							let ev = socket.sd_events[ e ];
+
+							if ( dropped < target_drop && ev && sdByteShifter.droppable_event_commands.has( ev[ 0 ] ) )
+							{
+								dropped++;
+								continue;
+							}
+
+							kept.push( ev );
 						}
-						
-						//console.log('socket.sd_events overflow (last sync was ' + ( sdWorld.time - previous_sync_time ) + 'ms ago): ', socket.sd_events );
 
-						//debugger;
+						socket.sd_events = kept;
 
-						socket.SDServiceMessage( 'Server: .sd_events overflow (' + socket.sd_events.length + ' events were skipped). Some sounds and effects might not spawn as result of that.' );
+						if ( dropped > 0 )
+						{
+							if ( SYNC_DBG ) _dbg.events_dropped = dropped;
 
-						socket.sd_events.length = 0;
+							if ( !allow_silent_event_skip )
+							if ( Date.now() > sdByteShifter.events_overflow_warning_next_time )
+							{
+								// Once in 6 hours
+								sdByteShifter.events_overflow_warning_next_time = Date.now() + 1000 * 60 * 60 * 6;
+								trace( '.sd_events overflow: dropped ' + dropped + ' cosmetic events (backlog was ' + _events_backlog + ', kept ' + socket.sd_events.length + ' incl. control events)' );
+							}
+
+							//console.log('socket.sd_events overflow (last sync was ' + ( sdWorld.time - previous_sync_time ) + 'ms ago): ', socket.sd_events );
+
+							socket.SDServiceMessage( 'Server: .sd_events overflow (' + dropped + ' sound/effect events were skipped). Some sounds and effects might not spawn as result of that.' );
+						}
 					}
 
-					while ( sd_events.length < 10 && socket.sd_events.length > 0 )
+					while ( sd_events.length < _drain_budget && socket.sd_events.length > 0 )
 					sd_events.push( socket.sd_events.shift() );
 				
 				
@@ -928,8 +997,39 @@ class sdByteShifter
 						if ( i < keys_arr.length )
 						socket.character.onSeesEntity( keys_arr[ i ] );
 					}
+
+					if ( SYNC_DBG )
+					{
+						_dbg.sync_ms = Date.now() - _dbg.t0;
+						_dbg.snapshot_entries = snapshot.length;
+						_dbg.snapshot_json_len = JSON.stringify( snapshot ).length;
+						_dbg.entities_by_net_id = current_snapshot_entities_by_net_id.size;
+						_dbg.events_drained = sd_events.length;
+
+						sdByteShifter._sync_dbg_agg = sdByteShifter._sync_dbg_agg || { builds: 0, sync_ms: 0, listed: 0, full_create: 0, partial_update: 0, static_reuse: 0, events_dropped: 0 };
+						let agg = sdByteShifter._sync_dbg_agg;
+						agg.builds++;
+						agg.sync_ms += _dbg.sync_ms;
+						agg.listed += _dbg.listed;
+						agg.full_create += _dbg.full_create;
+						agg.partial_update += _dbg.partial_update;
+						agg.static_reuse += _dbg.static_reuse;
+						agg.events_dropped += _dbg.events_dropped;
+
+						if ( Date.now() > ( socket._sync_dbg_next_log || 0 ) )
+						{
+							socket._sync_dbg_next_log = Date.now() + 5000;
+							console.log( '[SYNC_SOCK] ' + ( socket.character ? socket.character.title : '?' ) +
+								' sync_ms=' + _dbg.sync_ms + ' add_calls=' + _dbg.add_calls + ' listed=' + _dbg.listed +
+								' static_reuse=' + _dbg.static_reuse + ' full=' + _dbg.full_create + ' partial=' + _dbg.partial_update +
+								' snap_entries=' + _dbg.snapshot_entries + ' snap_json=' + _dbg.snapshot_json_len + 'B' +
+								' events backlog/drained/dropped=' + _dbg.events_backlog + '/' + _dbg.events_drained + '/' + _dbg.events_dropped +
+								' | AGG builds=' + agg.builds + ' avg_ms=' + ( agg.sync_ms / agg.builds ).toFixed(2) +
+								' avg_listed=' + ( agg.listed / agg.builds ).toFixed(0) + ' full=' + agg.full_create + ' partial=' + agg.partial_update + ' reuse=' + agg.static_reuse + ' ev_dropped=' + agg.events_dropped );
+						}
+					}
 				}
-				
+
 				socket.sync_busy = false;
 			};
 

--- a/index.js
+++ b/index.js
@@ -3306,25 +3306,53 @@ const ServerMainMethod = ()=>
 		for ( var i = 0; i < sockets.length; i++ )
 		{
 			var socket = sockets[ i ];
-			
+
 			if ( !socket.client.conn.transport.writable )
 			unwritable++;
-		
+
 			//sdWorld.max_update_rate;
 		}
+
+		// Debug-only snapshot scheduler accounting (phase-12-sync-02). Zero cost unless
+		// globalThis.DEBUG_SYNC_PROFILE is set on the inspector console. Attributes, per
+		// frame, why each socket did or did not get a SendSnapshot, so the per-frame sync
+		// budget can be tuned against sdWorld.last_frame_time with real numbers.
+		const SYNC_SCHED_DBG = globalThis.DEBUG_SYNC_PROFILE;
+		let _sched = null;
+		if ( SYNC_SCHED_DBG )
+		{
+			_sched = { eligible:0, writable:0, sent:0, skip_nth:0, skip_rate:0, skip_unwritable:0, skip_m_event:0, skip_busy:0 };
+			if ( !globalThis._sync_sched_next_log )
+			globalThis._sync_sched_next_log = 0;
+		}
 		
-		if ( unwritable === sockets.length )
+		// Snapshot scheduler backpressure. Historically only_do_nth_connection_per_frame
+		// only reacted to TCP unwritability (all sockets non-writable = network saturated),
+		// never to CPU/frame-time pressure. On a fast-network VPS that meant N writable
+		// clients each triggered a full per-client snapshot build every frame, and with
+		// 5-11 players the per-client snapshot path (sdByteShifter.AddEntity, ~28% of CPU
+		// in the 2026-06-18 world1003 remote profile) starved the simulation down to 4-5 FPS.
+		// sdWorld.last_frame_time is the PREVIOUS frame's simulation-only cost (set inside
+		// HandleWorldLogic, before this sync loop), so it is a clean overload signal: when
+		// it exceeds sdWorld.sync_backpressure_ms we spread client snapshot builds across
+		// more frames (ramp nth up toward sockets.length, ~1 client/frame at the cap),
+		// preserving simulation FPS instead of trying to freshly sync every client. When
+		// the server is healthy (sim under the threshold) nth decays back to 1 and behavior
+		// is identical to before, so normal/low-load multiplayer is unaffected.
+		const sync_cpu_overloaded = ( sdWorld.last_frame_time > sdWorld.sync_backpressure_ms );
+
+		if ( unwritable === sockets.length || sync_cpu_overloaded )
 		{
 			//if ( only_do_nth_connection_per_frame < sockets.length )
 			//console.log( sdWorld.time + ': only_do_nth_connection_per_frame increases to ' + (only_do_nth_connection_per_frame + 1) + ' (all sockets are non-writable)' );
-		
+
 			only_do_nth_connection_per_frame = Math.min( Math.max( 1, sockets.length ), only_do_nth_connection_per_frame + 1 );
 		}
 		else
 		{
 			//if ( only_do_nth_connection_per_frame > 1 )
 			//console.log( sdWorld.time + ': only_do_nth_connection_per_frame decreases to ' + (only_do_nth_connection_per_frame - 1) + ' (all sockets are writable)' );
-		
+
 			only_do_nth_connection_per_frame = Math.max( 1, only_do_nth_connection_per_frame - 1 );
 		}
 		
@@ -4029,6 +4057,26 @@ const ServerMainMethod = ()=>
 				*/
 			   
 			   
+				if ( SYNC_SCHED_DBG )
+				{
+					_sched.eligible++;
+					if ( socket.client.conn.transport.writable )
+					_sched.writable++;
+
+					if ( i % only_do_nth_connection_per_frame !== nth_connection_shift )
+					_sched.skip_nth++;
+					else if ( socket.sync_busy )
+					_sched.skip_busy++;
+					else if ( !( sdWorld.time > socket.last_sync + socket.max_update_rate ) )
+					_sched.skip_rate++;
+					else if ( !socket.client.conn.transport.writable )
+					_sched.skip_unwritable++;
+					else if ( !( sdWorld.time > socket.waiting_on_M_event_until ) )
+					_sched.skip_m_event++;
+					else
+					_sched.sent++;
+				}
+
 				if ( i % only_do_nth_connection_per_frame === nth_connection_shift )
 				if ( sdWorld.time > socket.last_sync + socket.max_update_rate && socket.client.conn.transport.writable && sdWorld.time > socket.waiting_on_M_event_until ) // Buffering prevention?
 				socket.byte_shifter.SendSnapshot();
@@ -4041,12 +4089,21 @@ const ServerMainMethod = ()=>
 			}
 		}
 		//sockets_array_locked = false;
+
+		if ( SYNC_SCHED_DBG && Date.now() > globalThis._sync_sched_next_log )
+		{
+			globalThis._sync_sched_next_log = Date.now() + 1000;
+			console.log( '[SYNC_SCHED] sim_frame_time=' + sdWorld.last_frame_time + 'ms nth=' + only_do_nth_connection_per_frame + '/' + sockets.length +
+				' eligible=' + _sched.eligible + ' writable=' + _sched.writable + ' sent=' + _sched.sent +
+				' | skip nth=' + _sched.skip_nth + ' rate=' + _sched.skip_rate + ' busy=' + _sched.skip_busy +
+				' unwritable=' + _sched.skip_unwritable + ' m_event=' + _sched.skip_m_event );
+		}
 	}
 	else
 	{
 		sdWorld.HandleWorldLogicNoPlayers();
 	}
-	
+
 	frame++;
 	
 	sdMemoryLeakSeeker.ThinkNow();


### PR DESCRIPTION
## Summary

Adds adaptive server snapshot backpressure and safer event queue draining for overloaded multiplayer sessions.

Changes included:

- Adds `sdWorld.sync_backpressure_ms` as a live-tunable frame-time threshold.
- Ramps `only_do_nth_connection_per_frame` up when simulation frame time exceeds that threshold, spreading client snapshot builds across frames under CPU pressure.
- Keeps healthy/low-load behavior unchanged by decaying the scheduler back to `1` when frame time is under the threshold.
- Replaces all-or-nothing `.sd_events` overflow clearing with adaptive draining and selective dropping of oldest cosmetic events only.
- Adds gated `DEBUG_SYNC_PROFILE` socket/scheduler logging for diagnosis.

## Why

A remote slot-1003 multiplayer profile showed per-client snapshot generation dominating CPU with several connected players. The old scheduler only backed off when every socket was transport-unwritable, so writable clients could all build snapshots in the same overloaded frame. The new path preserves simulation frame rate by reducing snapshot cadence under server CPU/frame pressure.

The event queue change prevents backlog from reaching the old hard-drop path, and when overflow still happens it preserves control events such as corrections instead of clearing the entire queue.

## Validation

- `node --check index.js`
- `node --check game/sdWorld.js`
- `node --check game/server/sdByteShifter.js`
- Deployed and profiled on VPS slot 1003; mechanism validated in live play, but this draft still needs a fuller 5-11 player stress run to confirm headline FPS improvement under the original remote load.

## Notes

Draft PR for case-by-case review. This is broader than the two lag-machine micro-optimizations because it contains the Phase 12 sync-budget and event-drain changes together.