### PR TITLE
Fix stale _god flag surviving demotion on hibernated/offline characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
+# Fork-local ignore policy
+# Ignore all newly generated or local-only files in this devtests fork.
+# Existing tracked upstream files remain tracked by Git.
+*
+!*/
+!.gitignore
+
+# AI and agent workspace content
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+.claude/
+.clavix/
+.codex/
+.cursor/
+.gemini/
+.windsurf/
+.aider*
+
 # Logs
 logs
 *.log

--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -1584,6 +1584,20 @@ THING is cosmic mic drop!`;
 		
 		sdCharacter.characters.push( this );
 	}
+	onServerSideSnapshotLoaded() // Called whenever this character is (re)constructed from a stored snapshot - e.g. waking up from sdDeepSleep hibernation after being offline
+	{
+		// _god is only ever meant to be held by a currently-listed admin. If this character
+		// went to sleep (chunk hibernation, world save/restart) while still marked as god and
+		// was demoted/removed from the admin list in the meantime, the demote code has no way
+		// to reach an unloaded character to clear the flag - so re-validate it here, the moment
+		// the character becomes live again, instead of trusting whatever was last saved.
+		if ( this._god )
+		if ( typeof sdModeration === 'undefined' || !sdModeration.GetAdminRowByHash( this._my_hash ) )
+		{
+			this._god = false;
+			this._debug = false;
+		}
+	}
 	GetCameraZoom()
 	{
 		return this._camera_zoom / this._additional_camera_zoom_mult;


### PR DESCRIPTION
The `DEMOTE` admin-panel command (`sdAdminPanel.js`) only clears a demoted player's `_god` flag by scanning `sdCharacter.characters` - the list of currently loaded character entities:

```js
for ( let i = 0; i < sdCharacter.characters.length; i++ )
if ( sdCharacter.characters[ i ]._god )
if ( sdCharacter.characters[ i ]._my_hash === target.my_hash || ... )
{
    sdCharacter.characters[ i ]._god = false;
}
```

A character that's asleep at demotion time - its chunk hibernated via `sdDeepSleep` because the player's been offline for a while, or the world was saved/restarted - isn't in that list, so the flag never gets cleared. `_god: true` survives in the saved snapshot indefinitely and reappears with full godmode behavior (free building, invincibility, admin tools) the next time that chunk wakes up, even though the character's hash no longer matches any current admin. `sdDeepSleep.js` only exempts *online* players from hibernation (`e.IsPlayerClass() && e._socket`), so an offline character is swept into chunk storage the same as any other world entity.

This surfaced as a real report: a non-admin account, inactive for months, exhibiting godmode-like behavior with a hash that doesn't match any current admin - exactly the signature of this gap.

## Fix

Adds `sdCharacter.onServerSideSnapshotLoaded()`, the existing hook other entities (e.g. `sdLongRangeTeleport`) already use to fix up transient state right after being (re)constructed from a stored snapshot. Every time a character reloads, it re-checks `_god` against the live admin list and clears it (along with `_debug`) if the character's hash isn't currently an admin. This closes the specific demote-while-asleep gap and also protects against any other future way `_god` could drift out of sync with the admin list, without needing to touch the demote code path or any stored snapshot files directly.

## Test plan
- [x] Offline harness reproducing the exact reported symptom (`_god: true`, hash absent from the admin list) - confirms it gets cleared on load
- [x] Regression check: a currently-listed admin's character keeps `_god`/`_debug` across the same reload path - no impact on legitimate admin use
- [x] Regression check: normal players and hashless/AI characters are unaffected or fail safe
- [x] `node --check` on the changed file