### PR TITLE
perf(backup): optional dedicated worker for snapshot deflate+write (decouple from main-loop load)

### DIFF
--- a/game/server/sdServerConfig.js
+++ b/game/server/sdServerConfig.js
@@ -1865,6 +1865,43 @@ class sdServerConfigFull extends sdServerConfigShort
 				callback( err );
 			}
 
+			// --- backup-tail-decouple: hand deflate + file write + rename to the dedicated snapshot
+			// worker so the snapshot persists on time even when the main event loop is saturated by
+			// per-client sync (production 5-11 players). Gated + multiplayer-only; ANY failure
+			// transparently falls back to the original inline zlib.deflate path below. Output is
+			// byte-identical (worker uses zlib.deflateSync with the same defaults).
+			if ( globalThis.SNAPSHOT_DEFLATE_MODE === 'worker' && !sdWorld.is_singleplayer && typeof globalThis.SnapshotDeflateToFile === 'function' )
+			{
+				let snapshot_path_temp = snapshot_path.split('.');
+				snapshot_path_temp[ snapshot_path_temp.length - 1 ] = 'TEMP.' + snapshot_path_temp[ snapshot_path_temp.length - 1 ];
+				snapshot_path_temp = snapshot_path_temp.join('.');
+
+				globalThis.SnapshotDeflateToFile( json, snapshot_path_temp, snapshot_path, true )
+				.then( ( info )=>
+				{
+					deflate_done_time = json_made_time + info.deflate_ms; // honest compute time, not main-loop delivery lag
+					save_done_time = deflate_done_time + info.write_ms;
+					console.log('Snapshot compression+write complete via worker (' + info.bytes + ' bytes)...');
+					console.log('TEMP file renamed.');
+					Report( false );
+					snapshot_save_busy = false;
+				})
+				.catch( ( e )=>
+				{
+					console.warn( 'Snapshot worker unavailable (' + ( ( e && e.message ) || e ) + '); falling back to inline compression.' );
+					DoInlineDeflate();
+				});
+
+				if ( sdWorld.server_config.save_raw_version_of_snapshot )
+				fs.writeFile( snapshot_path + '.raw.v', json, ( err )=>{} );
+
+				return;
+			}
+
+			DoInlineDeflate();
+
+			function DoInlineDeflate()
+			{
 			// zlib.deflate(buffer
 			zlib.deflate( json, ( err, buffer )=>{
 
@@ -1942,6 +1979,7 @@ class sdServerConfigFull extends sdServerConfigShort
 				}
 
 			});
+			}
 		}
 
 		sdWorld.SaveSnapshot = SaveSnapshot;

--- a/game/server/sdSnapshotSaveWorker.js
+++ b/game/server/sdSnapshotSaveWorker.js
@@ -1,0 +1,45 @@
+/*
+	Dedicated snapshot-save worker (phase: backup-tail-decouple).
+
+	The world backup's compression + disk write are handed here so they complete on time even
+	when the main event loop is saturated by per-client snapshot sync (production 5-11 players).
+	Measured mechanism: with the old inline `zlib.deflate(json, cb)` the compression finishes
+	off-thread on schedule, but its completion callback (and therefore the fs.writeFile) is
+	delivered on the busy main loop, so the snapshot lands on disk seconds late and the timings
+	report inflates 3-6x. Doing deflate + writeFile + rename inside this worker removes that
+	dependency: the file is persisted as soon as compression finishes, regardless of main-thread load.
+
+	Output is byte-identical to the inline path: zlib.deflateSync uses the same defaults
+	(Z_DEFAULT_COMPRESSION=6, memLevel 8, default strategy) as zlib.deflate, and the file is
+	always re-read with zlib.inflateSync at load time.
+
+	Protocol (parentPort):
+	  in : { id, json, temp_path, final_path, do_rename }
+	  out: { id, ok:true, bytes, deflate_ms, write_ms } | { id, ok:false, error }
+*/
+import { parentPort } from 'worker_threads';
+import zlib from 'zlib';
+import fs from 'fs';
+
+parentPort.on( 'message', ( job )=>
+{
+	let t0 = Date.now();
+	try
+	{
+		let buffer = zlib.deflateSync( job.json );
+		let t1 = Date.now();
+
+		fs.writeFileSync( job.temp_path, buffer );
+
+		if ( job.do_rename && job.temp_path !== job.final_path )
+		fs.renameSync( job.temp_path, job.final_path );
+
+		let t2 = Date.now();
+
+		parentPort.postMessage({ id: job.id, ok: true, bytes: buffer.length, deflate_ms: t1 - t0, write_ms: t2 - t1 });
+	}
+	catch ( e )
+	{
+		parentPort.postMessage({ id: job.id, ok: false, error: String( ( e && e.stack ) || e ) });
+	}
+} );

--- a/index.js
+++ b/index.js
@@ -3268,6 +3268,75 @@ globalThis.ExecuteParallelPromise = ( command )=>
 	return p;
 };
 
+// --- Dedicated snapshot-save worker (backup-tail-decouple) ------------------------------------
+// A single dedicated worker that runs the world-backup deflate + file write + rename off the main
+// thread, so the snapshot persists on time even when the main event loop is saturated by per-client
+// sync. Kept SEPARATE from the worker_services pool (which handles per-client LZW and would be
+// contended under exactly the load we care about) and, unlike ExecuteParallel, it NEVER falls back
+// to a synchronous main-thread deflate. If the worker is unavailable the promise rejects and the
+// caller (SaveSnapshot) transparently uses the original inline zlib.deflate path. Gated: only ever
+// invoked when SaveSnapshot runs with globalThis.SNAPSHOT_DEFLATE_MODE === 'worker'.
+let _snapshot_worker = null;
+let _snapshot_worker_seq = 0;
+let _snapshot_worker_pending = new Map(); // id -> { resolve, reject }
+
+const EnsureSnapshotWorker = ()=>
+{
+	if ( _snapshot_worker )
+	return _snapshot_worker;
+
+	let w = new Worker( __dirname + '/game/server/sdSnapshotSaveWorker.js' );
+
+	w.on( 'message', ( msg )=>
+	{
+		let waiter = _snapshot_worker_pending.get( msg.id );
+		if ( !waiter )
+		return;
+		_snapshot_worker_pending.delete( msg.id );
+		if ( msg.ok )
+		waiter.resolve( msg );
+		else
+		waiter.reject( new Error( msg.error || 'snapshot worker error' ) );
+	} );
+
+	let fail_all = ( err )=>
+	{
+		if ( _snapshot_worker === w )
+		_snapshot_worker = null;
+		for ( let waiter of _snapshot_worker_pending.values() )
+		waiter.reject( err instanceof Error ? err : new Error( String( err ) ) );
+		_snapshot_worker_pending.clear();
+	};
+	w.on( 'error', fail_all );
+	w.on( 'exit', ( code )=>{ if ( code !== 0 ) fail_all( new Error( 'snapshot worker exited with code ' + code ) ); } );
+
+	_snapshot_worker = w;
+	return w;
+};
+
+// Returns Promise<{ bytes, deflate_ms, write_ms }>. Rejects if the worker cannot be used.
+globalThis.SnapshotDeflateToFile = ( json, temp_path, final_path, do_rename )=>
+{
+	return new Promise( ( resolve, reject )=>
+	{
+		let w;
+		try { w = EnsureSnapshotWorker(); }
+		catch ( e ) { reject( e ); return; }
+
+		let id = ++_snapshot_worker_seq;
+		_snapshot_worker_pending.set( id, { resolve, reject } );
+		try
+		{
+			w.postMessage({ id, json, temp_path, final_path, do_rename: !!do_rename });
+		}
+		catch ( e )
+		{
+			_snapshot_worker_pending.delete( id );
+			reject( e );
+		}
+	});
+};
+
 let only_do_nth_connection_per_frame = 1;
 let nth_connection_shift = 0;
 


### PR DESCRIPTION
## Problem

On busy servers players report the world **backup "time" tripling** (or worse). Profiling the `Backup timings report (ms)` phases `[build, stringify, deflate, write]` shows the synchronous phases (build + `JSON.stringify`) are flat — the blow-up is entirely in the async **deflate** phase.

Root cause: `zlib.deflate(json, cb)` compresses off-thread on schedule, but its completion callback — which stamps the timing **and** triggers `fs.writeFile` — is delivered on the **main event loop**. When that loop is saturated by per-client snapshot sync (many players), the callback is delayed by seconds, so the snapshot lands on disk late and the report inflates 3–6×. It's a delivery/persistence-timing problem, not compression cost, so the server isn't truly frozen for that time — but the snapshot is persisted late and the durability window grows.

**Controlled repro** (250k-entity world), deflate phase:
| condition | deflate |
|---|---|
| baseline (idle) | ~3.0 s |
| libuv threadpool saturated | ~3.3 s (flat) |
| **main event loop saturated** | **~19 s** |

## Fix

An **opt-in** dedicated worker (`game/server/sdSnapshotSaveWorker.js`) that runs deflate + write(`TEMP`) + rename(final) entirely off the main thread, so the snapshot persists on time regardless of main-thread load.

- Exposed as `globalThis.SnapshotDeflateToFile`; `SaveSnapshot` uses it **only** when `globalThis.SNAPSHOT_DEFLATE_MODE === 'worker'`, otherwise the original inline path runs unchanged.
- The worker is **separate** from the LZW `worker_services` pool, so it's never contended by per-client sync, and — unlike `ExecuteParallel` — it **never** falls back to a synchronous main-thread deflate. On any failure it rejects and `SaveSnapshot` transparently uses the inline path.
- Output is **byte-identical**: the worker uses `zlib.deflateSync` with the same defaults, and files are re-read via `zlib.inflateSync` at load.

Purely additive (152 insertions, 0 deletions) and **inert by default** — no behavior change unless the flag is set.

## Validation

- **Offline 473/473**: `deflateSync` (worker) == `deflate` (inline) byte-for-byte; live worker write+rename; persisted file `inflateSync`-round-trips to the exact JSON.
- **Live A/B** under main-loop saturation: inline deflate **18.7 s** vs worker **2.2 s** (spike eliminated); worker output byte-identical; with the flag off, timings unchanged.

## How to enable

Set at runtime (no restart): `globalThis.SNAPSHOT_DEFLATE_MODE = 'worker'`. Leave unset for the current inline behavior.