### PR TITLE
Fix akimbo backup pistol getting orphaned when the primary weapon is lost

### DIFF
--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -1665,7 +1665,7 @@ THING is cosmic mic drop!`;
 			{
 				if ( this._inventory[ 10 ].extra[ sdGun.ID_SLOT ] )
 				this._inventory[ 10 ].extra[ sdGun.ID_SLOT ] = null;
-				this._inventory[ 10 ] = this._inventory[ 1 ]; // Put the dual wield slot into primary pistol slot
+				this._inventory[ 1 ] = this._inventory[ 10 ]; // Put the dual wield slot into primary pistol slot
 				this._inventory[ 10 ] = null;
 			}
 		}


### PR DESCRIPTION
## Summary
- `ReloadAndCombatLogic`'s slot-1-recovery patch (added for cases "like Octopus attack" where slot 1 is cleared by something other than `DropWeapon()`) had the promotion assignment backwards: `this._inventory[10] = this._inventory[1]` instead of `this._inventory[1] = this._inventory[10]`.
- Since this block only runs when `_inventory[1]` is already `null`, the old code just overwrote slot 10 with `null` - deleting the reference to the akimbo backup pistol from `_inventory[]` while never touching the gun's own `_held_by` pointer (which stays pointed at the character forever).
- Result: a permanently "held" gun (blocks re-pickup, which requires `_held_by === null`) that's also invisible to `_inventory[]` (blocks firing, and blocks `DropSpecificWeapon`'s `this._inventory.indexOf(ent)` lookup - which logs `"Should not happen"` and silently fails to drop it). Confirmed against a live server console error + world snapshot where a real gun had `_held_by` correctly pointing at the player's character, `extra[ID_SLOT]` cleared to `null` exactly as this block does, but was absent from `_inventory[]` - permanently stuck.
- One-line fix: swap the assignment direction so the backup pistol is actually promoted into slot 1, and slot 10 is cleared afterward as intended.

## Test plan
- [x] Offline proof extracts the real `ReloadAndCombatLogic` block from source and drives it against a mock character: promotion works, untouched dual-wield/empty-inventory/already-populated-slot-1 cases are unaffected, and the pre-fix block is shown reproducing the original bug. 13/13 assertions pass.