### PR TITLE
Fix world-event scheduler firing conditional events far above intended rate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
+# Fork-local ignore policy
+# Ignore all newly generated or local-only files in this devtests fork.
+# Existing tracked upstream files remain tracked by Git.
+*
+!*/
+!.gitignore
+
+# AI and agent workspace content
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+.claude/
+.clavix/
+.codex/
+.cursor/
+.gemini/
+.windsurf/
+.aider*
+
 # Logs
 logs
 *.log

--- a/game/entities/sdWeather.js
+++ b/game/entities/sdWeather.js
@@ -1558,8 +1558,8 @@ class sdWeather extends sdEntity
 				this._invasion_spawns_con = 25; // At least 25 Event executions must happen otherwise invasion will not end
 				this._invasion_event = this._potential_invasion_events[ Math.floor( Math.random() * this._potential_invasion_events.length ) ];; // Random event which can fit the invasion is selected.
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // if the event is already active, quickly initiate something else
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 						
 		}
 
@@ -2090,8 +2090,8 @@ class sdWeather extends sdEntity
 				}*/
 
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_SARRONIANS ) // Sarronian & Zektaron factions spawn. Spawns humanoids and drones.
 		{
@@ -2197,8 +2197,8 @@ class sdWeather extends sdEntity
 				});
 				
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_COUNCIL_BOMB ) // Spawn a Council Bomb anywhere on the map outside player views which detonates in 10 minutes
 		{
@@ -2298,8 +2298,8 @@ class sdWeather extends sdEntity
 				}*/
 
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		
 		if ( r === sdWeather.EVENT_OVERLORD )
@@ -2410,8 +2410,8 @@ class sdWeather extends sdEntity
 				}*/
 
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_VELOX ) // Velox faction spawn. TO DO: Support healing drones
 		{
@@ -2495,8 +2495,8 @@ class sdWeather extends sdEntity
 					group_radius: group_rad
 				});
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_CRYSTAL_BLOCKS ) // Put crystal shards in a 30 blocks
 		{
@@ -2833,8 +2833,8 @@ class sdWeather extends sdEntity
 				}
 				
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_SETR_DESTROYER ) // Setr Destroyer, basically alternate "flying mech"
 		{
@@ -3271,8 +3271,8 @@ class sdWeather extends sdEntity
 				if ( portal_machine.length > 0 ) // Spawned the machine?
 				sdCouncilMachine.ents_left = Math.min( 6, Math.max( 2, sdWorld.GetPlayingPlayersCount() ) ); // 2+1 = 3 machines on single player
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_SWORD_BOT ) // Falkonian sword bot, only one on map at the time
 		{
@@ -3561,8 +3561,8 @@ class sdWeather extends sdEntity
 					} while ( tr > 0 );
 				}*/
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_GUANAKO )
 		{
@@ -3869,8 +3869,8 @@ class sdWeather extends sdEntity
 					ais++;
 				}
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_ZEKTARON_DREADNOUGHT ) // Zektaron Dreadnought, main boss of the Zektarons
 		{
@@ -3891,8 +3891,8 @@ class sdWeather extends sdEntity
 				aerial_radius: 800
 				
 			});
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_KIVORTEC_WEAPONS_POD ) // KIVORTEC Weapons Pod. Has to be hacked before being opened and giving Star Defenders random KVT weaponry.
 		{
@@ -3925,8 +3925,8 @@ class sdWeather extends sdEntity
 				aerial_radius: 128
 				
 			});
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_COUNCIL_INCINERATOR ) // Council's Incinerator, mini boss from Council faction
 		{
@@ -3948,8 +3948,8 @@ class sdWeather extends sdEntity
 				group_radius: group_rad
 				
 			});
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_STEALER ) // Spawn a Stealer which steals unattended crystals.
 		{
@@ -3977,8 +3977,8 @@ class sdWeather extends sdEntity
 				aerial_radius: 128
 				
 			});
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_PROTECT_SDBG_DRONE ) // Mothership is trying to see if old drone stockpile is effective on planet ( players need to protect the drone for 5 minutes )
 		{
@@ -4051,8 +4051,8 @@ class sdWeather extends sdEntity
 				});
 
 			}
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_SOLAR_DISTRIBUTOR ) // Solar matter distributor is placed by SD's and needs to be activated
 		{
@@ -4112,8 +4112,8 @@ class sdWeather extends sdEntity
 				min_air_height: -400 // Minimum free space above entity placement location
 				
 			});
-			else
-			this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
+			//else
+			//this._time_until_event = Math.random() * 30 * 60 * 0; // Quickly switch to another event
 		}
 		if ( r === sdWeather.EVENT_CUBE_BOSS )
 		{


### PR DESCRIPTION
16 event handlers in `sdWeather.js` reset the world-event timer with `Math.random() * 30 * 60 * 0` on their "spawn cap already met" `else` branch, apparently intending a short randomized retry delay before trying a different event. That expression is always exactly `0` no matter what `Math.random()` returns, so instead of waiting, the scheduler re-rolls on the very next server tick - and keeps doing so every tick for as long as it keeps landing on an already-capped event (a Mothership Container that already exists, a boss that's already up, a structure that's already built, etc.), before it happens to land on an unconditional event like `EVENT_TASK_ASSIGNMENT`, which hands out real reward-eligible tasks to 3 random online players with no conditions attached.

On a young/empty server none of these caps are met yet, so this never triggers and everything paces normally. On a mature, actively-played server, several of these long-lived caps (some persist up to a week) are commonly true simultaneously, so every time the normal ~1-4 minute scheduler interval elapses during one of those stretches, it burns through a burst of full-tick-rate rerolls before landing on something real - inflating how often unconditional events fire well above their intended share of the schedule.

This fix matches the pattern already used for 4 other instances of this exact same line elsewhere in the file (already commented out, presumably for the same reason): disable the `else` branch entirely instead of overwriting the timer, so a capped pick is a no-op and the normal interval the scheduler already set just before dispatching stands unchanged.

## Test plan
- [x] Offline harness simulating the actual scheduler loop with a configurable mix of capped vs. unconditional daily events, comparing unpatched vs. patched firing rates for an unconditional event
- [x] Worst-case scenario (14 of 15 daily events simultaneously capped): unpatched fires the unconditional event at **15.4x** the intended rate; patched brings it back to ~1x (0.98x) of baseline
- [x] Moderate scenario (10 of 15 capped): unpatched at 2.89x, patched at 0.96x
- [x] `node --check` on the changed file