### PR TITLE
Fix held guns losing their inventory slot after a snapshot decode (boot or chunk wake)

### DIFF
--- a/game/entities/sdDeepSleep.js
+++ b/game/entities/sdDeepSleep.js
@@ -726,7 +726,9 @@ class sdDeepSleep extends sdEntity
 			
 			sdWorld.SolveUnresolvedEntityPointers();
 			sdWorld.unresolved_entity_pointers = null;
-			
+
+			sdWorld.entity_classes.sdGun.ReconnectHeldGuns( ents ); // Scoped to just this wake batch, not a full-world scan
+
 			for ( let i = 0; i < ents.length; i++ )
 			{
 				let ent = ents[ i ];

--- a/game/entities/sdGun.js
+++ b/game/entities/sdGun.js
@@ -197,8 +197,35 @@ class sdGun extends sdEntity
 			ent._time_amplification -= GSPEED;
 			return GSPEED * sdGun.time_amplification_gspeed_scale;
 		}
-		
+
 		return GSPEED;
+	}
+	static ReconnectHeldGuns( entities ) // Guns held by sdCharacter/sdPlayerDrone don't serialize _held_by or _inventory (see ExtraSerialzableFieldTest) - only the primitive held_by_net_id/held_by_class/extra[ID_SLOT] survive a snapshot decode (world boot or a deep-sleep chunk waking up). ApplySnapshot skips reconnecting those specifically ("Old gun code handles it"), but the only code that ever did was UpdateHolderClientSide, which is client-only. Call this once over whatever batch of entities was just decoded to rebuild both pointers server-side, same rule client already applies every tick.
+	{
+		for ( let i = 0; i < entities.length; i++ )
+		{
+			let gun = entities[ i ];
+
+			if ( gun.GetClass() !== 'sdGun' ) continue;
+			if ( gun._is_being_removed ) continue;
+			if ( gun._held_by !== null ) continue; // Already resolved (e.g. non-character holders go through the generic pointer path above)
+			if ( gun.held_by_class !== 'sdCharacter' && gun.held_by_class !== 'sdPlayerDrone' ) continue;
+			if ( gun.held_by_net_id === -1 ) continue;
+			if ( sdGun.classes[ gun.class ] === undefined ) continue;
+
+			let holder = sdEntity.GetObjectByClassAndNetId( gun.held_by_class, gun.held_by_net_id );
+
+			if ( holder && !holder._is_being_removed && holder.IsPlayerClass() )
+			{
+				let slot = gun.GetSlot();
+
+				if ( holder._inventory[ slot ] === null ) // Don't clobber a slot another gun already legitimately re-occupies
+				{
+					gun._held_by = holder;
+					holder._inventory[ slot ] = gun;
+				}
+			}
+		}
 	}
 	
 	IsGunRecoverable()

--- a/game/server/sdServerConfig.js
+++ b/game/server/sdServerConfig.js
@@ -1667,7 +1667,9 @@ class sdServerConfigFull extends sdServerConfigShort
 
 			sdWorld.SolveUnresolvedEntityPointers();
 			sdWorld.unresolved_entity_pointers = null;
-			
+
+			sdGun.ReconnectHeldGuns( sdEntity.entities );
+
 			if ( sdWorld.server_config.run_patch_overlap )
 			{
 				console.log( 'Running overlap patch...' );


### PR DESCRIPTION
## Summary
- Neither `sdGun._held_by` nor `sdCharacter._inventory[]` is part of a saved snapshot: `ExtraSerialzableFieldTest` doesn't allowlist `_held_by` (a single object pointer) on `sdGun`, and `_inventory` (an *array* of pointers) can't be allowlisted the same way, since the engine's generic entity-pointer encoder only converts a single `instanceof sdEntity` property value into a `{_net_id,_class}` reference - not array elements. Only the primitive companions (`held_by_net_id`, `held_by_class`, `extra[ID_SLOT]`) survive a decode.
- `sdEntity.ApplySnapshot` already has generic reconnection logic for a gun's `_held_by` from those primitives, but explicitly skips it when `held_by_class` is `'sdCharacter'` or `'sdPlayerDrone'`, with a comment deferring to "old gun code". The only code that ever did that reconnection is `sdGun.UpdateHolderClientSide()`, which is gated by `if ( !sdWorld.is_server )` - client only. Nothing runs the server-side equivalent.
- This isn't limited to full server restarts: `sdDeepSleep`'s chunk-hibernation wake path goes through the exact same `GetObjectFromSnapshot`/`ApplySnapshot` decode as world boot, so *any* held gun (primary or akimbo) inside a chunk that hibernates and wakes loses its `_held_by`/`_inventory` link - far more frequent than just a reboot. The gun ends up permanently "held" per its own pointer (blocking re-pickup, which requires `_held_by === null`) while being invisible to `_inventory[]` (blocking firing and dropping).
- Adds `sdGun.ReconnectHeldGuns(entities)`, which rebuilds both pointers from the surviving primitives for whatever batch of entities was just decoded, and wires it in right after `SolveUnresolvedEntityPointers()` at both call sites: `sdServerConfig.js` (world boot, scans all loaded entities once) and `sdDeepSleep.js` (chunk wake, scoped to just that wake's small entity batch - not a full-world scan on every hibernation cycle).

## Test plan
- [x] Offline proof extracts the real `ReconnectHeldGuns` method from source and drives it through 9 scenarios: primary + akimbo backup both reconnected, slot-collision defense (won't clobber an already-reoccupied slot instead of blindly reattaching), non-character holders left untouched (unaffected), ownerless/missing-holder/removed-holder/removed-gun/already-resolved/unknown-class guns all correctly left alone. 14/14 assertions pass.