### PR TITLE
Fix base-raid exploit: phasing through walls by exiting a sealed Life Box / Capsule pod

### DIFF
--- a/game/entities/sdCapsulePod.js
+++ b/game/entities/sdCapsulePod.js
@@ -10,6 +10,7 @@ import sdWorld from '../sdWorld.js';
 import sdEntity from './sdEntity.js';
 import sdBaseShieldingUnit from './sdBaseShieldingUnit.js';
 import sdGun from './sdGun.js';
+import sdCom from './sdCom.js';
 import sdTimer from './sdTimer.js';
 
 import sdSound from '../sdSound.js';
@@ -342,14 +343,91 @@ class sdCapsulePod extends sdEntity
 	}
 	onAfterDriverExcluded( slot, character )
 	{
+		// Note: exit position is decided in ExcludeDriver (LOS-guarded against the
+		// "seal the pod to phase through walls" raid exploit). Do NOT override
+		// character.x/character.y here or that protection is defeated.
 		this.occupied = 0;
 		this._update_version++;
-		
+
 		if ( this._sleep_timer )
 		{
 			this._sleep_timer.Cancel();
 			this._sleep_timer = null;
 		}
+	}
+	ExcludeDriver( c, force=false ) // Overridden to guarantee the player can never be ejected through a wall (anti-raid). Building blocks over an occupied pod used to squeeze the exiting player into a sealed base.
+	{
+		if ( !force )
+		if ( !sdWorld.is_server )
+		return;
+
+		for ( var i = 0; i < this.GetDriverSlotsCount(); i++ )
+		{
+			if ( this[ 'driver' + i ] === c )
+			{
+				let exit_x = this.x;
+				let exit_y = this.y;
+
+				if ( !force )
+				{
+					// Candidate exit spots around the pod, cardinal directions.
+					let cands = [
+						[ this.x,                                  this.y + this._hitbox_y1 - c._hitbox_y2 ], // above
+						[ this.x + this._hitbox_x1 - c._hitbox_x2, this.y ],                                  // left
+						[ this.x + this._hitbox_x2 - c._hitbox_x1, this.y ],                                  // right
+						[ this.x,                                  this.y + this._hitbox_y2 - c._hitbox_y1 ]   // below
+					];
+
+					let found = false;
+
+					for ( var ci = 0; ci < cands.length; ci++ )
+					{
+						let cx = cands[ ci ][ 0 ];
+						let cy = cands[ ci ][ 1 ];
+
+						// Spot must be free AND reachable in a straight line from the pod
+						// center without crossing a wall, so the player can never end up
+						// on the far (interior) side of a base wall.
+						if ( c.CanMoveWithoutOverlap( cx, cy, 0 ) )
+						if ( sdWorld.CheckLineOfSight( this.x, this.y, cx, cy, this, sdCom.com_visibility_ignored_classes, null ) )
+						{
+							exit_x = cx;
+							exit_y = cy;
+							found = true;
+							break;
+						}
+					}
+
+					if ( !found )
+					{
+						// Pod is sealed - refuse to eject rather than phase the player through walls.
+						if ( c._socket )
+						c._socket.SDServiceMessage( 'The Capsule pod is sealed - clear the blocks around it before exiting' );
+
+						return;
+					}
+				}
+
+				this[ 'driver' + i ] = null;
+				c.driver_of = null;
+				c.SetCameraZoom( sdWorld.default_zoom );
+
+				c.x = exit_x;
+				c.y = exit_y;
+
+				c.PhysWakeUp();
+
+				if ( c._socket )
+				c._socket.SDServiceMessage( 'Leaving vehicle' );
+
+				this.onAfterDriverExcluded( i, c );
+
+				return;
+			}
+		}
+
+		if ( c._socket )
+		c._socket.SDServiceMessage( 'Error: Attempted leaving vehicle in which character is not located.' );
 	}
 	IsVehicle()
 	{

--- a/game/entities/sdLifeBox.js
+++ b/game/entities/sdLifeBox.js
@@ -133,11 +133,85 @@ class sdLifeBox extends sdEntity
 	}
 	onAfterDriverExcluded( slot, character )
 	{
-		character.x = this.x;
-		character.y = this.y;
-		
+		// Note: exit position is decided in ExcludeDriver (LOS-guarded against the
+		// "seal the box to phase through walls" raid exploit). Do NOT override
+		// character.x/character.y here or that protection is defeated.
 		this.occupied = 0;
 		//this._update_version++;
+	}
+	ExcludeDriver( c, force=false ) // Overridden to guarantee the player can never be ejected through a wall (anti-raid). Build blocks over an occupied Life Box used to squeeze the exiting player into a sealed base.
+	{
+		if ( !force )
+		if ( !sdWorld.is_server )
+		return;
+
+		for ( var i = 0; i < this.GetDriverSlotsCount(); i++ )
+		{
+			if ( this[ 'driver' + i ] === c )
+			{
+				let exit_x = this.x;
+				let exit_y = this.y;
+
+				if ( !force )
+				{
+					// Candidate exit spots around the box, cardinal directions.
+					let cands = [
+						[ this.x,                                  this.y + this._hitbox_y1 - c._hitbox_y2 ], // above
+						[ this.x + this._hitbox_x1 - c._hitbox_x2, this.y ],                                  // left
+						[ this.x + this._hitbox_x2 - c._hitbox_x1, this.y ],                                  // right
+						[ this.x,                                  this.y + this._hitbox_y2 - c._hitbox_y1 ]   // below
+					];
+
+					let found = false;
+
+					for ( var ci = 0; ci < cands.length; ci++ )
+					{
+						let cx = cands[ ci ][ 0 ];
+						let cy = cands[ ci ][ 1 ];
+
+						// Spot must be free AND reachable in a straight line from the box
+						// center without crossing a wall, so the player can never end up
+						// on the far (interior) side of a base wall.
+						if ( c.CanMoveWithoutOverlap( cx, cy, 0 ) )
+						if ( sdWorld.CheckLineOfSight( this.x, this.y, cx, cy, this, sdCom.com_visibility_ignored_classes, null ) )
+						{
+							exit_x = cx;
+							exit_y = cy;
+							found = true;
+							break;
+						}
+					}
+
+					if ( !found )
+					{
+						// Box is sealed - refuse to eject rather than phase the player through walls.
+						if ( c._socket )
+						c._socket.SDServiceMessage( 'The Life Box is sealed - clear the blocks around it before exiting' );
+
+						return;
+					}
+				}
+
+				this[ 'driver' + i ] = null;
+				c.driver_of = null;
+				c.SetCameraZoom( sdWorld.default_zoom );
+
+				c.x = exit_x;
+				c.y = exit_y;
+
+				c.PhysWakeUp();
+
+				if ( c._socket )
+				c._socket.SDServiceMessage( 'Leaving vehicle' );
+
+				this.onAfterDriverExcluded( i, c );
+
+				return;
+			}
+		}
+
+		if ( c._socket )
+		c._socket.SDServiceMessage( 'Error: Attempted leaving vehicle in which character is not located.' );
 	}
 	GetDriverZoom()
 	{


### PR DESCRIPTION
## The exploit

Players can glitch inside a sealed enemy base:

1. Place a **Life Box** (`sdLifeBox`) or **Capsule pod** (`sdCapsulePod`) flush against the base's outer wall.
2. Get inside it.
3. Have a friend / second tab build blocks over the occupied vehicle.
4. Exit — the character ends up **inside the base's walls**, free to start building bombs / RTPs.

## Root cause

On exit, the vehicle decided where to drop the character using **only an overlap test** (`CanMoveWithoutOverlap`) and never checked whether reaching that spot **crossed a wall**. When the vehicle is sealed, the only overlap-free cell the un-stuck physics can resolve to is on the *interior* side of the adjacent wall, so the player is squeezed through it.

`sdLifeBox` made it worse: `onAfterDriverExcluded` forced the character to the vehicle's exact centre, discarding even the base class's existing placement search (`sdEntity.ExcludeDriver`, the one commented `// To prevent the teleport exploit`).

## Fix

Both vehicles now override `ExcludeDriver` so a cardinal exit spot is accepted **only when it is both**:

- overlap-free (`CanMoveWithoutOverlap`), **and**
- reachable in a straight line from the vehicle centre without crossing a wall (`sdWorld.CheckLineOfSight`).

This makes it impossible to relocate a player to the far side of a wall. If every candidate is blocked (vehicle fully sealed), the exit is **refused** with a service message instead of phasing the player through geometry. Forced ejection (vehicle destroyed) still falls back to the centre, unchanged.

`com_visibility_ignored_classes` is used for the LOS check so doors / characters / turrets don't count as walls — legitimate exits are unaffected.

## Notes

- Server-authoritative path only (`!sdWorld.is_server` early-returns for non-forced exits), so no client desync.
- `sdLifeBox.onAfterDriverExcluded` no longer overrides the exit position (now matches the correct `sdCapsulePod` idiom).
- The same un-LOS-guarded exit pattern exists on other rideable vehicles (`sdHover`, `sdQuadro`, etc.), but those are far harder to seal against a base and are left out of this PR to keep it focused. Happy to follow up if you'd like them hardened too.

Files changed: `game/entities/sdLifeBox.js`, `game/entities/sdCapsulePod.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)