### PR TITLE
Cap unverified ad-reward crystal claims (server can't confirm the ad played)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
+# Fork-local ignore policy
+# Ignore all newly generated or local-only files in this devtests fork.
+# Existing tracked upstream files remain tracked by Git.
+*
+!*/
+!.gitignore
+
+# AI and agent workspace content
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+.claude/
+.clavix/
+.codex/
+.cursor/
+.gemini/
+.windsurf/
+.aider*
+
 # Logs
 logs
 *.log

--- a/game/entities/sdLongRangeTeleport.js
+++ b/game/entities/sdLongRangeTeleport.js
@@ -61,8 +61,37 @@ class sdLongRangeTeleport extends sdEntity
 		sdLongRangeTeleport.ignored_class_pointers.add( 'sdSensorArea' );
 		sdLongRangeTeleport.ignored_class_pointers.add( 'sdBG' );
 		//sdLongRangeTeleport.ignored_class_pointers.add( 'sdStatusEffect' );
-		
+
+		sdLongRangeTeleport.ad_reward_claims_by_hash = new Map(); // my_hash -> { count, window_start }. Server-side daily cap for CLAIM_REWARD_AD, since ad-watch completion can't be verified server-side (see AD_REWARD_START / GiveRewards)
+
 		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
+	}
+	static CanClaimAdReward( my_hash ) // Independent of the 5-minute AD_REWARD_START cooldown - bounds worst case if a client skips watching the ad entirely
+	{
+		if ( !my_hash ) // No persistent identity to rate-limit against - deny rather than allow unbounded free claims
+		return false;
+
+		let cap = sdWorld.server_config.ad_reward_daily_cap;
+
+		if ( cap === -1 )
+		return true;
+
+		let entry = sdLongRangeTeleport.ad_reward_claims_by_hash.get( my_hash );
+
+		if ( !entry || sdWorld.time > entry.window_start + 1000 * 60 * 60 * 24 )
+		{
+			entry = { count: 0, window_start: sdWorld.time };
+			sdLongRangeTeleport.ad_reward_claims_by_hash.set( my_hash, entry );
+		}
+
+		return entry.count < cap;
+	}
+	static RegisterAdRewardClaim( my_hash )
+	{
+		let entry = sdLongRangeTeleport.ad_reward_claims_by_hash.get( my_hash );
+
+		if ( entry ) // CanClaimAdReward always runs first and creates/refreshes the window, so this should never be missing
+		entry.count++;
 	}
 	get hitbox_x1() { return -48; }
 	get hitbox_x2() { return 48; }
@@ -890,7 +919,8 @@ class sdLongRangeTeleport extends sdEntity
 			if ( socket && socket.ad_reward_pending )
 			{
 				socket.ad_reward_pending = false;
-				
+				sdLongRangeTeleport.RegisterAdRewardClaim( socket.my_hash );
+
 				let r = [ 640, 1280, 2560, 5120 ][ ~~( Math.pow( Math.random(), 2 ) * 4 ) ];
 				let crystal = new sdCrystal({ x:this.x, y:this.y - 24, matter_max: r, type:sdCrystal.TYPE_CRYSTAL_ARTIFICIAL });
 				sdEntity.entities.push( crystal );
@@ -1394,10 +1424,15 @@ class sdLongRangeTeleport extends sdEntity
 							{
 								if ( sdWorld.time > executer_socket.next_ad_time )
 								{
-									executer_socket.ResetAdCooldown();
-									executer_socket.CommandFromEntityClass( sdLongRangeTeleport, 'AD_START_ALLOWED', [ this._net_id ] );
+									if ( sdLongRangeTeleport.CanClaimAdReward( executer_socket.my_hash ) )
+									{
+										executer_socket.ResetAdCooldown();
+										executer_socket.CommandFromEntityClass( sdLongRangeTeleport, 'AD_START_ALLOWED', [ this._net_id ] );
 
-									executer_socket.ad_reward_pending = true;
+										executer_socket.ad_reward_pending = true;
+									}
+									else
+									executer_socket.SDServiceMessage( 'Daily limit for ad rewards reached. Try again tomorrow.' );
 								}
 								else
 								executer_socket.SDServiceMessage( 'Not so soon. Try in 5 minutes' );

--- a/game/server/sdServerConfig.js
+++ b/game/server/sdServerConfig.js
@@ -63,7 +63,8 @@ class sdServerConfigFull extends sdServerConfigShort
 	static port = undefined; // Will be automatically set to 3000 + world_slot, but you can specify specific port instead
 	static database_server = null; // Example: 'https://www.gevanni.com:3000'; // Remote database_server must allow current server's IP in list above. Set as null if this server should have its' own database
 	static adsense_client = 'ca-pub-7381466440820611'; // To learn how to install your ads go there https://developers.google.com/ad-placement/docs/beta . This adsense_client comes from HTML code for AdSense. You'll additionally be requested to allow ads on your domain via ads.txt file. Your server will not show ads designed for other servers and vice versa
-	
+	static ad_reward_daily_cap = 8; // Max amount of times (per 24h, per account) a player can claim the free "watch an ad" Long-range teleport crystal reward. The server has no way to verify an ad SDK actually played an ad client-side, so this cap bounds the impact of a client that requests the reward without ever showing one. Set to -1 to disable the cap (not recommended)
+
 	static save_raw_version_of_snapshot = false; // One that can be easily viewed in Notepad-like applications. It is never used within server logic. "true" can slow-down snapshot generation.
 	
 	static store_game_files_in_ram = false; // Will make server never use hard drive without need until next reboot, except for cases when backup is being made (more RAM usage, can be suitable for VPS servers that have strange Disk I/O issues)


### PR DESCRIPTION
`AD_REWARD_START` sets `socket.ad_reward_pending = true` as soon as it's requested, before the client's ad SDK ever confirms playback. `CLAIM_REWARD_AD` only checks that flag and pays out a free crystal (640-5120 matter) - it doesn't cost `_task_reward_counter` like every other LRT reward type. A client can skip the ad entirely and fire `AD_REWARD_START` -> `CLAIM_REWARD_AD` back to back, limited only by the 5-minute cooldown, for unbounded free matter.

This adds a server-side daily cap (default 8/day, configurable via `ad_reward_daily_cap`, keyed per-account so reconnecting doesn't reset it) as a backstop, since there's no way to cryptographically verify ad completion from this client-side ad SDK. Doesn't change legitimate ad-reward behavior for normal play.

## Test plan
- [x] Offline harness proving the unpatched code grants the reward with zero ad-watch confirmation, gated only by the 5-minute cooldown
- [x] Offline harness proving the patched cap: blocks the 9th same-day claim, persists across reconnects (keyed by account hash, not socket), denies rather than allows unlimited claims when no hash is present, and rolls over after 24h
- [x] `node --check` on both changed files