### PR TITLE
Fix inefficient class-name-list warnings (sdTurret/sdNode + sdWater)

### DIFF
--- a/game/entities/sdCable.js
+++ b/game/entities/sdCable.js
@@ -259,9 +259,18 @@ class sdCable extends sdEntity
         // Someone fired cable tool and then dropped it onto weaponbench?
         if ( !bullet._owner || bullet._owner._is_being_removed )
         return;
-			
+
         const is_player = bullet._owner.IsPlayerClass();
-    
+
+        // Resolved through the registry rather than imported directly: sdCom.js imports sdCable.js,
+        // and sdTurret.js imports sdCom.js, so a direct `import sdTurret` here would create a real
+        // circular import chain (sdCable -> sdTurret -> sdCom -> sdCable). This also replaces the
+        // slow globalThis fallback getter (stack-trace capture + rate-limited warning on every single
+        // cable-bullet hit) that bare sdTurret/sdNode references below were silently falling through
+        // to - same registry-lookup pattern already used elsewhere in this file (see sdSteeringWheel).
+        const sdTurret = sdWorld.entity_classes.sdTurret;
+        const sdNode = sdWorld.entity_classes.sdNode;
+
         if ( bullet._owner._current_built_entity )
         if ( !bullet._owner._current_built_entity.is( sdCable ) )
         bullet._owner._current_built_entity = null;

--- a/game/entities/sdLiquidAbsorber.js
+++ b/game/entities/sdLiquidAbsorber.js
@@ -196,8 +196,8 @@ class sdLiquidAbsorber extends sdEntity
 
 			if ( this.charge >= sdLiquidAbsorber.cycle_time )
 			{
-				//let liquids = sdWorld.GetAnythingNear( this.x, this.y , sdLiquidAbsorber.scan_distance, null, [ 'sdWater' ] );
-				let liquids = this.GetAnythingNearCache( this.x, this.y, sdLiquidAbsorber.scan_distance, null, [ 'sdWater' ] );
+				//let liquids = sdWorld.GetAnythingNear( this.x, this.y , sdLiquidAbsorber.scan_distance, null, sdWater.water_class_array );
+				let liquids = this.GetAnythingNearCache( this.x, this.y, sdLiquidAbsorber.scan_distance, null, sdWater.water_class_array );
 				
 				for ( let i = 0; i < liquids.length; i++ ) // Protect nearby entities inside base unit's radius
 				{

--- a/game/server/sdServerConfig.js
+++ b/game/server/sdServerConfig.js
@@ -1455,11 +1455,11 @@ class sdServerConfigFull extends sdServerConfigShort
 			// Dedicated first 60% of attempts to spawn somewhere where there is no early damage
 			if ( tr > max_tr * 0.6 || bad_areas_near === 0 )
 			// Dedicated first 80% of attempts to spawn somewhere where can stand and there is no water
-			if ( tr > max_tr * 0.8 || ( can_stand_here && !sdWorld.CheckWallExistsBox( 
-					x + character_entity._hitbox_x1 - 16, 
-					y + character_entity._hitbox_y1 - 16, 
-					x + character_entity._hitbox_x2 + 16, 
-					y + character_entity._hitbox_y2 + 16, null, null, [ 'sdWater' ], null ) ) )
+			if ( tr > max_tr * 0.8 || ( can_stand_here && !sdWorld.CheckWallExistsBox(
+					x + character_entity._hitbox_x1 - 16,
+					y + character_entity._hitbox_y1 - 16,
+					x + character_entity._hitbox_x2 + 16,
+					y + character_entity._hitbox_y2 + 16, null, null, sdWater.water_class_array, null ) ) ) // Reuse the pre-made array (sdWater.js init_class) instead of a fresh literal every spawn-search iteration (up to max_tr=10000 per spawn) - a new array here defeats GetClassListByClassNameList's cache entirely, rebuilding the class Set from scratch every call
 			// Dedicated first 40% of attempts to spawn somewhere where ground exists
 			if ( tr > max_tr * 0.4 || 
 				 socket.command_centre || 


### PR DESCRIPTION
## The warnings

Two live-production warnings, both symptoms of the same underlying mistake (a fresh array/unimported reference where a stable, pre-made one should be reused):

```
Class sdTurret was accessed without being properly imported...
Class sdNode was accessed without being properly imported...
```
```
Inefficient class name list (["sdWater"]) to class object list conversion detected...
    at sdServerConfigFull.PlayerSpawnPointSeeker
```

Players reported water feeling laggier, and the second warning fires from the player-spawn search loop, which runs up to `max_tr=10000` iterations per spawn attempt.

## Fix 1: sdCable.js's sdTurret/sdNode references

`CableProjectileLogic()` referenced `sdTurret` and `sdNode` as bare globals without importing them, falling through to the `globalThis` fallback getter `sdWorld.FinalizeClasses()` installs for exactly this case - capturing a stack trace and rate-limit-checking on *every single* cable-bullet hit.

I didn't just add the missing imports: `sdCom.js` imports `sdCable.js`, and `sdTurret.js` imports `sdCom.js`, so a direct `import sdTurret from './sdTurret.js'` in `sdCable.js` would create a genuine circular import chain (`sdCable -> sdTurret -> sdCom -> sdCable`). Instead both are resolved via `sdWorld.entity_classes.sdTurret` / `.sdNode` - the same registry-lookup pattern already used elsewhere in this exact file (see the `sdSteeringWheel` reference a few lines below). This is provably the *same* class reference as the old fallback getter, just via a plain property read instead of a `defineProperty` getter: `FinalizeClasses()` populates both `entity_classes` and the getter's closure from the identical loop (`let c = entity_classes[i]; ... get(){ return c; }`).

## Fix 2: sdServerConfig.js's PlayerSpawnPointSeeker

`CheckWallExistsBox()` was passed a fresh `[ 'sdWater' ]` array literal on every iteration of the spawn-search loop. `GetClassListByClassNameList()` memoizes the resolved class `Set` **onto the array object itself** (`class_names_array._classes = classes`) - a new array every call means the cache is never hit, and the `Set` gets rebuilt from scratch (plus the stack-trace-capturing inefficiency detector re-triggers) on every single spawn-search iteration where this check runs.

Replaced with `sdWater.water_class_array` - the exact pre-made, reused array `sdWater.js`'s `init_class()` already exists for this purpose (the same array `sdWeather.js` and `sdCharacter.js` already reuse for their own water checks - this file just wasn't using it).

Also fixed the same pattern in `sdLiquidAbsorber`'s per-tick water scan for consistency, though that path goes through `GetAnythingNear`'s plain `.indexOf()` check rather than `GetClassListByClassNameList`, so its impact is minor GC churn rather than the cache-defeating rebuild.

## Testing

Audited with a live local server (fresh `world_slot=9999`, real `index.js`, no mocks): clean boot, zero import/circular-dependency errors, zero runtime exceptions through full class registration (~200+ entity classes including `sdCable`/`sdTurret`/`sdNode`/`sdLiquidAbsorber`), world creation, and socket.io startup. The actual risk this change carried - a circular-import failure - is conclusively ruled out this way, since Node surfaces that immediately at module-load time, before any server code runs at all.

Files changed: `game/entities/sdCable.js`, `game/entities/sdLiquidAbsorber.js`, `game/server/sdServerConfig.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)