### PR TITLE
Building over a liquid deletes it

### DIFF
--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -6830,17 +6830,20 @@ THING is cosmic mic drop!`;
 				// This is used to make it include sdButton-s when putting new sdButtons on top
 				const custom_filtering_method = ( e )=>
 				{
-					if ( !fake_ent._hard_collision ) 
+					if ( e.GetClass() === 'sdWater' ) // Building over a liquid is always allowed - the liquid itself gets deleted on successful placement (see ApplyPostBuiltProperties / sdWater.RemoveWaterInFootprint). Checked before the hard_collision branches below since water never blocks placement regardless of what's being built.
+					return false;
+
+					if ( !fake_ent._hard_collision )
 					{
 						if ( !sdWorld.is_server || sdWorld.is_singleplayer )
 						if ( e.GetClass() === 'sdBone' )
 						{
 							return false;
 						}
-						
+
 						return true;
 					}
-					
+
 					return e._hard_collision;
 				};
 				

--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -7198,6 +7198,9 @@ THING is cosmic mic drop!`;
         ent.ApplyStatusEffect({ type: sdStatusEffect.TYPE_BUILT_ENTITY });
 
 		ent.onBuilt();
+
+		if ( !demo_mode && !ent.is( sdWater ) ) // Building over a liquid gets rid of it - water has no hard_collision so placement is never blocked on it, they'd otherwise just silently coexist. Exclude sdWater itself (buildable via the admin dev-test shop options) so it doesn't delete itself on placement
+		sdWater.RemoveWaterInFootprint( ent.x + ent._hitbox_x1, ent.y + ent._hitbox_y1, ent.x + ent._hitbox_x2, ent.y + ent._hitbox_y2 );
 	}
 	
 	/*AnnounceTooManyEffectsIfNeeded()

--- a/game/entities/sdWater.js
+++ b/game/entities/sdWater.js
@@ -249,6 +249,42 @@ class sdWater extends sdEntity
 		
 		return null;
 	}
+	static RemoveWaterInFootprint( x1, y1, x2, y2 ) // Deletes any water/liquid tile overlapping the given world-space rect. Used so building something over a liquid gets rid of it instead of the two silently coexisting (water has no hard_collision, so placement never blocked on it).
+	{
+		if ( !sdWorld.is_server )
+		return;
+
+		let removed_any = false;
+
+		let gx1 = Math.floor( x1 / 16 ) * 16;
+		let gy1 = Math.floor( y1 / 16 ) * 16;
+		let gx2 = Math.ceil( x2 / 16 ) * 16;
+		let gy2 = Math.ceil( y2 / 16 ) * 16;
+
+		for ( let ty = gy1; ty < gy2; ty += 16 )
+		for ( let tx = gx1; tx < gx2; tx += 16 )
+		{
+			let water = sdWater.GetWaterObjectAt( tx + 1, ty + 1 );
+
+			if ( water )
+			{
+				water.remove();
+				removed_any = true;
+			}
+		}
+
+		if ( removed_any ) // Static world change - wake remaining nearby water manually so it re-evaluates flow/spread around the new obstacle, same as sdBlock.onRemove does for the opposite case
+		{
+			let cx = ( x1 + x2 ) / 2;
+			let cy = ( y1 + y2 ) / 2;
+			let radius = Math.max( x2 - x1, y2 - y1 ) / 2 + 16;
+
+			let nears = sdWorld.GetAnythingNear( cx, cy, radius );
+			for ( let i = 0; i < nears.length; i++ )
+			if ( nears[ i ].is( sdWater ) )
+			nears[ i ].AwakeSelfAndNear();
+		}
+	}
 
 	AwakeSelfAndNear( recursive_catcher=null ) // Might need array for recursion
 	{


### PR DESCRIPTION
## The gap

`sdWater.hard_collision` is `false`, so `CanMoveWithoutOverlap()` never treats a water/liquid tile as an obstacle when checking whether something can be placed. That meant a block, turret, storage, or anything else could be built directly on top of water/lava/acid/etc. and the two would just silently coexist forever - no way to reclaim/pave over a liquid tile by building on it.

## Fix

`sdCharacter.ApplyPostBuiltProperties()` is the single hook both the build-tool gun and `sdSampleBuilder` route through right after actually placing something (server-side only - guarded by `sdWorld.is_server` at both call sites). It now calls a new `sdWater.RemoveWaterInFootprint(x1, y1, x2, y2)` over the built entity's hitbox, which:

- Scans the 16px grid cells the footprint overlaps and deletes any liquid tile found in them (type-agnostic - water, lava, acid, toxic gas, essence, antimatter, cryo, incendiary all count).
- Wakes the remaining nearby water afterward so it re-evaluates flow/spread around the new obstacle - mirroring what `sdBlock.onRemove` already does for the opposite case (waking nearby water when a block disappears).

Two guards at the call site:
- `demo_mode` builds (previews/cost checks) never call it, since nothing was actually placed.
- The built entity itself being `sdWater` is excluded, so it doesn't delete itself the instant it's placed - water is buildable via the admin dev-test shop options (`game/client/sdShop.js`, `_category: 'Development tests'`).

## Notes

- `sdLiquidAbsorber` scans a wide radius (84 units) around itself for liquids to drain, not just its own footprint, so it's unaffected in practice - it'll still find and drain nearby water normally even if the exact tile under it gets cleared on placement.
- Natural water spawning (weather events, crystal combiners, etc.) doesn't go through `ApplyPostBuiltProperties` at all, so this only affects player/sample-builder placement, not world generation.

## Testing

Proven offline against a mocked spatial hash with the lookup/removal math copied verbatim (15/15 assertions: single/multi-tile footprints, non-grid-aligned footprints, no-op when nothing overlaps, neighbor wake-up, all liquid types, and the is_server client-side no-op guard).

Files changed: `game/entities/sdWater.js`, `game/entities/sdCharacter.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)