### PR TITLE
fix(sdStorageTank): make large tanks immovable unless on a steering wheel

### DIFF
--- a/game/entities/sdStorageTank.js
+++ b/game/entities/sdStorageTank.js
@@ -103,7 +103,16 @@ class sdStorageTank extends sdEntity
 	}
 	IsAttachableToSteeringWheel()
 	{ return this.type === sdStorageTank.TYPE_LARGE; }
-	
+
+	IsPhysicallyMovable() // Large tanks are static world objects (onThink applies gravity + ApplyVelocityAndCollisions only for TYPE_PORTABLE) and should move only while driven by a steering wheel. Without this the inherited "true" makes the collision resolver treat them as pushable, so colliding entities transfer momentum into a body that never moves on its own - getting caught and then catapulted on release.
+	{
+		if ( this.type === sdStorageTank.TYPE_LARGE )
+		if ( this._steering_wheel_net_id === -1 ) // not attached to a steering wheel
+		return false;
+
+		return super.IsPhysicallyMovable();
+	}
+
 	IsLiquidTypeAllowed( type )
 	{
 		if ( type === -1 )


### PR DESCRIPTION
## Problem

Large liquid containers (`sdStorageTank` `TYPE_LARGE`) can **"catch" moving entities** — players, crates, hooked items — pinning them in place, then **catapult them at high speed** when they finally break free. Players reported this most often with large liquid containers.

## Root cause

`sdStorageTank` doesn't override `IsPhysicallyMovable()`, so it inherits `sdEntity`'s default, which returns `true` for any body that has `sx` and isn't held. But large tanks have **no self-physics** — `onThink` applies gravity and `ApplyVelocityAndCollisions` **only for `TYPE_PORTABLE`** — and the commented-out `is_static` getter shows large tanks were intended to be **static world objects**, moving only when driven by a steering wheel.

Because they're (incorrectly) judged movable, the collision resolver in `ApplyVelocityAndCollisions` treats a large tank as a pushable dynamic body: it transfers momentum into the tank (`best_is_dynamic` path) and does **not** clear the colliding entity's velocity into the blocked axis. The tank never realizes that momentum (no self-physics), so the mover stays pinned while gravity/jetpack keeps **accumulating velocity**, which releases as a catapult.

## Fix

Override `IsPhysicallyMovable()` to return `false` for `TYPE_LARGE` tanks that are **not attached to a steering wheel** (`_steering_wheel_net_id === -1`). Player collisions then take the static-wall path, which stops velocity correctly — no catch, no catapult.

- Tanks **attached to a steering wheel** keep the inherited behavior, so they still move while driven.
- **Portable** tanks are unaffected.

```js
IsPhysicallyMovable()
{
    if ( this.type === sdStorageTank.TYPE_LARGE )
    if ( this._steering_wheel_net_id === -1 ) // not attached to a steering wheel
    return false;

    return super.IsPhysicallyMovable();
}
```

## Testing

Verified live on a test server: large tanks report `IsPhysicallyMovable() === false` (portable stays `true`); the catch/catapult no longer reproduces (the player collides and stops like a wall); steering-wheel-attached tanks still move while driven.