### PR TITLE
Fix ghost items and disappearing real items in storage crates

### DIFF
--- a/game/entities/sdEntity.js
+++ b/game/entities/sdEntity.js
@@ -4447,6 +4447,10 @@ class sdEntity
 												
 		//let existing = sdEntity.GetObjectByClassAndNetId( snapshot._class ? snapshot._class : 'auto', snapshot._net_id );
 		let existing = sdEntity.GetObjectByClassAndNetId( snapshot._class, snapshot._net_id );
+
+		if ( existing && existing._is_being_removed ) // Entity is queued for deferred removal (.remove() was called but BulkRemoveEntitiesFromEntitiesArray hasn't reached it yet) - still cache-resolvable but a zombie. Resurrecting it here (ApplySnapshot never restores _is_being_removed) would pop it back into the world only for the pending removal pass to silently sweep it away again. Treat it as gone and reconstruct fresh below instead. This is what let sdStorage.ExtractItem() occasionally hand back a ghost that vanishes, or fail to hand back anything at all for a slot that still shows contents.
+		existing = null;
+
 		if ( existing )
 		{
 			existing.ApplySnapshot( snapshot );
@@ -5730,10 +5734,17 @@ class sdEntity
 			{
 				//if ( sdEntity.entities_by_net_id_cache[ this._net_id ] !== this )
 				if ( sdEntity.entities_by_net_id_cache_map.get( this._net_id ) !== this )
-				debugger; // Should never happen
-			
-				//delete sdEntity.entities_by_net_id_cache[ this._net_id ];
-				sdEntity.entities_by_net_id_cache_map.delete( this._net_id );
+				{
+					// A newer entity already reclaimed this _net_id in the cache (see the
+					// _is_being_removed skip in GetObjectFromSnapshot: a zombie entity can still
+					// be pending this deferred removal after a fresh replacement was constructed
+					// for the same _net_id). Do not delete a mapping that no longer belongs to us.
+				}
+				else
+				{
+					//delete sdEntity.entities_by_net_id_cache[ this._net_id ];
+					sdEntity.entities_by_net_id_cache_map.delete( this._net_id );
+				}
 				
 				if ( sdWorld.is_server )
 				if ( !sdWorld.is_singleplayer )

--- a/game/entities/sdStorage.js
+++ b/game/entities/sdStorage.js
@@ -141,8 +141,30 @@ class sdStorage extends sdEntity
 	}
 	onSnapshotApplied() // To override
 	{
-		while ( this.is_armable.length < this._stored_items.length )
-		this.is_armable.push( 0 );
+		// Keep the three parallel arrays in lockstep on every reconstruction (not just newly-built
+		// crates), with _stored_items as ground truth for how many real items exist. Server-only:
+		// _stored_items is underscore-prefixed and never included in the normal (non-full) network
+		// snapshot, so on the client it is always empty and must not be treated as ground truth there
+		// - doing so would truncate the stored_names/is_armable the client legitimately just received
+		// over the network down to nothing. Server-side this runs unconditionally (unlike the
+		// _storage_fix_applied migration below) so it also heals crates that were already desynced by
+		// ExtractItem()'s old independent-splice bug before this fix was deployed: padding restores
+		// real stored items that had lost their stored_names/is_armable entry (and so were invisible
+		// in the item list), truncating removes stale "ghost" entries with no backing _stored_items slot.
+		if ( sdWorld.is_server )
+		{
+			while ( this.is_armable.length < this._stored_items.length )
+			this.is_armable.push( 0 );
+
+			while ( this.stored_names.length < this._stored_items.length )
+			this.stored_names.push( '?' );
+
+			if ( this.is_armable.length > this._stored_items.length )
+			this.is_armable.length = this._stored_items.length;
+
+			if ( this.stored_names.length > this._stored_items.length )
+			this.stored_names.length = this._stored_items.length;
+		}
 
         if ( !this._storage_fix_applied ) // Remove after update
         {
@@ -793,13 +815,19 @@ class sdStorage extends sdEntity
 				ent = sdEntity.GetObjectFromSnapshot( this._stored_items[ slot ] );
 			}
 
-			if ( this._stored_items[ slot ] !== null && this._stored_items[ slot ] !== undefined ) // Holey array recovery test
+			// Splice all three parallel arrays together, unconditionally, whenever a slot is removed.
+			// The previous "Holey array recovery test" spliced each array independently based on its
+			// OWN null/undefined check at `slot`. That let a stray null in just ONE of the three arrays
+			// shrink only that array while the other two stayed full length, permanently shifting every
+			// later index out of alignment between _stored_items/is_armable/stored_names for the rest of
+			// this crate's lifetime. That misalignment is what produced both reported symptoms: entries
+			// in stored_names pointing at the wrong (or no) _stored_items slot - i.e. "ghost" items whose
+			// name doesn't match what Get actually returns - and the crate's real trailing item(s) losing
+			// their stored_names/is_armable entry entirely, so they never appear in the list at all despite
+			// still being present in _stored_items. Splicing all three together at the same index keeps
+			// them the same length from here on regardless of which one(s) happen to hold a stray null.
 			this._stored_items.splice( slot, 1 );
-		
-			if ( this.is_armable[ slot ] !== null && this.is_armable[ slot ] !== undefined ) // Holey array recovery test
 			this.is_armable.splice( slot, 1 );
-		
-			if ( this.stored_names[ slot ] !== null && this.stored_names[ slot ] !== undefined ) // Holey array recovery test
 			this.stored_names.splice( slot, 1 );
 
 			if ( ent )


### PR DESCRIPTION
## The bug

Two reports from a live server: storage crates sometimes list items that don't actually exist ("ghost" items — clicking Get either hands back the wrong item or nothing), and sometimes real items that are genuinely in a crate never show up in its list at all.

## Root cause 1: the three parallel arrays can silently desync

`sdStorage` tracks each crate's contents in three parallel arrays that are supposed to stay the same length and index-aligned: `_stored_items` (entity snapshots, ground truth), `stored_names` (display strings), `is_armable` (booleans).

`ExtractItem()` spliced each of the three **independently**, each guarded by that array's own null/undefined check at `slot` (the "Holey array recovery test" from the earlier holey-array crash fix). A single stray `null` in just *one* of the three (old corrupted save data is one known source) shrinks only that array while the other two stay full length — permanently shifting every later index out of alignment between them for the rest of that crate's lifetime:

- `stored_names[i]` ends up describing the wrong (or no) `_stored_items[i]` → a listed item whose name doesn't match what Get actually returns.
- The crate's real trailing item(s) lose their `stored_names`/`is_armable` entry entirely → present in `_stored_items`, but never shown in the list.

## Root cause 2: extraction can resurrect an entity mid-removal

`sdEntity.remove()` only flags `_is_being_removed = true`; the actual purge from `entities_by_net_id_cache_map` is deferred to a throttled backlog pass (`BulkRemoveEntitiesFromEntitiesArray`, 1ms time-slice / 1% floor per tick). Until that pass reaches it, the entity is still fully resolvable by `_net_id`.

`GetObjectFromSnapshot()` resolves by `_net_id` first and reuses a match unconditionally. If the entity backing a stored item snapshot is still in that removal-limbo window at the moment `ExtractItem()` reconstructs it, the zombie gets resurrected instead of a fresh object being built. `ApplySnapshot()` never restores `_is_being_removed`, so the "extracted" item pops back into the world only for the still-pending removal pass to sweep it away again on a later tick — a ghost that vanishes right after being taken.

## Fix

- `ExtractItem()` now splices all three parallel arrays together, unconditionally, at the same index — no more per-array independent guards to drift apart.
- `onSnapshotApplied()` now also re-syncs `is_armable`/`stored_names` to `_stored_items.length` (ground truth) every time a crate is reconstructed server-side: padding restores real items that lost their display entry, truncating drops stale ghost entries with no backing item. This is server-only — `_stored_items` is underscore-prefixed and never part of the normal (non-full) network snapshot, so it's always empty on the client and must not be used as ground truth there. This means crates that were *already* desynced by the old bug self-heal on their next reconstruction (server restart / deep-sleep wake), rather than staying broken forever.
- `GetObjectFromSnapshot()` now treats an `_is_being_removed` match as not-found, so extraction builds a fresh object instead of resurrecting a zombie.
- The removal cleanup's cache delete is now guarded to only fire if the cache still points at `this`, so a zombie's deferred removal can no longer delete a *newer* entity's valid registration for the same `_net_id` out from under it.

## Testing

Proven offline against mocked/copied-verbatim logic (32/32 assertions across both root causes, including reproducing each bug against the pre-fix code and confirming the client-side no-op guard doesn't regress normal network sync).

Files changed: `game/entities/sdEntity.js`, `game/entities/sdStorage.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)