### PR TITLE
Fix cables being cut and reconfigured through walls

### DIFF
--- a/game/entities/sdCable.js
+++ b/game/entities/sdCable.js
@@ -963,6 +963,34 @@ class sdCable extends sdEntity
 								Math.min( Math.max( this.y + this._hitbox_y1, yy ), this.y + this._hitbox_y2 ) );
 	}
 	
+	HasClearLineOfSightForManagement( executer_character ) // Used to stop cables from being cut or reconfigured through walls
+	{
+		// The server does not have the sagging cable shape ( the `_points` are
+		// built on client-side only ), so cable proximity is measured against the
+		// straight segment between the two endpoints. That segment can pass right
+		// through walls, which previously let players cut or reconfigure cables
+		// from the far side of a wall they could not actually reach. Require a
+		// clear line of sight ( no sdBlock walls ) from the player to the nearest
+		// point of that segment.
+		//
+		// This is a no-op for normal play: point-blank actions ( the common case )
+		// are closer than the line-of-sight sampling step and always pass, and a
+		// player can always reach a cable's own endpoints. Only operating on a
+		// cable through a wall is rejected.
+		if ( !this.p || !this.c )
+		return true; // Malformed cable, let the existing onThink cleanup handle it
+
+		let cx = executer_character.x + ( executer_character.hitbox_x1 + executer_character.hitbox_x2 ) / 2;
+		let cy = executer_character.y + ( executer_character.hitbox_y1 + executer_character.hitbox_y2 ) / 2;
+
+		sdWorld.distToSegment(
+			{ x: cx, y: cy },
+			{ x: this.p.x + this.d[ 0 ], y: this.p.y + this.d[ 1 ] },
+			{ x: this.c.x + this.d[ 2 ], y: this.c.y + this.d[ 3 ] } ); // Parks the nearest point in sdWorld.reusable_closest_point
+
+		return sdWorld.CheckLineOfSight( cx, cy, sdWorld.reusable_closest_point.x, sdWorld.reusable_closest_point.y, null, null, sdBlock.as_class_list );
+	}
+
 	DrawBG( ctx, attached )
 	//Draw( ctx, attached )
 	{
@@ -1131,6 +1159,18 @@ class sdCable extends sdEntity
 						 ( executer_character._inventory[ sdGun.classes[ sdGun.CLASS_CABLE_TOOL ].slot ] && 
 						   executer_character._inventory[ sdGun.classes[ sdGun.CLASS_CABLE_TOOL ].slot ].class === sdGun.CLASS_CABLE_TOOL ) )
 					{
+						// Cables can not be cut or reconfigured through a wall. Wireless
+						// links ( managed at range near nodes ) and cables attached to the
+						// player themselves are exempt.
+						if ( this.t !== sdCable.TYPE_WIRELESS )
+						if ( this.p !== executer_character && this.c !== executer_character )
+						if ( !this.HasClearLineOfSightForManagement( executer_character ) )
+						{
+							if ( executer_socket )
+							executer_socket.SDServiceMessage( 'Cable is obstructed by a wall' );
+							return;
+						}
+
 						if ( command_name === 'CUT_CABLE' )
 						{
 							if ( this._shielded && !this._shielded._is_being_removed && this._shielded.protect_cables )


### PR DESCRIPTION
## Problem

`sdCable.ExecuteContextCommand` authorizes `CUT_CABLE` and `SET_TYPE` using **only distance** to the cable:

- executer is alive + has the cable tool (or is an `sdPlayerDrone`)
- `sdArea.CheckPointDamageAllowed( player )` (or the cable is attached to the player)
- `GetAccurateDistance( player_center ) < 32`

There is no line-of-sight / wall check. On the **server** a cable has no draped shape — the sagging `_points` are built client-side only — so `GetAccurateDistance` measures distance to the **straight segment between the two endpoints**, and that segment can pass straight through walls. A player standing on the far side of a wall, within 32px of that invisible straight line, can therefore **cut or reconfigure cables they cannot actually reach** (the reported "cutting cables through walls"). The same gap applies to changing a cable's transfer type.

## Fix

Add a reachability check, `HasClearLineOfSightForManagement(executer_character)`, that finds the nearest point on the cable's segment (`sdWorld.distToSegment` → `sdWorld.reusable_closest_point`) and requires a clear `sdWorld.CheckLineOfSight(... sdBlock.as_class_list)` from the player to it. It gates **both** `CUT_CABLE` and `SET_TYPE`. Wireless links (managed at range near nodes) and cables attached to the player themselves are exempt.

## No difference to normal players

This is a no-op for legitimate play, by construction:

- `CheckLineOfSight` samples every 8px and returns clear for sub-step rays, so **point-blank actions — the normal case — always pass**, walls or not.
- A player can always reach a cable's own **endpoints**, so near-endpoint cuts are unaffected.
- **Wireless** links and **own** cables are exempt.
- Only operating on a cable with a wall *between the player and it* — the exploit — is rejected (with a `Cable is obstructed by a wall` service message).

Because the subclass `ExecuteContextCommand` runs server-side only (the client menu just emits `ENTITY_CONTEXT_ACTION`), there is no change to client UX.

## Testing

- `node --check` passes.
- An offline harness loads the real `HasClearLineOfSightForManagement` from source and drives it with a faithful re-implementation of the engine's 8px LOS sampler: **8/8** — through-wall blocked; near-endpoint / point-blank / clear-LOS / malformed-cable / wireless / own-cable all allowed.

## Diff

Additive only — one new method plus a guard block in the existing cable-tool branch (40 insertions, 0 deletions) in `game/entities/sdCable.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)