### PR TITLE
Fix hide-contents overrides corrupting the shared per-entity snapshot cache

### DIFF
--- a/game/entities/sdCom.js
+++ b/game/entities/sdCom.js
@@ -202,9 +202,17 @@ class sdCom extends sdEntity
 		}
 		
 		let snapshot = super.GetSnapshot( current_frame, save_as_much_as_possible, observer_entity );
-		
+
 		if ( hide_contents )
 		{
+			// Clone before mutating: snapshot is the entity's shared, persistently-cached snapshot
+			// object (same reference every call - see sdEntity.GetSnapshot's _snapshot_cache), reused
+			// regardless of observer. Mutating it in place here would let a far observer's subscriber
+			// list get trimmed for this same object other observers already hold a reference to this
+			// tick (sdByteShifter's per-entity diff-prep cache keys reuse on this object's identity,
+			// same class of bug as the sdStorage ghost-items/hide-contents race).
+			snapshot = Object.assign( {}, snapshot );
+
 			let id = snapshot.subscribers.indexOf( observer_entity.biometry );
 			
 			if ( id === -1 )

--- a/game/entities/sdEntity.js
+++ b/game/entities/sdEntity.js
@@ -3305,13 +3305,21 @@ class sdEntity
 		
 		let snapshot = sdEntity.prototype.GetSnapshot.call( this, current_frame, save_as_much_as_possible, observer_entity );
 		//let snapshot = super.GetSnapshot( current_frame, save_as_much_as_possible, observer_entity );
-		
+
 		if ( hide_contents )
 		{
+			// Clone before mutating: snapshot is this entity's shared, persistently-cached snapshot
+			// object (same reference every call - see GetSnapshot's _snapshot_cache), reused regardless
+			// of observer. Mutating it in place would let one observer's driver-hiding pass blank out
+			// (or leak) driver slots for another observer's already-cached copy within the same tick
+			// (sdByteShifter's per-entity diff-prep cache keys reuse on this object's identity - same
+			// class of bug as the sdStorage ghost-items/hide-contents race).
+			snapshot = Object.assign( {}, snapshot );
+
 			for ( var i = 0; i < this.GetDriverSlotsCount(); i++ )
 			snapshot[ 'driver' + i ] = null;
 		}
-		
+
 		return snapshot;
 	}
 	

--- a/game/entities/sdStorage.js
+++ b/game/entities/sdStorage.js
@@ -80,13 +80,23 @@ class sdStorage extends sdEntity
 		}
 		
 		let snapshot = super.GetSnapshot( current_frame, save_as_much_as_possible, observer_entity );
-		
+
 		if ( hide_contents )
 		{
+			// super.GetSnapshot returns the entity's shared, persistently-cached snapshot object
+			// (same reference every call, only its properties are refreshed in place - see
+			// sdEntity.GetSnapshot's _snapshot_cache). Mutating it here would corrupt what other
+			// observers - near or far - see for this same tick: sdByteShifter's per-entity diff-prep
+			// cache (phase-13-snapshot-01) keys its reuse on this object's identity, and since it's
+			// always the same object regardless of observer, a far player's snapshot request could
+			// silently blank out stored_names/is_armable for a nearby player's already-cached diff (or
+			// vice versa leak contents to a far player), depending on per-tick observer processing
+			// order. Clone first so hiding contents for this observer can never affect another.
+			snapshot = Object.assign( {}, snapshot );
 			snapshot.stored_names = [];
 			snapshot.is_armable = [];
 		}
-		
+
 		return snapshot;
 	}
 	constructor( params )


### PR DESCRIPTION
## The bug

`sdStorage.GetSnapshot`, `sdCom.GetSnapshot`, and `sdEntity.GetDriverObfuscatingSnapshot` each hide observer-specific data (crate contents, com subscriber lists, driver seats) by skewing `current_frame` to force a rebuild, then mutating the object returned by `super.GetSnapshot()` in place.

That object is always the entity's single persistent `_snapshot_cache` reference — `sdEntity.GetSnapshot` reuses and refills it in place, never allocates fresh, regardless of which observer asked for it.

## Root cause

`perf/snapshot-diff-hoist` added a per-entity descriptor cache in `sdByteShifter.AddEntity` (`_diff_prep_cache`) that's reused across every connected socket once population > 1, invalidated only on `(frame, snapshot-object-identity)` change. Its own comment assumes any observer-dependent `GetSnapshot` override returns a fresh object when content differs for different observers — true in general, but false for these three overrides, since they all hand back the same cache object every time.

Within one server tick (`frame` is constant for the whole per-socket sync loop), whichever observer is processed first bakes their hide/reveal state into the descriptor, and every other observer of the same entity that tick silently reuses it:

- A legitimate viewer's item list can get blanked out (the reported "storage crate interface breaks after a couple pickup/drops" bug — needs 2+ players to trigger since the fast path is gated on socket count), or
- In the opposite processing order, hidden contents can leak to a far observer who shouldn't see them.

## Fix

Clone the snapshot before mutating it whenever `hide_contents` is active, at all three call sites. This gives each hidden-state snapshot a distinct object identity from the full one, so the diff-prep cache's own invalidation check does exactly what its comment already assumed — no changes needed in `sdByteShifter` itself. The common near-observer path (no clone) is untouched, preserving the perf win where it matters most.

## Testing

Verified offline against a reduced model of the real caching + diff-prep-cache logic, covering both corruption directions and confirming the near/near fast path still hits the descriptor cache (12/12 assertions).

Files changed: `game/entities/sdCom.js`, `game/entities/sdEntity.js`, `game/entities/sdStorage.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)