### PR TITLE
Fix sample builder bypassing wall/LOS and restricted-area build checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
+# Fork-local ignore policy
+# Ignore all newly generated or local-only files in this devtests fork.
+# Existing tracked upstream files remain tracked by Git.
+*
+!*/
+!.gitignore
+
+# AI and agent workspace content
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+.claude/
+.clavix/
+.codex/
+.cursor/
+.gemini/
+.windsurf/
+.aider*
+
 # Logs
 logs
 *.log

--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -6852,8 +6852,8 @@ THING is cosmic mic drop!`;
 					if ( fake_ent.IsEarlyThreat() )
 					//if ( fake_ent.is( sdTurret ) || fake_ent.is( sdCom ) || fake_ent.is( sdBarrel ) || fake_ent.is( sdBomb ) || ( fake_ent.is( sdBlock ) && fake_ent.material === sdBlock.MATERIAL_SHARP ) )
 					{
-						let off;
-						
+						let off = { x:0, y:0 }; // Default for non-character initiators (e.g. sdSampleBuilder) which have no GetBulletSpawnOffset
+
 						if ( initiator )
 						if ( initiator.GetBulletSpawnOffset )
 						off = initiator.GetBulletSpawnOffset();

--- a/game/entities/sdSampleBuilder.js
+++ b/game/entities/sdSampleBuilder.js
@@ -244,7 +244,12 @@ class sdSampleBuilder extends sdEntity
 						delta_y = s._sample_entity.y + ( s._sample_entity._hitbox_y1 + s._sample_entity._hitbox_y2 ) / 2 - s.y;
 					}
 					
-					let ent = sdCharacter.GeneralCreateBuildObject( this.x + delta_x, this.y + delta_y, s._sample_shop_item, null, this._build_tool_level, this._workbench_level, true, false, false );
+					// Pass this (not null) as initiator so GeneralCheckBuildObjectPossibilityNow still runs its
+					// early-threat wall/LOS check and its restricted-area check anchored on the builder's own
+					// position, instead of skipping both (those checks special-case a null initiator as "always
+					// allow") - otherwise this auto-crafter could stamp out turrets/bombs/mines through walls or
+					// inside no-build zones with nobody ever having had line of sight to the build spot.
+					let ent = sdCharacter.GeneralCreateBuildObject( this.x + delta_x, this.y + delta_y, s._sample_shop_item, this, this._build_tool_level, this._workbench_level, true, false, false );
 
 					if ( ent )
 					{								


### PR DESCRIPTION
## Summary
- `sdSampleBuilder.onThink` always calls `sdCharacter.GeneralCreateBuildObject(...)` with `initiator = null`, since the auto-crafter never has an owning character.
- `GeneralCheckBuildObjectPossibilityNow` has two permission checks that special-case a falsy initiator as "nothing to validate against, allow it":
  1. the early-threat wall/LOS check (turrets, bombs, mines, coms, sharp blocks) - `IsEarlyThreat()`'s own comment says this exists so "players would [not] be able to spawn turrets through closed doors & walls".
  2. the `sdArea.TYPE_PREVENT_DAMAGE` restricted-zone check, which is supposed to block building inside admin no-build zones.
- Because a sample builder always passes `null`, both checks are skipped for everything it produces. A sampler primed with a turret/bomb/mine template plus a builder sitting at a wall or door can stamp out copies on the far side with nobody ever needing line of sight to the spot - or inside a zone that's supposed to forbid building entirely. Same exploit family as the cable cut-through-walls and Life Box exit-raid fixes already in this fork.
- Fix: pass `this` (the builder entity) as the initiator instead of `null`, so both checks run anchored at the builder's own position, same as for a real player. That needed a small companion fix in `sdCharacter.js`: the LOS branch calls `initiator.GetBulletSpawnOffset()`, which only `sdCharacter`/`sdTurret` implement - `sdSampleBuilder` doesn't, so `off` now defaults to `{x:0,y:0}` instead of being left `undefined` (which would otherwise throw on `off.x` the moment a non-null, non-character initiator reached that line).

## Test plan
- [x] `_audit_samplebuilder_wallphase_test.cjs` (offline, gitignored, not part of this diff) - 9/9 checks: wall-phase early-threat build denied post-fix (was allowed pre-fix), restricted-zone build denied post-fix (was allowed pre-fix), god-mode initiators still bypass both checks unchanged, non-character initiator no longer throws on the offset math.
- [x] `node --check` on both changed files.
- [x] Full server boot smoke test with the patch applied - world init, chunk/db creation, socket listener all came up with no runtime errors.
- [ ] Live in-game verification (build a sample builder + sampler pair against a wall with a turret template and confirm the build is refused) not done in this pass - flagging for a maintainer/tester to confirm in a running world, same as prior fixes in this fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)