### PR TITLE
Fix BSU revenge-target null dereference crash

### DIFF
--- a/game/entities/sdBaseShieldingUnit.js
+++ b/game/entities/sdBaseShieldingUnit.js
@@ -1165,7 +1165,8 @@ class sdBaseShieldingUnit extends sdEntity
 			{
 				if ( this._revenge_target._is_being_removed || ( this._revenge_target.IsPlayerClass() && ( this._revenge_target.hea || this._revenge_target._hea || 0 ) <= 0 ) ) // Broken tanks still can damage shields walls with conveyors indefinitely
 				this._revenge_target = null;
-				
+
+				if ( this._revenge_target ) // Re-check: the block above may have just nulled it out
 				if ( this._revenge_target.IsPlayerClass() && this._revenge_target.driver_of ) // Check if target is in a vehicle
 				{
 					if ( this._revenge_target.driver_of.GetClass() === 'sdRescueTeleport' ) // Rescue cloner?


### PR DESCRIPTION
## The crash

Live crash report from a production server (`world_slot=1000`, ~4.5 hours uptime, `exit_status=1`):

```
TypeError: Cannot read properties of null (reading 'IsPlayerClass')
    at sdBaseShieldingUnit.onThink (game/entities/sdBaseShieldingUnit.js:1211)
```

## Root cause

The "BSU revenge turrets no longer target players inside rescue cloners" change wrapped the existing null-out check in a block and added a second dereference right after it, without re-checking for null in between:

```js
if ( this._revenge_target )
{
    if ( ... ) this._revenge_target = null;          // can null it out here
    if ( this._revenge_target.IsPlayerClass() ... )  // ...then dereferenced unconditionally
}
```

Any BSU whose revenge target gets removed, or is a player who died, nulls `_revenge_target` on the first check and then crashes on the very next line trying to call `.IsPlayerClass()` on `null`. This isn't an edge case - both of those (target removed, target died) are exactly the conditions the surrounding code is designed to detect, so it fires reliably in normal play and takes the whole process down.

## Fix

Re-check `this._revenge_target` for null before the second dereference. The actual rescue-cloner-detection feature this block exists for is unaffected - a target still driving a rescue cloner still gets un-targeted correctly.

## Testing

Proven offline by reproducing the exact crash against the unmodified code (both the removed-entity and dead-player trigger conditions throw the same `TypeError`), and confirming the fix closes both without changing the rescue-cloner check's behavior (5/5 assertions).

Files changed: `game/entities/sdBaseShieldingUnit.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)