### PR TITLE
Client QoL: loading screen, startup-screen polish, task HUD, character profile selector

### DIFF
--- a/game/client/sdLoadingScreen.js
+++ b/game/client/sdLoadingScreen.js
@@ -19,6 +19,44 @@ class sdLoadingScreen
 {
 	static init_class()
 	{
+		// Two plain DOM layers behind the canvas, replicating #page_background / #bg_stars from the main menu (style.css)
+		// so the loading screen sits on the same nebula backdrop + blended starfield instead of a flat placeholder color.
+		// Kept as real elements (not drawn into the canvas) so mix-blend-mode:screen on the stars layer works correctly -
+		// that blend mode blends the element against whatever's behind IT, which would fall apart if it were baked into
+		// the same canvas as the card/text content sitting on top of it.
+		let bg = document.createElement( 'div' );
+		bg.id = 'loading_screen_bg';
+		bg.style.position = 'fixed';
+		bg.style.left = '0px';
+		bg.style.top = '0px';
+		bg.style.width = '100%';
+		bg.style.height = '100%';
+		bg.style.zIndex = '9998';
+		bg.style.display = 'none';
+		bg.style.background = 'url(assets/bg_menu.jpg)';
+		bg.style.backgroundSize = 'cover';
+		bg.style.backgroundPosition = 'bottom center';
+		bg.style.filter = 'blur(0.2vh)';
+		document.body.appendChild( bg );
+
+		let stars = document.createElement( 'div' );
+		stars.id = 'loading_screen_stars';
+		stars.style.position = 'fixed';
+		stars.style.left = '50%';
+		stars.style.top = '0px';
+		stars.style.transform = 'translate(-50%,-50%)';
+		stars.style.width = '100vw';
+		stars.style.height = '100vw';
+		stars.style.zIndex = '9999';
+		stars.style.display = 'none';
+		stars.style.background = 'url(assets/bg_stars.gif)';
+		stars.style.mixBlendMode = 'screen';
+		stars.style.imageRendering = 'pixelated';
+		document.body.appendChild( stars );
+
+		sdLoadingScreen.bg_el = bg;
+		sdLoadingScreen.stars_el = stars;
+
 		let canvas = document.createElement( 'canvas' );
 		canvas.id = 'loading_screen_canvas';
 
@@ -384,6 +422,8 @@ class sdLoadingScreen
 
 		sdLoadingScreen.showing = true;
 		sdLoadingScreen.canvas.style.display = 'block';
+		sdLoadingScreen.bg_el.style.display = 'block';
+		sdLoadingScreen.stars_el.style.display = 'block';
 
 		sdLoadingScreen.current_index = ~~( Math.random() * sdLoadingScreen.assets.length );
 		sdLoadingScreen.time_on_current = 0;
@@ -411,6 +451,8 @@ class sdLoadingScreen
 	{
 		sdLoadingScreen.showing = false;
 		sdLoadingScreen.canvas.style.display = 'none';
+		sdLoadingScreen.bg_el.style.display = 'none';
+		sdLoadingScreen.stars_el.style.display = 'none';
 
 		if ( sdLoadingScreen.raf_handle !== null )
 		cancelAnimationFrame( sdLoadingScreen.raf_handle );
@@ -445,6 +487,16 @@ class sdLoadingScreen
 
 		sdLoadingScreen.raf_handle = requestAnimationFrame( ()=>sdLoadingScreen.Loop() );
 	}
+	static RoundedRectPath( ctx, x, y, w, h, r )
+	{
+		ctx.beginPath();
+		ctx.moveTo( x + r, y );
+		ctx.arcTo( x + w, y, x + w, y + h, r );
+		ctx.arcTo( x + w, y + h, x, y + h, r );
+		ctx.arcTo( x, y + h, x, y, r );
+		ctx.arcTo( x, y, x + w, y, r );
+		ctx.closePath();
+	}
 	static Draw( now )
 	{
 		let ctx = sdLoadingScreen.ctx;
@@ -452,9 +504,7 @@ class sdLoadingScreen
 		let h = sdLoadingScreen.canvas.height;
 
 		ctx.setTransform( 1, 0, 0, 1, 0, 0 );
-
-		ctx.fillStyle = '#05070d';
-		ctx.fillRect( 0, 0, w, h );
+		ctx.clearRect( 0, 0, w, h ); // No solid fill anymore - #loading_screen_bg / #loading_screen_stars (behind the canvas) provide the same nebula + starfield backdrop as the main menu
 
 		let asset = sdLoadingScreen.assets[ sdLoadingScreen.current_index ];
 		let { title, tip } = sdLoadingScreen.GetTip( asset.tip_key, asset.fallback_title );
@@ -467,13 +517,15 @@ class sdLoadingScreen
 		const card_height = 320 * scale;
 		const card_x = ( w - card_width ) / 2;
 		const card_y = ( h - card_height ) / 2;
+		const card_radius = 8 * scale;
 
-		// Card background
-		ctx.fillStyle = 'rgba(255,255,255,0.04)';
-		ctx.fillRect( card_x, card_y, card_width, card_height );
-		ctx.strokeStyle = 'rgba(255,255,255,0.15)';
-		ctx.lineWidth = 2;
-		ctx.strokeRect( card_x, card_y, card_width, card_height );
+		// Card background - same dark-panel/thin-border convention as .menu_rect / menu_button / settings panels
+		sdLoadingScreen.RoundedRectPath( ctx, card_x, card_y, card_width, card_height, card_radius );
+		ctx.fillStyle = 'rgba(20,20,20,0.45)';
+		ctx.fill();
+		ctx.strokeStyle = 'rgba(255,255,255,0.09)';
+		ctx.lineWidth = 2 * scale;
+		ctx.stroke();
 
 		// Icon - gently bobs up/down and pulses scale, so it doesn't feel like a static screenshot
 		const bob = Math.sin( now / 600 ) * 6 * scale;
@@ -493,13 +545,13 @@ class sdLoadingScreen
 
 		// Title
 		ctx.textAlign = 'center';
-		ctx.fillStyle = '#ffffaa';
-		ctx.font = ( 22 * scale ) + 'px Verdana';
+		ctx.fillStyle = '#ffffff';
+		ctx.font = ( 22 * scale ) + "px 'ui_font2', Verdana, sans-serif";
 		ctx.fillText( title, icon_cx, card_y + 210 * scale );
 
 		// Tip (word-wrapped to the card width), or a generic placeholder if this entry has no tip filled in yet
-		ctx.fillStyle = 'rgba(255,255,255,0.8)';
-		ctx.font = ( 14 * scale ) + 'px Verdana';
+		ctx.fillStyle = 'rgba(255,255,255,0.7)';
+		ctx.font = ( 14 * scale ) + "px 'ui_font2', Verdana, sans-serif";
 
 		let tip_lines = sdLoadingScreen.WrapText( ctx, tip || 'Did you know? Every part of this world was built by players like you.', card_width - 40 * scale );
 
@@ -515,15 +567,15 @@ class sdLoadingScreen
 		{
 			let represents_current = ( sdLoadingScreen.current_index % DOT_COUNT ) === i;
 
-			ctx.fillStyle = represents_current ? '#ffffaa' : 'rgba(255,255,255,0.25)';
+			ctx.fillStyle = represents_current ? '#8bff63' : 'rgba(255,255,255,0.25)'; // Same green accent as "Connected to... / playing / online" on the main menu
 			ctx.beginPath();
 			ctx.arc( icon_cx - dots_width / 2 + i * dot_spacing + dot_spacing / 2, card_y + card_height - 20 * scale, 3 * scale, 0, Math.PI * 2 );
 			ctx.fill();
 		}
 
 		// "Loading..." label with an animated ellipsis
-		ctx.fillStyle = '#ffffff';
-		ctx.font = ( 18 * scale ) + 'px Verdana';
+		ctx.fillStyle = '#8bff63';
+		ctx.font = ( 18 * scale ) + "px 'ui_font2', Verdana, sans-serif";
 		let dots = '.'.repeat( 1 + ( Math.floor( now / 400 ) % 3 ) );
 		ctx.fillText( 'Loading' + dots, w / 2, card_y - 20 * scale );
 	}

--- a/game/client/sdLoadingScreen.js
+++ b/game/client/sdLoadingScreen.js
@@ -268,39 +268,107 @@ class sdLoadingScreen
 
 		const SIZE = 96;
 
-		let icon_canvas = document.createElement( 'canvas' );
-		icon_canvas.width = SIZE;
-		icon_canvas.height = SIZE;
+		// Guns' hitbox is a tiny fixed pickup-collision box (~8x6px) totally unrelated to their actual sprite size
+		// (multi-part weapons can draw 100+ px wide) - scaling off of it was blowing guns up far past the icon
+		// canvas and clipping most of the sprite off. Draw at native scale into a generously-oversized scratch
+		// canvas first, then measure the ACTUAL opaque pixel bounds and scale/center based on that instead, which
+		// works correctly regardless of which of this game's several different sprite-drawing paths a given
+		// entity/gun uses.
+		const SCRATCH_SIZE = 400;
 
-		let ctx2 = icon_canvas.getContext( '2d' );
-		sdRenderer.AddCacheDrawMethod( ctx2 );
-		ctx2.imageSmoothingEnabled = false;
+		let scratch = document.createElement( 'canvas' );
+		scratch.width = SCRATCH_SIZE;
+		scratch.height = SCRATCH_SIZE;
+
+		let sctx = scratch.getContext( '2d' );
+		sdRenderer.AddCacheDrawMethod( sctx );
+		sctx.imageSmoothingEnabled = false;
 
 		try
 		{
-			ctx2.translate(
-				~~( SIZE / 2 - ( fake_ent._hitbox_x2 + fake_ent._hitbox_x1 ) / 2 ),
-				~~( SIZE / 2 - ( fake_ent._hitbox_y2 + fake_ent._hitbox_y1 ) / 2 )
+			sctx.translate(
+				~~( SCRATCH_SIZE / 2 - ( fake_ent._hitbox_x2 + fake_ent._hitbox_x1 ) / 2 ),
+				~~( SCRATCH_SIZE / 2 - ( fake_ent._hitbox_y2 + fake_ent._hitbox_y1 ) / 2 )
 			);
 
-			ctx2.save();
-			fake_ent.DrawBG( ctx2, false );
-			ctx2.restore();
+			sctx.save();
+			fake_ent.DrawBG( sctx, false );
+			sctx.restore();
 
-			ctx2.save();
-			fake_ent.Draw( ctx2, false );
-			ctx2.restore();
+			sctx.save();
+			fake_ent.Draw( sctx, false );
+			sctx.restore();
 
-			ctx2.save();
-			fake_ent.DrawFG( ctx2, false );
-			ctx2.restore();
+			sctx.save();
+			fake_ent.DrawFG( sctx, false );
+			sctx.restore();
 		}
 		catch ( e )
 		{
 			return null;
 		}
 
+		let bounds = sdLoadingScreen.MeasureOpaqueBounds( sctx, SCRATCH_SIZE, SCRATCH_SIZE );
+
+		if ( !bounds )
+		return null; // Nothing drawn yet (ex. sprite image still loading) - callers already handle a null return gracefully
+
+		let sprite_w = bounds.x2 - bounds.x1;
+		let sprite_h = bounds.y2 - bounds.y1;
+		let largest_dim = Math.max( sprite_w, sprite_h, 4 );
+
+		const TARGET_FILL = 0.7; // Sprites scale up to occupy roughly this fraction of the icon canvas along their longest edge
+		const MAX_SAFE_FILL = 0.92; // Hard ceiling so a scaled sprite can never exceed the icon canvas bounds (small margin for the alpha threshold in MeasureOpaqueBounds slightly undercounting soft/antialiased edges)
+
+		let fill_scale = ( SIZE * TARGET_FILL ) / largest_dim;
+		let safe_cap = ( SIZE * MAX_SAFE_FILL ) / largest_dim;
+
+		let sprite_scale = Math.min( safe_cap, Math.max( 1, fill_scale ) ); // Never shrink below native size, except in the rare case a sprite is so large even native size would clip - then shrink just enough to fit
+
+		if ( asset.class_name === 'sdGun' ) // Guns read as small/thin even after the general proportional scale-up above, so give them an extra boost (still bounded by the same clip-safety ceiling)
+		sprite_scale = Math.min( safe_cap, sprite_scale * 2 );
+
+		let icon_canvas = document.createElement( 'canvas' );
+		icon_canvas.width = SIZE;
+		icon_canvas.height = SIZE;
+
+		let ctx2 = icon_canvas.getContext( '2d' );
+		ctx2.imageSmoothingEnabled = false;
+
+		let draw_w = sprite_w * sprite_scale;
+		let draw_h = sprite_h * sprite_scale;
+
+		ctx2.drawImage( scratch, bounds.x1, bounds.y1, sprite_w, sprite_h, ( SIZE - draw_w ) / 2, ( SIZE - draw_h ) / 2, draw_w, draw_h );
+
 		return icon_canvas;
+	}
+	static MeasureOpaqueBounds( ctx, w, h ) // Scans for the bounding box of non-transparent pixels drawn so far - used to find a sprite's true visual extent when the entity's hitbox doesn't represent it (see MakeIcon)
+	{
+		let data;
+
+		try { data = ctx.getImageData( 0, 0, w, h ).data; }
+		catch ( e ) { return null; }
+
+		let min_x = w, min_y = h, max_x = -1, max_y = -1;
+
+		for ( let y = 0; y < h; y++ )
+		for ( let x = 0; x < w; x++ )
+		{
+			let alpha = data[ ( y * w + x ) * 4 + 3 ];
+
+			if ( alpha > 10 )
+			{
+				if ( x < min_x ) min_x = x;
+				if ( x > max_x ) max_x = x;
+				if ( y < min_y ) min_y = y;
+				if ( y > max_y ) max_y = y;
+			}
+		}
+
+		if ( max_x < 0 )
+		return null;
+
+		return { x1: min_x, y1: min_y, x2: max_x + 1, y2: max_y + 1 };
 	}
 	static BuildAssetList()
 	{
@@ -309,6 +377,14 @@ class sdLoadingScreen
 
 		let assets = [];
 		let seen_keys = new Set();
+
+		// Pure admin/dev-utility entity classes (world-editing, protection-zone markers, dev test spawner) - never
+		// something a normal player builds or encounters as a recognizable "thing", so not interesting for a
+		// gameplay-preview carousel. Small, explicit list rather than pattern-matching, since most classes referenced
+		// from sdShop.js's "Development tests" category (sdSandWorm, sdDrone, sdWorkbench, etc.) ARE real creatures/
+		// items players normally encounter in the world - that category is just a convenient admin spawn shortcut for
+		// them, not evidence the class itself is admin-only.
+		const ADMIN_ONLY_ENTITY_CLASSES = new Set([ 'sdArea', 'sdPresetEditor', 'sdVirus', 'sdFactionSpawner' ]);
 
 		// Primary source for guns: sdGun.classes directly, NOT sdShop.options. sdShop.options is populated by a
 		// 'SET sdShop.options' message sent by the server after connecting - it's still just placeholder stub
@@ -322,6 +398,9 @@ class sdLoadingScreen
 			let gun_class_entry = sdGun.classes[ class_id ];
 
 			if ( !gun_class_entry )
+			continue;
+
+			if ( gun_class_entry.matter_cost === Infinity ) // Same signal sdShop.js itself relies on ("Cost of Infinity is what actually prevents items here from being accessible to non-in-godmode-admins") - covers the admin remover/teleporter/damager/mass-deleter guns
 			continue;
 
 			let dedupe_key = 'gun:' + class_id;
@@ -352,6 +431,9 @@ class sdLoadingScreen
 			let cls = sdWorld.entity_classes_array[ i ];
 
 			if ( cls.name === 'sdGun' ) // Already fully covered above (154 distinct, properly-titled gun types) - a bare new sdGun({}) here would just be a generic, less useful duplicate
+			continue;
+
+			if ( ADMIN_ONLY_ENTITY_CLASSES.has( cls.name ) )
 			continue;
 
 			let dedupe_key = cls.name + ':::';
@@ -466,6 +548,18 @@ class sdLoadingScreen
 		sdLoadingScreen.current_fake_ent = null;
 		sdLoadingScreen.current_fake_ent_index = -1;
 	}
+	static PickNextRandomIndex() // Random rather than sequential, so repeat viewings of the loading screen don't always start the same cycle through the same ~300 assets in the same order
+	{
+		if ( sdLoadingScreen.assets.length <= 1 )
+		return 0;
+
+		let next_index = sdLoadingScreen.current_index;
+
+		while ( next_index === sdLoadingScreen.current_index ) // Avoid picking the same asset twice in a row
+		next_index = ~~( Math.random() * sdLoadingScreen.assets.length );
+
+		return next_index;
+	}
 	static Loop()
 	{
 		if ( !sdLoadingScreen.showing )
@@ -480,7 +574,7 @@ class sdLoadingScreen
 		if ( sdLoadingScreen.time_on_current > sdLoadingScreen.ASSET_DURATION_MS )
 		{
 			sdLoadingScreen.time_on_current = 0;
-			sdLoadingScreen.current_index = ( sdLoadingScreen.current_index + 1 ) % sdLoadingScreen.assets.length;
+			sdLoadingScreen.current_index = sdLoadingScreen.PickNextRandomIndex();
 		}
 
 		sdLoadingScreen.Draw( now );
@@ -558,18 +652,19 @@ class sdLoadingScreen
 		for ( let i = 0; i < tip_lines.length; i++ )
 		ctx.fillText( tip_lines[ i ], icon_cx, card_y + 245 * scale + i * 20 * scale );
 
-		// Progress dots
-		const DOT_COUNT = Math.min( 24, sdLoadingScreen.assets.length );
+		// Activity dots - a simple animated wave rather than a literal position-in-list indicator, since assets now
+		// cycle in random order (PickNextRandomIndex) rather than sequentially, so there's no real "progress" to show
+		const DOT_COUNT = 7;
 		const dot_spacing = 10 * scale;
 		const dots_width = DOT_COUNT * dot_spacing;
 
 		for ( let i = 0; i < DOT_COUNT; i++ )
 		{
-			let represents_current = ( sdLoadingScreen.current_index % DOT_COUNT ) === i;
+			let wave = ( Math.sin( now / 250 - i * 0.8 ) + 1 ) / 2; // 0..1
 
-			ctx.fillStyle = represents_current ? '#8bff63' : 'rgba(255,255,255,0.25)'; // Same green accent as "Connected to... / playing / online" on the main menu
+			ctx.fillStyle = `rgba(139,255,99,${ 0.25 + wave * 0.75 })`; // Same green accent as "Connected to... / playing / online" on the main menu
 			ctx.beginPath();
-			ctx.arc( icon_cx - dots_width / 2 + i * dot_spacing + dot_spacing / 2, card_y + card_height - 20 * scale, 3 * scale, 0, Math.PI * 2 );
+			ctx.arc( icon_cx - dots_width / 2 + i * dot_spacing + dot_spacing / 2, card_y + card_height - 20 * scale, ( 2 + wave * 1.5 ) * scale, 0, Math.PI * 2 );
 			ctx.fill();
 		}
 

--- a/game/client/sdLoadingScreen.js
+++ b/game/client/sdLoadingScreen.js
@@ -1,0 +1,556 @@
+
+/*
+
+	Loading screen shown between clicking "Play" and the world actually appearing (previously just a black canvas -
+	sdWorld.GotoGame() shows the game canvas immediately, before any snapshot data has arrived).
+
+	Cycles through a "card" for each known entity/gun, drawing its real in-game sprite (via a throwaway "fake" instance,
+	same trick sdShop.js uses for its build-menu icons) alongside a tooltip pulled from loading_tips.json. Tips are
+	optional per entry - entries with no tip just show their title.
+
+*/
+
+import sdWorld from '../sdWorld.js';
+import sdRenderer from './sdRenderer.js';
+import sdGun from '../entities/sdGun.js';
+import sdSound from '../sdSound.js';
+
+class sdLoadingScreen
+{
+	static init_class()
+	{
+		let canvas = document.createElement( 'canvas' );
+		canvas.id = 'loading_screen_canvas';
+
+		canvas.style.position = 'fixed';
+		canvas.style.left = '0px';
+		canvas.style.top = '0px';
+		canvas.style.zIndex = '10000'; // Above sdRenderer.canvas (#SD2D) and the menu #page
+		canvas.style.display = 'none';
+		canvas.style.imageRendering = 'pixelated';
+		canvas.style.cursor = 'none';
+
+		document.body.appendChild( canvas );
+
+		sdLoadingScreen.canvas = canvas;
+		sdLoadingScreen.ctx = canvas.getContext( '2d' );
+
+		sdLoadingScreen.showing = false;
+		sdLoadingScreen.assets = null; // Built lazily on first Show() - entity classes aren't all registered yet at this point
+		sdLoadingScreen.tips = null; // Fetched lazily too, may not have resolved by the time Show() is first called - that's fine, falls back to title-only
+
+		sdLoadingScreen.current_index = 0;
+		sdLoadingScreen.time_on_current = 0;
+		sdLoadingScreen.last_frame_time = 0;
+
+		sdLoadingScreen.raf_handle = null;
+		sdLoadingScreen.hide_check_handle = null;
+		sdLoadingScreen.hide_started_at = 0;
+
+		sdLoadingScreen.ASSET_DURATION_MS = 4000;
+		sdLoadingScreen.SAFETY_HIDE_MS = 20000; // In case sdWorld.my_entity never resolves for some reason, don't get stuck showing this forever
+
+		sdLoadingScreen.ATTACK_PHASE_AFTER_MS = 2000; // "moving" entities show their idle/walk animation for this long, then we try to trigger their attack animation for the rest of their time on screen
+
+		sdLoadingScreen.current_fake_ent = null; // Kept alive for as long as its asset is on screen (unlike MakeIcon's per-frame throwaway instances) so muzzle flash / walk-cycle / attack state can accumulate across frames
+		sdLoadingScreen.current_fake_ent_index = -1;
+		sdLoadingScreen.current_fake_ent_broken = false; // Set once onThink throws for this entity, so we stop retrying it every frame
+		sdLoadingScreen.gun_shot_schedule = null; // Array of ms-since-shown timestamps still pending a shot, for the current asset if it's a gun
+		sdLoadingScreen.attack_phase_started = false;
+
+		window.addEventListener( 'resize', ()=>sdLoadingScreen.OnResize() );
+		sdLoadingScreen.OnResize();
+
+		fetch( 'loading_tips.json' )
+			.then( ( r )=>r.json() )
+			.then( ( data )=>{ sdLoadingScreen.tips = data; } )
+			.catch( ()=>{ sdLoadingScreen.tips = null; } );
+	}
+	static OnResize()
+	{
+		if ( !sdLoadingScreen.canvas )
+		return;
+
+		sdLoadingScreen.canvas.width = window.innerWidth;
+		sdLoadingScreen.canvas.height = window.innerHeight;
+	}
+	static CanBuild( class_name, params ) // Used only while building the asset list, to filter out entries that can't construct at all (bad params etc.) - does NOT tell us whether it can *draw* something visible yet, since sprite images load asynchronously (see MakeIcon)
+	{
+		let cls = sdWorld.entity_classes[ class_name ];
+
+		if ( !cls )
+		return false;
+
+		let fake_ent = null;
+
+		try
+		{
+			fake_ent = new cls( Object.assign( { x: 0, y: 0 }, params ) );
+			fake_ent.UpdateHitbox();
+		}
+		catch ( e )
+		{
+			return false;
+		}
+		finally
+		{
+			if ( fake_ent )
+			try { fake_ent.remove(); fake_ent._broken = false; fake_ent._remove(); } catch ( e2 ) {}
+		}
+
+		return true;
+	}
+	static ConstructFakeEnt( class_name, params )
+	{
+		let cls = sdWorld.entity_classes[ class_name ];
+
+		if ( !cls )
+		return null;
+
+		try
+		{
+			let fake_ent = new cls( Object.assign( { x: 0, y: 0 }, params ) );
+			fake_ent.UpdateHitbox();
+			fake_ent.x = 0;
+			fake_ent.y = 0;
+			return fake_ent;
+		}
+		catch ( e )
+		{
+			return null;
+		}
+	}
+	static DestroyFakeEnt( fake_ent )
+	{
+		if ( !fake_ent )
+		return;
+
+		try { fake_ent.remove(); fake_ent._broken = false; fake_ent._remove(); } catch ( e ) {}
+	}
+	static EnsureCurrentFakeEnt( asset_index, asset ) // (Re)creates the persistent fake entity when the displayed asset changes, and resets its per-asset animation state
+	{
+		if ( sdLoadingScreen.current_fake_ent_index === asset_index )
+		if ( sdLoadingScreen.current_fake_ent )
+		return sdLoadingScreen.current_fake_ent;
+
+		sdLoadingScreen.DestroyFakeEnt( sdLoadingScreen.current_fake_ent );
+
+		sdLoadingScreen.current_fake_ent = sdLoadingScreen.ConstructFakeEnt( asset.class_name, asset.params );
+		sdLoadingScreen.current_fake_ent_index = asset_index;
+		sdLoadingScreen.current_fake_ent_broken = false;
+		sdLoadingScreen.attack_phase_started = false;
+
+		if ( asset.class_name === 'sdGun' )
+		sdLoadingScreen.gun_shot_schedule = [ 900, 1700, 2500 ]; // ms-since-shown - a few low-volume "shots" spread across the display window
+		else
+		sdLoadingScreen.gun_shot_schedule = null;
+
+		return sdLoadingScreen.current_fake_ent;
+	}
+	static UpdateGun( fake_gun, time_on_current, GSPEED )
+	{
+		if ( sdLoadingScreen.gun_shot_schedule )
+		for ( let i = 0; i < sdLoadingScreen.gun_shot_schedule.length; i++ )
+		if ( time_on_current >= sdLoadingScreen.gun_shot_schedule[ i ] )
+		{
+			sdLoadingScreen.gun_shot_schedule.splice( i, 1 );
+			i--;
+
+			try
+			{
+				fake_gun.muzzle = 5;
+
+				if ( fake_gun._sound )
+				sdSound.PlaySound({
+					name: fake_gun._sound,
+					x: 0, y: 0,
+					volume: 0.06, // "Very low sound" per the request - these fire repeatedly while cycling through ~150 assets, should be barely-there ambience, not a real gunshot
+					pitch: fake_gun._sound_pitch || 1,
+					_server_allowed: true // Required for sdSound.PlaySound to actually play anything when called from plain client-side code (no server round-trip before the world has even loaded)
+				});
+			}
+			catch ( e ) {}
+		}
+
+		if ( fake_gun.muzzle > 0 )
+		fake_gun.muzzle = Math.max( 0, fake_gun.muzzle - GSPEED * 0.15 );
+	}
+	static UpdateMovingEntity( fake_ent, time_on_current, GSPEED )
+	{
+		if ( sdLoadingScreen.current_fake_ent_broken )
+		return;
+
+		if ( !fake_ent.IsPhysicallyMovable() )
+		return;
+
+		if ( !sdLoadingScreen.attack_phase_started )
+		if ( time_on_current > sdLoadingScreen.ATTACK_PHASE_AFTER_MS )
+		{
+			sdLoadingScreen.attack_phase_started = true;
+
+			if ( '_current_target' in fake_ent ) // Common convention across ~30 creature AI classes - give it something in range to react to, so its own logic (not ours) decides how to show "attacking"
+			fake_ent._current_target = {
+				x: 24, y: 0,
+				hea: 999, _hea: 999,
+				_is_being_removed: false,
+				biometry: 'loading_screen_dummy_target',
+				GetClass: ()=>'sdCharacter',
+				IsTargetable: ()=>true,
+				IsInSafeArea: ()=>false,
+				IsAdminEntity: ()=>false
+			};
+		}
+
+		try
+		{
+			fake_ent.onThink( GSPEED );
+		}
+		catch ( e )
+		{
+			sdLoadingScreen.current_fake_ent_broken = true; // Give up on animating this one for the rest of its time on screen - it'll just show its construction-time pose, which is a safe fallback
+		}
+
+		// onThink may have actually moved it via physics - keep it pinned to the icon's center regardless, we only wanted the internal animation/AI state to progress, not real displacement
+		fake_ent.x = 0;
+		fake_ent.y = 0;
+	}
+	static MakeIcon( asset, asset_index, time_on_current ) // Builds a fresh offscreen bitmap EVERY call (see below for why), of the ONE persistent fake entity for the currently-displayed asset
+	{                                                       // Sprite images load asynchronously (sdWorld.CreateImageFromFile) - a one-shot bake taken before the image finishes loading would be permanently blank, so this redraws each frame instead of caching, which self-heals once the image loads. Cheap since only ever done for the current asset, never all of them at once.
+		let fake_ent = sdLoadingScreen.EnsureCurrentFakeEnt( asset_index, asset );
+
+		if ( !fake_ent )
+		return null;
+
+		const GSPEED = 1; // Stand-in for a ~normal server tick's worth of time, used only to drive animation/muzzle-decay counters here, not real physics timing
+
+		if ( asset.class_name === 'sdGun' )
+		sdLoadingScreen.UpdateGun( fake_ent, time_on_current, GSPEED );
+		else
+		sdLoadingScreen.UpdateMovingEntity( fake_ent, time_on_current, GSPEED );
+
+		const SIZE = 96;
+
+		let icon_canvas = document.createElement( 'canvas' );
+		icon_canvas.width = SIZE;
+		icon_canvas.height = SIZE;
+
+		let ctx2 = icon_canvas.getContext( '2d' );
+		sdRenderer.AddCacheDrawMethod( ctx2 );
+		ctx2.imageSmoothingEnabled = false;
+
+		try
+		{
+			ctx2.translate(
+				~~( SIZE / 2 - ( fake_ent._hitbox_x2 + fake_ent._hitbox_x1 ) / 2 ),
+				~~( SIZE / 2 - ( fake_ent._hitbox_y2 + fake_ent._hitbox_y1 ) / 2 )
+			);
+
+			ctx2.save();
+			fake_ent.DrawBG( ctx2, false );
+			ctx2.restore();
+
+			ctx2.save();
+			fake_ent.Draw( ctx2, false );
+			ctx2.restore();
+
+			ctx2.save();
+			fake_ent.DrawFG( ctx2, false );
+			ctx2.restore();
+		}
+		catch ( e )
+		{
+			return null;
+		}
+
+		return icon_canvas;
+	}
+	static BuildAssetList()
+	{
+		if ( sdLoadingScreen.assets )
+		return sdLoadingScreen.assets;
+
+		let assets = [];
+		let seen_keys = new Set();
+
+		// Primary source for guns: sdGun.classes directly, NOT sdShop.options. sdShop.options is populated by a
+		// 'SET sdShop.options' message sent by the server after connecting - it's still just placeholder stub
+		// entries at the exact moment this list needs to build (sdWorld.GotoGame() fires synchronously, right
+		// after emitting RESPAWN, with no wait for any server round-trip), so relying on it here would silently
+		// show zero guns in the common case. sdGun.classes is populated locally at boot (sdGunClass.init_class()),
+		// no server dependency.
+		if ( sdGun.classes )
+		for ( let class_id in sdGun.classes )
+		{
+			let gun_class_entry = sdGun.classes[ class_id ];
+
+			if ( !gun_class_entry )
+			continue;
+
+			let dedupe_key = 'gun:' + class_id;
+
+			if ( seen_keys.has( dedupe_key ) )
+			continue;
+
+			let params = { class: Number( class_id ) };
+
+			if ( !sdLoadingScreen.CanBuild( 'sdGun', params ) )
+			continue;
+
+			seen_keys.add( dedupe_key );
+
+			assets.push({
+				class_name: 'sdGun',
+				params,
+				tip_key: 'guns.' + sdLoadingScreen.FindGunClassIdName( Number( class_id ) ),
+				fallback_title: gun_class_entry.title || 'Gun'
+			});
+		}
+
+		// Supplementary: every OTHER registered entity class not already covered above, best-effort (many will fail
+		// to construct with no params and are silently skipped - that's fine, this is just extra visual variety)
+		if ( sdWorld.entity_classes_array )
+		for ( let i = 0; i < sdWorld.entity_classes_array.length; i++ )
+		{
+			let cls = sdWorld.entity_classes_array[ i ];
+
+			if ( cls.name === 'sdGun' ) // Already fully covered above (154 distinct, properly-titled gun types) - a bare new sdGun({}) here would just be a generic, less useful duplicate
+			continue;
+
+			let dedupe_key = cls.name + ':::';
+
+			if ( seen_keys.has( dedupe_key ) )
+			continue;
+
+			if ( !sdLoadingScreen.CanBuild( cls.name, {} ) )
+			continue;
+
+			seen_keys.add( dedupe_key );
+
+			assets.push({
+				class_name: cls.name,
+				params: {},
+				tip_key: 'entities.' + cls.name,
+				fallback_title: cls.name
+			});
+		}
+
+		sdLoadingScreen.assets = assets;
+
+		return assets;
+	}
+	static FindGunClassIdName( numeric_id )
+	{
+		if ( sdLoadingScreen._gun_id_name_cache === undefined )
+		{
+			sdLoadingScreen._gun_id_name_cache = new Map();
+
+			for ( let key in sdGun )
+			if ( key.indexOf( 'CLASS_' ) === 0 )
+			sdLoadingScreen._gun_id_name_cache.set( sdGun[ key ], key );
+		}
+
+		return sdLoadingScreen._gun_id_name_cache.get( numeric_id ) || null;
+	}
+	static GetTip( tip_key, fallback_title )
+	{
+		let title = fallback_title;
+		let tip = '';
+
+		if ( tip_key )
+		if ( sdLoadingScreen.tips )
+		{
+			let parts = tip_key.split( '.' ); // ex. [ 'entities', 'sdBlock' ] or [ 'guns', 'CLASS_PISTOL' ]
+			let group = sdLoadingScreen.tips[ parts[ 0 ] ];
+
+			if ( group )
+			if ( group[ parts[ 1 ] ] )
+			{
+				if ( group[ parts[ 1 ] ].title )
+				title = group[ parts[ 1 ] ].title;
+
+				if ( group[ parts[ 1 ] ].tip )
+				tip = group[ parts[ 1 ] ].tip;
+			}
+		}
+
+		return { title, tip };
+	}
+	static Show()
+	{
+		sdLoadingScreen.BuildAssetList();
+
+		if ( sdLoadingScreen.assets.length === 0 )
+		return; // Nothing could be built (ex. classes not loaded yet for some reason) - just skip, leaving the old black-screen behavior rather than showing an empty overlay
+
+		sdLoadingScreen.showing = true;
+		sdLoadingScreen.canvas.style.display = 'block';
+
+		sdLoadingScreen.current_index = ~~( Math.random() * sdLoadingScreen.assets.length );
+		sdLoadingScreen.time_on_current = 0;
+		sdLoadingScreen.last_frame_time = Date.now();
+
+		sdLoadingScreen.Loop();
+
+		sdLoadingScreen.hide_started_at = Date.now();
+		sdLoadingScreen.PollForHide();
+	}
+	static PollForHide()
+	{
+		if ( !sdLoadingScreen.showing )
+		return;
+
+		if ( sdWorld.my_entity || Date.now() - sdLoadingScreen.hide_started_at > sdLoadingScreen.SAFETY_HIDE_MS )
+		{
+			sdLoadingScreen.Hide();
+			return;
+		}
+
+		sdLoadingScreen.hide_check_handle = setTimeout( ()=>sdLoadingScreen.PollForHide(), 200 );
+	}
+	static Hide()
+	{
+		sdLoadingScreen.showing = false;
+		sdLoadingScreen.canvas.style.display = 'none';
+
+		if ( sdLoadingScreen.raf_handle !== null )
+		cancelAnimationFrame( sdLoadingScreen.raf_handle );
+		sdLoadingScreen.raf_handle = null;
+
+		if ( sdLoadingScreen.hide_check_handle !== null )
+		clearTimeout( sdLoadingScreen.hide_check_handle );
+		sdLoadingScreen.hide_check_handle = null;
+
+		sdLoadingScreen.DestroyFakeEnt( sdLoadingScreen.current_fake_ent );
+		sdLoadingScreen.current_fake_ent = null;
+		sdLoadingScreen.current_fake_ent_index = -1;
+	}
+	static Loop()
+	{
+		if ( !sdLoadingScreen.showing )
+		return;
+
+		let now = Date.now();
+		let dt = now - sdLoadingScreen.last_frame_time;
+		sdLoadingScreen.last_frame_time = now;
+
+		sdLoadingScreen.time_on_current += dt;
+
+		if ( sdLoadingScreen.time_on_current > sdLoadingScreen.ASSET_DURATION_MS )
+		{
+			sdLoadingScreen.time_on_current = 0;
+			sdLoadingScreen.current_index = ( sdLoadingScreen.current_index + 1 ) % sdLoadingScreen.assets.length;
+		}
+
+		sdLoadingScreen.Draw( now );
+
+		sdLoadingScreen.raf_handle = requestAnimationFrame( ()=>sdLoadingScreen.Loop() );
+	}
+	static Draw( now )
+	{
+		let ctx = sdLoadingScreen.ctx;
+		let w = sdLoadingScreen.canvas.width;
+		let h = sdLoadingScreen.canvas.height;
+
+		ctx.setTransform( 1, 0, 0, 1, 0, 0 );
+
+		ctx.fillStyle = '#05070d';
+		ctx.fillRect( 0, 0, w, h );
+
+		let asset = sdLoadingScreen.assets[ sdLoadingScreen.current_index ];
+		let { title, tip } = sdLoadingScreen.GetTip( asset.tip_key, asset.fallback_title );
+
+		let icon = sdLoadingScreen.MakeIcon( asset, sdLoadingScreen.current_index, sdLoadingScreen.time_on_current ); // Rebuilt every frame - see MakeIcon for why (async sprite loading)
+
+		const scale = Math.min( 2, Math.max( 1, Math.min( w, h ) / 700 ) );
+
+		const card_width = 520 * scale;
+		const card_height = 320 * scale;
+		const card_x = ( w - card_width ) / 2;
+		const card_y = ( h - card_height ) / 2;
+
+		// Card background
+		ctx.fillStyle = 'rgba(255,255,255,0.04)';
+		ctx.fillRect( card_x, card_y, card_width, card_height );
+		ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+		ctx.lineWidth = 2;
+		ctx.strokeRect( card_x, card_y, card_width, card_height );
+
+		// Icon - gently bobs up/down and pulses scale, so it doesn't feel like a static screenshot
+		const bob = Math.sin( now / 600 ) * 6 * scale;
+		const pulse = 1 + Math.sin( now / 900 ) * 0.04;
+
+		const icon_draw_size = 128 * scale * pulse;
+		const icon_cx = card_x + card_width / 2;
+		const icon_cy = card_y + 110 * scale + bob;
+
+		if ( icon )
+		{
+			ctx.save();
+			ctx.imageSmoothingEnabled = false;
+			ctx.drawImage( icon, icon_cx - icon_draw_size / 2, icon_cy - icon_draw_size / 2, icon_draw_size, icon_draw_size );
+			ctx.restore();
+		}
+
+		// Title
+		ctx.textAlign = 'center';
+		ctx.fillStyle = '#ffffaa';
+		ctx.font = ( 22 * scale ) + 'px Verdana';
+		ctx.fillText( title, icon_cx, card_y + 210 * scale );
+
+		// Tip (word-wrapped to the card width), or a generic placeholder if this entry has no tip filled in yet
+		ctx.fillStyle = 'rgba(255,255,255,0.8)';
+		ctx.font = ( 14 * scale ) + 'px Verdana';
+
+		let tip_lines = sdLoadingScreen.WrapText( ctx, tip || 'Did you know? Every part of this world was built by players like you.', card_width - 40 * scale );
+
+		for ( let i = 0; i < tip_lines.length; i++ )
+		ctx.fillText( tip_lines[ i ], icon_cx, card_y + 245 * scale + i * 20 * scale );
+
+		// Progress dots
+		const DOT_COUNT = Math.min( 24, sdLoadingScreen.assets.length );
+		const dot_spacing = 10 * scale;
+		const dots_width = DOT_COUNT * dot_spacing;
+
+		for ( let i = 0; i < DOT_COUNT; i++ )
+		{
+			let represents_current = ( sdLoadingScreen.current_index % DOT_COUNT ) === i;
+
+			ctx.fillStyle = represents_current ? '#ffffaa' : 'rgba(255,255,255,0.25)';
+			ctx.beginPath();
+			ctx.arc( icon_cx - dots_width / 2 + i * dot_spacing + dot_spacing / 2, card_y + card_height - 20 * scale, 3 * scale, 0, Math.PI * 2 );
+			ctx.fill();
+		}
+
+		// "Loading..." label with an animated ellipsis
+		ctx.fillStyle = '#ffffff';
+		ctx.font = ( 18 * scale ) + 'px Verdana';
+		let dots = '.'.repeat( 1 + ( Math.floor( now / 400 ) % 3 ) );
+		ctx.fillText( 'Loading' + dots, w / 2, card_y - 20 * scale );
+	}
+	static WrapText( ctx, text, max_width ) // Same pixel-accurate approach as sdTask's expanded-view wrap
+	{
+		let words = text.split( ' ' );
+		let lines = [];
+		let line = '';
+
+		for ( let i = 0; i < words.length; i++ )
+		{
+			let candidate = line ? ( line + ' ' + words[ i ] ) : words[ i ];
+
+			if ( line && ctx.measureText( candidate ).width > max_width )
+			{
+				lines.push( line );
+				line = words[ i ];
+			}
+			else
+			line = candidate;
+		}
+
+		if ( line )
+		lines.push( line );
+
+		return lines;
+	}
+}
+
+export default sdLoadingScreen;

--- a/game/client/sdLoadingScreen.js
+++ b/game/client/sdLoadingScreen.js
@@ -88,6 +88,8 @@ class sdLoadingScreen
 		sdLoadingScreen.ASSET_DURATION_MS = 4000;
 		sdLoadingScreen.SAFETY_HIDE_MS = 20000; // In case sdWorld.my_entity never resolves for some reason, don't get stuck showing this forever
 
+		sdLoadingScreen.PRELOAD_COUNT = 6; // Restrict the carousel to this many assets (half guns, half other entities - see BuildAssetList), all warmed up front in Show() - trades the ~300-asset variety for a guarantee that whichever card is showing always already has its sprite loaded, instead of a freshly-randomly-picked one sometimes showing blank for however long its image takes to fetch. This game is served over plain HTTP (no TLS, so no HTTP/2 multiplexing) - Chrome caps concurrent connections per host at ~6, so firing off more than that in one burst just queues the rest behind the first 6, defeating the point for exactly the ones queued last
+
 		sdLoadingScreen.ATTACK_PHASE_AFTER_MS = 2000; // "moving" entities show their idle/walk animation for this long, then we try to trigger their attack animation for the rest of their time on screen
 
 		sdLoadingScreen.current_fake_ent = null; // Kept alive for as long as its asset is on screen (unlike MakeIcon's per-frame throwaway instances) so muzzle flash / walk-cycle / attack state can accumulate across frames
@@ -423,6 +425,8 @@ class sdLoadingScreen
 			});
 		}
 
+		let guns_count = assets.length; // Where the gun entries end and entity entries begin, for BuildAssetList's curated sample below
+
 		// Supplementary: every OTHER registered entity class not already covered above, best-effort (many will fail
 		// to construct with no params and are silently skipped - that's fine, this is just extra visual variety)
 		if ( sdWorld.entity_classes_array )
@@ -452,6 +456,22 @@ class sdLoadingScreen
 				tip_key: 'entities.' + cls.name,
 				fallback_title: cls.name
 			});
+		}
+
+		// Curated sample rather than the full ~300 - half guns, half other entities, in whatever order
+		// they were discovered above (arbitrary, but stable run to run). See PRELOAD_COUNT.
+		if ( assets.length > sdLoadingScreen.PRELOAD_COUNT )
+		{
+			let half = Math.ceil( sdLoadingScreen.PRELOAD_COUNT / 2 );
+			let guns = assets.slice( 0, guns_count ).slice( 0, half );
+			let others = assets.slice( guns_count ).slice( 0, sdLoadingScreen.PRELOAD_COUNT - guns.length );
+
+			// If one side came up short (ex. fewer than half guns available), top back up from the other side
+			let curated = guns.concat( others );
+			if ( curated.length < sdLoadingScreen.PRELOAD_COUNT )
+			curated = curated.concat( assets.slice( curated.length, curated.length + ( sdLoadingScreen.PRELOAD_COUNT - curated.length ) ) );
+
+			assets = curated;
 		}
 
 		sdLoadingScreen.assets = assets;
@@ -501,6 +521,15 @@ class sdLoadingScreen
 
 		if ( sdLoadingScreen.assets.length === 0 )
 		return; // Nothing could be built (ex. classes not loaded yet for some reason) - just skip, leaving the old black-screen behavior rather than showing an empty overlay
+
+		// Warm every curated asset's sprite(s) right now, in one burst, instead of only ever loading
+		// the currently-displayed one - by the time the 2nd/3rd/etc. card comes up a few seconds from
+		// now, its image should already be cached rather than starting cold at the moment it's shown.
+		// MakeIcon's return value is unused here - only the side effect (triggering the image fetch via
+		// Draw() -> ctx.drawImageFilterCache -> img.RequiredNow()) matters. Wrapped per-asset so one
+		// misbehaving entry can't stop the rest from warming.
+		for ( let i = 0; i < sdLoadingScreen.assets.length; i++ )
+		try { sdLoadingScreen.MakeIcon( sdLoadingScreen.assets[ i ], i, 0 ); } catch ( e ) {}
 
 		sdLoadingScreen.showing = true;
 		sdLoadingScreen.canvas.style.display = 'block';

--- a/game/client/sdRenderer.js
+++ b/game/client/sdRenderer.js
@@ -2501,14 +2501,6 @@ class sdRenderer
             ctx.fillStyle = '#ffff00';
 			ctx.fillText( T("Score") + ": " + sdWorld.RoundedThousandsSpaces( sdWorld.my_score ), sdRenderer.screen_width - leaderboard_width - score_bar_width - 7, 35 );
             
-            if ( sdRenderer.display_coords )
-			if ( sdWorld.my_entity ) // Defensive - this whole HUD block is already gated on sdWorld.my_entity above, but keep this safe if that ever changes
-			{
-				ctx.textAlign = 'right'; // Anchor to the screen edge so the text can't run off-screen at narrow resolutions (previously left-aligned close to the edge, clipping the string)
-				ctx.fillStyle = '#ffffaa';
-				ctx.fillText("Coordinates: X = " + sdWorld.my_entity.x.toFixed( 0 ) + ", Y = " + sdWorld.my_entity.y.toFixed( 0 ), sdRenderer.screen_width - 10 * scale, sdRenderer.screen_height - 15 );
-			}
-            
             //ctx, x, y, v1, v2, color = "#ff0000", width = 20, height = 3, name
 
             ctx.textAlign = 'left';
@@ -2550,21 +2542,30 @@ class sdRenderer
 			}
 			if ( globalThis.enable_debug_info )
 			{
-				
+				let coords_line_offset = ( sdRenderer.display_coords && sdWorld.my_entity ) ? 15 : 0; // Shift this block up to leave room at the bottom corner for the coordinates line below, instead of overlapping it
+
 				ctx.fillStyle = '#ffffaa'; // By MrMcShroom / ZapruderFilm // EG: Could be also nice to eventually not let players know where they are exactly - maybe some in-game events would lead to that
-           		//ctx.fillText("Coordinates: X = " + sdWorld.my_entity.x.toFixed(0) + ", Y = " + sdWorld.my_entity.y.toFixed(0), 420, 50 );	
-				
-				ctx.fillText( sdRenderer.last_frame_times.length+" FPS", 10 * scale, sdRenderer.screen_height - 70 );
-				
-				ctx.fillText( "Entities: " + sdEntity.entities.length + " / " + sdEntity.active_entities.length + " / " + sdEntity.global_entities.length + " :: total / active / global" , 10 * scale, sdRenderer.screen_height - 55 );
-				
-				ctx.fillText("Mouse Coordinates: X = " + sdWorld.my_entity.look_x.toFixed(0) + ", Y = " + sdWorld.my_entity.look_y.toFixed(0), 10 * scale, sdRenderer.screen_height - 40 );
-				
-				ctx.fillText("Atlas textures and images: "+sdAtlasMaterial.textures_total_counter+" / "+sdAtlasMaterial.images_total_counter, 10 * scale, sdRenderer.screen_height - 25 );
-				
-				ctx.fillText("Last long server frame time took: " + Math.floor( sdWorld.last_frame_time ) + "ms (slowest case entity was "+sdWorld.last_slowest_class+")", 10 * scale, sdRenderer.screen_height - 10 );
+           		//ctx.fillText("Coordinates: X = " + sdWorld.my_entity.x.toFixed(0) + ", Y = " + sdWorld.my_entity.y.toFixed(0), 420, 50 );
+
+				ctx.fillText( sdRenderer.last_frame_times.length+" FPS", 10 * scale, sdRenderer.screen_height - 70 - coords_line_offset );
+
+				ctx.fillText( "Entities: " + sdEntity.entities.length + " / " + sdEntity.active_entities.length + " / " + sdEntity.global_entities.length + " :: total / active / global" , 10 * scale, sdRenderer.screen_height - 55 - coords_line_offset );
+
+				ctx.fillText("Mouse Coordinates: X = " + sdWorld.my_entity.look_x.toFixed(0) + ", Y = " + sdWorld.my_entity.look_y.toFixed(0), 10 * scale, sdRenderer.screen_height - 40 - coords_line_offset );
+
+				ctx.fillText("Atlas textures and images: "+sdAtlasMaterial.textures_total_counter+" / "+sdAtlasMaterial.images_total_counter, 10 * scale, sdRenderer.screen_height - 25 - coords_line_offset );
+
+				ctx.fillText("Last long server frame time took: " + Math.floor( sdWorld.last_frame_time ) + "ms (slowest case entity was "+sdWorld.last_slowest_class+")", 10 * scale, sdRenderer.screen_height - 10 - coords_line_offset );
 			}
-			
+
+			if ( sdRenderer.display_coords ) // Bottom-left corner (not bottom-right - that's where the "Track: ..." now-playing indicator lives) - stacks below globalThis.enable_debug_info's lines when both are on, via coords_line_offset above
+			if ( sdWorld.my_entity )
+			{
+				ctx.textAlign = 'left';
+				ctx.fillStyle = '#ffffaa';
+				ctx.fillText( "Coordinates: X = " + sdWorld.my_entity.x.toFixed( 0 ) + ", Y = " + sdWorld.my_entity.y.toFixed( 0 ), 10 * scale, sdRenderer.screen_height - 10 );
+			}
+
 			ctx.save();
 			ctx.translate( 15 * scale, 100 );
 			sdTask.DrawTaskList( ctx, scale );

--- a/game/client/sdRenderer.js
+++ b/game/client/sdRenderer.js
@@ -1108,6 +1108,9 @@ class sdRenderer
 							offsetB ? offsetB[ 2 ] : 0,
 							offsetC ? offsetC[ 2 ] : 0
 						);
+
+					if ( e._is_bg_entity === 1 ) // Background tiles/props (ex. sdBG) frequently have no ObjectOffset3D override, which ties their _sort at the same default (0) as many normal entities that also don't override it. Since visible_entities is sorted by descending _sort and drawn front-to-back-of-array (later array index paints over earlier ones), that tie was broken by incidental array order, letting BG randomly paint over normal entities. Force BG entities to the highest _sort so they always land first in the array and get painted first (i.e. behind everything else), regardless of ties.
+					e._sort += 1000000;
 				}
 				
 				/*if ( e.is( sdEffect ) )
@@ -2499,9 +2502,11 @@ class sdRenderer
 			ctx.fillText( T("Score") + ": " + sdWorld.RoundedThousandsSpaces( sdWorld.my_score ), sdRenderer.screen_width - leaderboard_width - score_bar_width - 7, 35 );
             
             if ( sdRenderer.display_coords )
+			if ( sdWorld.my_entity ) // Defensive - this whole HUD block is already gated on sdWorld.my_entity above, but keep this safe if that ever changes
 			{
+				ctx.textAlign = 'right'; // Anchor to the screen edge so the text can't run off-screen at narrow resolutions (previously left-aligned close to the edge, clipping the string)
 				ctx.fillStyle = '#ffffaa';
-				ctx.fillText("Coordinates: X = " + sdWorld.my_entity.x.toFixed( 0 ) + ", Y = " + sdWorld.my_entity.y.toFixed( 0 ), sdRenderer.screen_width - 120 * scale, sdRenderer.screen_height - 15 );
+				ctx.fillText("Coordinates: X = " + sdWorld.my_entity.x.toFixed( 0 ) + ", Y = " + sdWorld.my_entity.y.toFixed( 0 ), sdRenderer.screen_width - 10 * scale, sdRenderer.screen_height - 15 );
 			}
             
             //ctx, x, y, v1, v2, color = "#ff0000", width = 20, height = 3, name
@@ -2562,11 +2567,7 @@ class sdRenderer
 			
 			ctx.save();
 			ctx.translate( 15 * scale, 100 );
-			for ( let t = 0; t < sdTask.tasks.length; t++ )
-			{
-				let task = sdTask.tasks[ t ];
-				task.DrawTaskInterface( ctx, scale );
-			}
+			sdTask.DrawTaskList( ctx, scale );
 			ctx.restore();
 			
 			if ( sdRenderer.show_leader_board === 1 || sdRenderer.show_leader_board === 2 )

--- a/game/client/sdStartupScreen_v2.js
+++ b/game/client/sdStartupScreen_v2.js
@@ -951,14 +951,289 @@
 				default_option: 3
 			});
 			AddOption({ caption: `Instructor`, prefix: `hints`, condition: `entity === 1`,
-				options: { 
-					1:`Disabled`, 
-					2:`Enabled` 
+				options: {
+					1:`Disabled`,
+					2:`Enabled`
 				},
 				default_option: 2
 			});
-			
-			
+
+			// Local character profiles - lets a player keep several distinct local appearance/settings presets and switch between them,
+			// without ever letting an imported preset silently take over another server character (see safe-import notes below)
+			{
+				const LOCAL_PROFILES_KEY = 'sd_character_profiles_v1';
+				const PROFILE_IDENTITY_FIELDS = [ 'my_hash' ]; // Only ever restored from profiles that were saved on THIS browser (see SelectLocalProfile) - never from an imported file
+
+				globalThis.GetLocalProfiles = ()=>
+				{
+					try
+					{
+						let raw = localStorage.getItem( LOCAL_PROFILES_KEY );
+						if ( !raw )
+						return [];
+
+						let list = JSON.parse( raw );
+
+						if ( !Array.isArray( list ) )
+						return [];
+
+						return list;
+					}
+					catch( e )
+					{
+						return [];
+					}
+				};
+				globalThis.SetLocalProfiles = ( list )=>
+				{
+					try
+					{
+						localStorage.setItem( LOCAL_PROFILES_KEY, JSON.stringify( list ) );
+					}
+					catch( e ){}
+				};
+
+				let profile_select = null;
+
+				let RefreshProfileList = ()=>
+				{
+					if ( !profile_select )
+					return;
+
+					let list = globalThis.GetLocalProfiles();
+
+					profile_select.innerHTML = '';
+
+					let placeholder = document.createElement( 'option' );
+					placeholder.value = '';
+					placeholder.textContent = list.length ? '- Select a saved character -' : '- No saved characters yet -';
+					profile_select.append( placeholder );
+
+					for ( let i = 0; i < list.length; i++ )
+					{
+						let option_el = document.createElement( 'option' );
+						option_el.value = list[ i ].id;
+						option_el.textContent = list[ i ].name;
+						profile_select.append( option_el );
+					}
+				};
+
+				globalThis.SaveCurrentAsLocalProfile = ( existing_id=null )=>
+				{
+					let list = globalThis.GetLocalProfiles();
+
+					let previous_name = existing_id ? ( list.find( p=>p.id === existing_id ) || {} ).name : null;
+
+					let name = prompt( 'Name this character profile:', previous_name || 'My character' );
+
+					if ( !name )
+					return;
+
+					name = ( name + '' ).slice( 0, 40 );
+
+					// Captures every registered input, including my_hash - safe here because this profile is being
+					// saved FROM this browser's own current, already-in-use identity, not imported from elsewhere
+					let save = globalThis.SavePlayerSettingsAsObject();
+
+					let id = existing_id || ( 'profile_' + Date.now() + '_' + ( ~~( Math.random() * 1e9 ) ) );
+
+					let entry = { id, name, timestamp: Date.now(), save };
+
+					let idx = list.findIndex( p=>p.id === id );
+					if ( idx === -1 )
+					list.push( entry );
+					else
+					list[ idx ] = entry;
+
+					globalThis.SetLocalProfiles( list );
+					RefreshProfileList();
+					profile_select.value = id;
+				};
+
+				globalThis.SelectLocalProfile = ()=>
+				{
+					let id = profile_select ? profile_select.value : '';
+
+					if ( !id )
+					return;
+
+					let list = globalThis.GetLocalProfiles();
+					let profile = list.find( p=>p.id === id );
+
+					if ( !profile )
+					return;
+
+					// Safe to restore my_hash here too - this profile can only exist in sd_character_profiles_v1
+					// if it was saved from this same browser (SaveCurrentAsLocalProfile), so its my_hash already
+					// belongs to this device. This is a switch between your OWN local characters, not an import.
+					globalThis.LoadPlayerSettingsFromObject( profile.save );
+
+					globalThis.GetPlayerSettings();
+					globalThis.SavePlayerSettings();
+
+					globalThis.RandomizeSkin( 'push-state-only' );
+				};
+
+				globalThis.RenameLocalProfile = ()=>
+				{
+					let id = profile_select ? profile_select.value : '';
+					let list = globalThis.GetLocalProfiles();
+					let profile = list.find( p=>p.id === id );
+
+					if ( !profile )
+					{
+						alert( 'Select a saved character first.' );
+						return;
+					}
+
+					let name = prompt( 'Rename character profile:', profile.name );
+					if ( !name )
+					return;
+
+					profile.name = ( name + '' ).slice( 0, 40 );
+					globalThis.SetLocalProfiles( list );
+					RefreshProfileList();
+					profile_select.value = id;
+				};
+
+				globalThis.DeleteLocalProfile = ()=>
+				{
+					let id = profile_select ? profile_select.value : '';
+					let list = globalThis.GetLocalProfiles();
+					let profile = list.find( p=>p.id === id );
+
+					if ( !profile )
+					{
+						alert( 'Select a saved character first.' );
+						return;
+					}
+
+					if ( !confirm( 'Delete character profile "' + profile.name + '"?\n\nThis only removes the local shortcut - it does not delete or reset any server-side character.' ) )
+					return;
+
+					list = list.filter( p=>p.id !== id );
+					globalThis.SetLocalProfiles( list );
+					RefreshProfileList();
+				};
+
+				globalThis.ExportLocalProfile = ()=>
+				{
+					let id = profile_select ? profile_select.value : '';
+					let list = globalThis.GetLocalProfiles();
+					let profile = list.find( p=>p.id === id );
+
+					if ( !profile )
+					{
+						alert( 'Select a saved character first.' );
+						return;
+					}
+
+					let include_identity = confirm( 'Include your character identity in this export?\n\nChoose OK only if you are transferring this profile to your OWN other device or browser.\n\nChoose Cancel to share just the appearance/settings (recommended when sharing with someone else) - importing it elsewhere will spawn a fresh local character with this look instead of claiming your character.' );
+
+					let export_save = Object.assign( {}, profile.save );
+
+					if ( !include_identity )
+					for ( let field of PROFILE_IDENTITY_FIELDS )
+					delete export_save[ field ];
+
+					let payload = JSON.stringify({ sd_character_profile: 1, name: profile.name, save: export_save });
+
+					try
+					{
+						let blob = new Blob( [ payload ], { type: 'application/json' } );
+						let url = URL.createObjectURL( blob );
+						let a = document.createElement( 'a' );
+						a.href = url;
+						a.download = ( profile.name || 'character' ).replace( /[^a-z0-9_\- ]/gi, '_' ) + '.sdprofile.json';
+						document.body.append( a );
+						a.click();
+						a.remove();
+						setTimeout( ()=>URL.revokeObjectURL( url ), 1000 );
+					}
+					catch( e )
+					{
+						prompt( 'Copy this profile data:', payload );
+					}
+				};
+
+				globalThis.ImportLocalProfileFromFile = ( input_el )=>
+				{
+					let file = input_el.files && input_el.files[ 0 ];
+
+					if ( !file )
+					return;
+
+					let reader = new FileReader();
+					reader.onload = ()=>
+					{
+						input_el.value = '';
+
+						let parsed;
+						try
+						{
+							parsed = JSON.parse( reader.result );
+						}
+						catch( e )
+						{
+							alert( 'That file is not a valid character profile.' );
+							return;
+						}
+
+						if ( !parsed || typeof parsed.save !== 'object' || !parsed.save )
+						{
+							alert( 'That file is not a valid character profile.' );
+							return;
+						}
+
+						let imported_save = Object.assign( {}, parsed.save );
+
+						// Never adopt an imported identity - explicitly re-pin my_hash back to this device's current
+						// value (rather than deleting the key, which would let LoadPlayerSettingsFromObject write
+						// "undefined" into the field). Keeps this device's existing server character ownership intact
+						// no matter what the imported file contains.
+						imported_save.my_hash = inputs_hash[ 'my_hash' ] ? inputs_hash[ 'my_hash' ].el.value : undefined;
+
+						globalThis.LoadPlayerSettingsFromObject( imported_save );
+
+						globalThis.GetPlayerSettings();
+						globalThis.SavePlayerSettings();
+
+						globalThis.RandomizeSkin( 'push-state-only' );
+
+						// Snapshot AFTER applying (and AFTER re-pinning my_hash above), so this new local profile
+						// carries THIS device's own identity going forward, not the imported file's
+						let list = globalThis.GetLocalProfiles();
+						let id = 'profile_' + Date.now() + '_' + ( ~~( Math.random() * 1e9 ) );
+						list.push({ id, name: ( ( parsed.name || 'Imported character' ) + '' ).slice( 0, 40 ), timestamp: Date.now(), save: globalThis.SavePlayerSettingsAsObject() });
+						globalThis.SetLocalProfiles( list );
+						RefreshProfileList();
+						profile_select.value = id;
+
+						alert( 'Character appearance imported. If the server has no character under your current identity yet, you will spawn as a new character with this appearance.' );
+					};
+					reader.readAsText( file );
+				};
+
+				AddHTML(`
+					<settings_line>
+						<left>Saved characters:</left>
+						<right>
+							<select id="local_profile_select" style="width:220px" onchange="SelectLocalProfile()"></select>
+							<input style="width:120px" type="button" value="Save as new" onclick="SaveCurrentAsLocalProfile()">
+							<input style="width:100px" type="button" value="Update" onclick="SaveCurrentAsLocalProfile(document.getElementById('local_profile_select').value)">
+							<input style="width:100px" type="button" value="Rename" onclick="RenameLocalProfile()">
+							<input style="width:100px" type="button" value="Delete" onclick="DeleteLocalProfile()">
+							<input style="width:100px" type="button" value="Export" onclick="ExportLocalProfile()">
+							<input style="width:100px" type="button" value="Import" onclick="document.getElementById('local_profile_import_file').click()">
+							<input id="local_profile_import_file" type="file" accept="application/json,.json" style="display:none" onchange="ImportLocalProfileFromFile(this)">
+						</right>
+					</settings_line>
+				`);
+
+				profile_select = document.getElementById( 'local_profile_select' );
+				RefreshProfileList();
+			}
+
 			AddSoundsToNewButtons();
 		}
 		

--- a/game/client/sdStartupScreen_v2.js
+++ b/game/client/sdStartupScreen_v2.js
@@ -858,19 +858,28 @@
 			AddHTML(`
 				<settings_line>
 					<left>Colors:</left>
-					<right>
-						<input type="color" id="color_bright" value="#c0c0c0">
-						<input type="color" id="color_dark" value="#808080">
-						<input type="color" id="color_visor" value="#ff0000">
-						<input type="color" id="color_bright3" value="#c0c0c0">
-						<input type="color" id="color_dark3" value="#808080">
-						<input type="color" id="color_suit" value="#000080">
-						<input type="color" id="color_suit2" value="#000080">
-						<input type="color" id="color_dark2" value="#808080">
-						<input type="color" id="color_shoes" value="#000000">
-						<input type="color" id="color_skin" value="#808000">
-						<input type="color" id="color_extra1" value="#0000ff">
-						<input style="width:8vw" type="button" value="Undo" onclick="RandomizeSkin('undo')"><input style="width:8vw" type="button" value="Redo" onclick="RandomizeSkin('redo')">
+					<right style="display:flex; flex-wrap:wrap; align-items:flex-start;">
+						${ [
+							[ 'color_bright',  '#c0c0c0', 'Helmet (light)' ],
+							[ 'color_dark',    '#808080', 'Helmet (shadow)' ],
+							[ 'color_visor',   '#ff0000', 'Visor' ],
+							[ 'color_bright3', '#c0c0c0', 'Chest badge (light)' ],
+							[ 'color_dark3',   '#808080', 'Chest badge (shadow)' ],
+							[ 'color_suit',    '#000080', 'Jacket' ],
+							[ 'color_suit2',   '#000080', 'Legs' ],
+							[ 'color_dark2',   '#808080', 'Suit accent' ],
+							[ 'color_shoes',   '#000000', 'Shoes' ],
+							[ 'color_skin',    '#808000', 'Skin' ],
+							[ 'color_extra1',  '#0000ff', 'Extra accent' ]
+						].map( ( [ id, value, label ] )=>
+							`<span style="display:inline-flex; flex-direction:column; align-items:center; margin:0 0.3vw;">
+								<input type="color" id="${ id }" value="${ value }" title="${ label }">
+								<div style="font-size:0.65vw; color:#aaaaaa; white-space:nowrap; margin-top:0.1vw;">${ label }</div>
+							</span>`
+						).join('') }
+						<span style="display:inline-flex; flex-direction:column; justify-content:flex-end;">
+							<input style="width:8vw" type="button" value="Undo" onclick="RandomizeSkin('undo')"><input style="width:8vw" type="button" value="Redo" onclick="RandomizeSkin('redo')">
+						</span>
 					</right>
 				</settings_line>
 			`);

--- a/game/client/sdStartupScreen_v2.js
+++ b/game/client/sdStartupScreen_v2.js
@@ -91,6 +91,7 @@
 	let animation_appear = 'section_appear '+(anim_duration_ms/1000)+'s ease forwards';
 	let animation_disappear = 'section_disappear '+(anim_duration_ms/1000)+'s ease forwards';
 	let current_screen = null;
+	let pending_transition_timeout = null; // Rapid GoToScreen calls (ex. double-clicking, or clicking again before the 150ms fade finishes) used to stack overlapping setTimeout-deferred Proceed() calls, which could interrupt each other's CSS animation mid-flight and leave a screen stuck at a partial opacity (looks "blank"/invisible while technically still display:block). Cancelling any still-pending one before starting a new transition keeps only the latest requested navigation in flight.
 	let settings_screen_appearance_callbacks = []; // Scroll radio buttons, which is impossible if screen has display none
 	globalThis.page_background = document.getElementById( 'page_background' );
 	globalThis.page_foreground = document.getElementById( 'page_foreground' );
@@ -186,16 +187,21 @@
 					settings_screen_appearance_callbacks.length = 0;
 				}*/
 				
-				current_screen = new_screen;
 			};
-			
+
+			if ( pending_transition_timeout !== null ) // A previous GoToScreen call hasn't finished its fade yet - drop it rather than let both Proceed() calls fire and fight over current_screen/animation state
+			{
+				clearTimeout( pending_transition_timeout );
+				pending_transition_timeout = null;
+			}
+
 			if ( current_screen )
 			{
 				current_screen.parentNode.scroll({ behavior:'smooth', top:0 });
-				
+
 				current_screen.style.animation = animation_disappear;
 				current_screen.style.display = 'none';
-				
+
 				/*if ( current_screen.id === 'screen_menu' )
 				{
 					menu_defender.style.animation = animation_disappear;
@@ -204,15 +210,15 @@
 				if ( screen_callbacks[ current_screen.id ] )
 				if ( screen_callbacks[ current_screen.id ].onLeave )
 				screen_callbacks[ current_screen.id ].onLeave();
-				
-				//current_screen = new_screen;
-			
-				setTimeout( Proceed, anim_duration_ms );
+
+				current_screen = new_screen; // Updated synchronously (not inside Proceed) so a rapid follow-up GoToScreen call always sees the correct in-flight target, instead of racing against the still-pending timeout below
+
+				pending_transition_timeout = setTimeout( ()=>{ pending_transition_timeout = null; Proceed(); }, anim_duration_ms );
 			}
 			else
 			{
-				//current_screen = new_screen;
-				
+				current_screen = new_screen;
+
 				Proceed();
 			}
 		}
@@ -858,28 +864,28 @@
 			AddHTML(`
 				<settings_line>
 					<left>Colors:</left>
-					<right style="display:flex; flex-wrap:wrap; align-items:flex-start;">
-						${ [
-							[ 'color_bright',  '#c0c0c0', 'Helmet (light)' ],
-							[ 'color_dark',    '#808080', 'Helmet (shadow)' ],
-							[ 'color_visor',   '#ff0000', 'Visor' ],
-							[ 'color_bright3', '#c0c0c0', 'Chest badge (light)' ],
-							[ 'color_dark3',   '#808080', 'Chest badge (shadow)' ],
-							[ 'color_suit',    '#000080', 'Jacket' ],
-							[ 'color_suit2',   '#000080', 'Legs' ],
-							[ 'color_dark2',   '#808080', 'Suit accent' ],
-							[ 'color_shoes',   '#000000', 'Shoes' ],
-							[ 'color_skin',    '#808000', 'Skin' ],
-							[ 'color_extra1',  '#0000ff', 'Extra accent' ]
-						].map( ( [ id, value, label ] )=>
-							`<span style="display:inline-flex; flex-direction:column; align-items:center; margin:0 0.3vw;">
-								<input type="color" id="${ id }" value="${ value }" title="${ label }">
-								<div style="font-size:0.65vw; color:#aaaaaa; white-space:nowrap; margin-top:0.1vw;">${ label }</div>
-							</span>`
-						).join('') }
-						<span style="display:inline-flex; flex-direction:column; justify-content:flex-end;">
-							<input style="width:8vw" type="button" value="Undo" onclick="RandomizeSkin('undo')"><input style="width:8vw" type="button" value="Redo" onclick="RandomizeSkin('redo')">
-						</span>
+					<right>
+						<div style="display:grid; grid-template-columns:repeat(auto-fill, 5vw); column-gap:0.2vw; row-gap:0.4vw;">
+							${ [
+								[ 'color_bright',  '#c0c0c0', 'Helmet (light)' ],
+								[ 'color_dark',    '#808080', 'Helmet (shadow)' ],
+								[ 'color_visor',   '#ff0000', 'Visor' ],
+								[ 'color_bright3', '#c0c0c0', 'Chest badge (light)' ],
+								[ 'color_dark3',   '#808080', 'Chest badge (shadow)' ],
+								[ 'color_suit',    '#000080', 'Jacket' ],
+								[ 'color_suit2',   '#000080', 'Legs' ],
+								[ 'color_dark2',   '#808080', 'Suit accent' ],
+								[ 'color_shoes',   '#000000', 'Shoes' ],
+								[ 'color_skin',    '#808000', 'Skin' ],
+								[ 'color_extra1',  '#0000ff', 'Extra accent' ]
+							].map( ( [ id, value, label ] )=>
+								`<div style="display:flex; flex-direction:column; align-items:center;">
+									<input type="color" id="${ id }" value="${ value }" title="${ label }">
+									<div style="font-size:0.6vw; color:#aaaaaa; text-align:center; line-height:1.2; margin-top:0.1vw; background:rgba(20,20,20,0.35); border-radius:3px; padding:0.05vw 0.2vw; box-sizing:border-box;">${ label }</div>
+								</div>`
+							).join('') }
+						</div>
+						<input style="width:8vw; margin-top:0.5vw;" type="button" value="Undo" onclick="RandomizeSkin('undo')"><input style="width:8vw" type="button" value="Redo" onclick="RandomizeSkin('redo')">
 					</right>
 				</settings_line>
 			`);

--- a/game/client/sdStartupScreen_v2.js
+++ b/game/client/sdStartupScreen_v2.js
@@ -867,25 +867,27 @@
 					<right>
 						<div style="display:grid; grid-template-columns:repeat(auto-fill, 5vw); column-gap:0.2vw; row-gap:0.4vw;">
 							${ [
-								[ 'color_bright',  '#c0c0c0', 'Helmet (light)' ],
-								[ 'color_dark',    '#808080', 'Helmet (shadow)' ],
-								[ 'color_visor',   '#ff0000', 'Visor' ],
-								[ 'color_bright3', '#c0c0c0', 'Chest badge (light)' ],
-								[ 'color_dark3',   '#808080', 'Chest badge (shadow)' ],
-								[ 'color_suit',    '#000080', 'Jacket' ],
-								[ 'color_suit2',   '#000080', 'Legs' ],
-								[ 'color_dark2',   '#808080', 'Suit accent' ],
-								[ 'color_shoes',   '#000000', 'Shoes' ],
-								[ 'color_skin',    '#808000', 'Skin' ],
-								[ 'color_extra1',  '#0000ff', 'Extra accent' ]
-							].map( ( [ id, value, label ] )=>
+								[ 'color_bright',  '#c0c0c0', 'Helmet', 'Light' ],
+								[ 'color_dark',    '#808080', 'Helmet', 'Shadow' ],
+								[ 'color_visor',   '#ff0000', 'Visor', '' ],
+								[ 'color_bright3', '#c0c0c0', 'Chest badge', 'Light' ],
+								[ 'color_dark3',   '#808080', 'Chest badge', 'Shadow' ],
+								[ 'color_suit',    '#000080', 'Jacket', '' ],
+								[ 'color_suit2',   '#000080', 'Legs', '' ],
+								[ 'color_dark2',   '#808080', 'Suit', 'Accent' ],
+								[ 'color_shoes',   '#000000', 'Shoes', '' ],
+								[ 'color_skin',    '#808000', 'Skin', '' ],
+								[ 'color_extra1',  '#0000ff', 'Extra', 'Accent' ]
+							].map( ( [ id, value, label1, label2 ] )=>
 								`<div style="display:flex; flex-direction:column; align-items:center;">
-									<input type="color" id="${ id }" value="${ value }" title="${ label }">
-									<div style="font-size:0.6vw; color:#aaaaaa; text-align:center; line-height:1.2; margin-top:0.1vw; background:rgba(20,20,20,0.35); border-radius:3px; padding:0.05vw 0.2vw; box-sizing:border-box;">${ label }</div>
+									<input type="color" id="${ id }" value="${ value }" title="${ label1 }${ label2 ? ' (' + label2 + ')' : '' }">
+									<div style="width:100%; font-size:0.9vw; color:#cccccc; text-align:center; line-height:1.3; margin-top:0.15vw; background:rgba(20,20,20,0.35); border-radius:3px; padding:0.1vw 0.2vw; box-sizing:border-box;">${ label1 }${ label2 ? '<br>' + label2 : '' }</div>
 								</div>`
 							).join('') }
 						</div>
-						<input style="width:8vw; margin-top:0.5vw;" type="button" value="Undo" onclick="RandomizeSkin('undo')"><input style="width:8vw" type="button" value="Redo" onclick="RandomizeSkin('redo')">
+						<div style="margin-top:0.5vw;">
+							<input style="width:8vw;" type="button" value="Undo" onclick="RandomizeSkin('undo')"><input style="width:8vw" type="button" value="Redo" onclick="RandomizeSkin('redo')">
+						</div>
 					</right>
 				</settings_line>
 			`);

--- a/game/entities/sdGunClass.js
+++ b/game/entities/sdGunClass.js
@@ -49,7 +49,7 @@ class sdGunClass
 {
 	static init_class()
 	{
-		function AddRecolorsFromColorAndCost( arr, from_color, cost, prefix='', category='' )
+		function AddRecolorsFromColorAndCost( arr, from_color, cost, prefix='', category='', also_set_projectile_color=false ) // also_set_projectile_color: for guns whose projectile/beam is drawn from gun.extra[ sdGun.ID_PROJECTILE_COLOR ] rather than a re-tinted sprite (ex. rail beams), the sd_filter recolor below never reaches the projectile - opt in per-gun instead of changing this shared helper's default behavior for everyone else
 		{
 			/*let colors = [
 				'cyan', '#00fff6',
@@ -88,7 +88,7 @@ class sdGunClass
 				//hint_color: '#ff0000', // Should be guessed from gun
 				color_picker_for: from_color,
 				action: ( gun, initiator=null, hex_color=null )=> // action method is called with 3rd parameter only because .color_picker_for is causing sdWeaponBench to send extra parameters at .AddColorPickerContextOption . It does not send first parameter from "parameters_array" which is passed to .ExecuteContextCommand as it contains just upgrade ID, which is pointless here (yes, it converts array into function arguments)
-				{ 
+				{
 					if ( typeof hex_color === 'string' && hex_color.length === 7 ) // ReplaceColorInSDFilter_v2 does the type check but just in case
 					{
 						if ( !gun.sd_filter )
@@ -98,6 +98,10 @@ class sdGunClass
 
 						sdWorld.ReplaceColorInSDFilter_v2( gun.sd_filter, from_color, hex_color );
 						//sdWorld.ReplaceColorInSDFilter_v2( gun.sd_filter, from_color, '#00ff00' );
+
+						if ( also_set_projectile_color )
+						if ( !hasNoExtra( gun, initiator ) )
+						gun.extra[ sdGun.ID_PROJECTILE_COLOR ] = hex_color;
 					}
 				}
 			});
@@ -1990,9 +1994,9 @@ class sdGunClass
 				else
 				return false;
 			},
-			upgrades: AddGunDefaultUpgrades( AddRecolorsFromColorAndCost( [], '#bf1d00', 30 ) )
+			upgrades: AddGunDefaultUpgrades( AddRecolorsFromColorAndCost( [], '#bf1d00', 30, '', '', true ) ) // also_set_projectile_color: true - this is a rail/beam weapon, its beam color comes from gun.extra[ ID_PROJECTILE_COLOR ] (see projectile_properties_dynamic above), not from the sprite recolor alone
 		};
-		
+
 		sdGun.classes[ sdGun.CLASS_CUBE_SHARD = 22 ] = 
 		{
 			image: sdWorld.CreateImageFromFile( 'cube_shard2' ),

--- a/game/entities/sdRescueTeleport.js
+++ b/game/entities/sdRescueTeleport.js
@@ -138,30 +138,30 @@ class sdRescueTeleport extends sdEntity
 							if ( any_is_suitable )
 							{
 								if ( !is_deeply_within_range )
-								sdTask.MakeSureCharacterHasTask({ 
-									similarity_hash:'RTP-HINT', 
+								sdTask.MakeSureCharacterHasTask({
+									similarity_hash:'RTP-HINT',
 									executer: character,
 									mission: sdTask.MISSION_GAMEPLAY_HINT,
-									title: 'Rescue Teleport signal is weak',
+									title: sdTask.TITLE_RESCUE_TELEPORT_SIGNAL_WEAK,
 									description: 'You are likely leaving effective range of your Rescue Teleport.'
 								});
 							}
 							else
 							{
 								if ( available_rtps.length === 0 && character._score < 100 )
-								sdTask.MakeSureCharacterHasTask({ 
-									similarity_hash:'RTP-HINT', 
+								sdTask.MakeSureCharacterHasTask({
+									similarity_hash:'RTP-HINT',
 									executer: character,
 									mission: sdTask.MISSION_GAMEPLAY_HINT,
-									title: 'Rescue Teleport required',
+									title: sdTask.TITLE_RESCUE_TELEPORT_REQUIRED,
 									description: 'You\'ll need a Rescue Teleport to keep your chances of survival high! You\'ll need matter from crystals to both build and charge it. Use Build Tool (B key) to build.'
 								});
 								else
-								sdTask.MakeSureCharacterHasTask({ 
-									similarity_hash:'RTP-HINT', 
+								sdTask.MakeSureCharacterHasTask({
+									similarity_hash:'RTP-HINT',
 									executer: character,
 									mission: sdTask.MISSION_GAMEPLAY_HINT,
-									title: 'Rescue Teleport signal lost',
+									title: sdTask.TITLE_RESCUE_TELEPORT_SIGNAL_LOST,
 									description: 'Signal with your Rescue Teleport has been lost.'
 								});
 							}

--- a/game/entities/sdTask.js
+++ b/game/entities/sdTask.js
@@ -563,8 +563,13 @@ class sdTask extends sdEntity
 		let expanded = sdRenderer.show_leader_board === 3; // Dedicated tasks-only view - give full details for every task
 		let shown = expanded ? visible_tasks.length : Math.min( visible_tasks.length, sdTask.MAX_COMPACT_TASKS );
 
+		// The caller (sdRenderer) translates to x = 15 * scale before this draws, so this is the width remaining
+		// to the right screen edge (with a matching margin) - null keeps the narrow, fixed-character-count wrap
+		// used by the compact HUD column, since that one was never meant to use the whole screen.
+		let max_width = expanded ? ( sdRenderer.screen_width - 30 * scale ) : null;
+
 		for ( let t = 0; t < shown; t++ )
-		visible_tasks[ t ].DrawTaskInterface( ctx, scale );
+		visible_tasks[ t ].DrawTaskInterface( ctx, scale, max_width );
 
 		let hidden_count = visible_tasks.length - shown;
 		if ( hidden_count > 0 )
@@ -1248,49 +1253,74 @@ class sdTask extends sdEntity
 		ctx.filter = 'none';
 	}
 	
-	DrawTaskInterface( ctx, scale )
+	DrawTaskInterface( ctx, scale, max_width=null ) // max_width (in pixels, post-translate): when given, wraps text by actually measured pixel width instead of the fixed 40-character guess, so it can be widened for the expanded (Tab) view instead of staying stuck in the narrow default HUD column
 	{
 		if ( sdRenderer.show_leader_board === 0 || sdRenderer.show_leader_board === 2 )
 		return;
-	
+
 		let mission = sdTask.missions[ this.mission ];
-		
+
 		if ( !mission )
 		{
 			return;
 		}
-		
+
 		let task_title_color = mission.task_title_color || sdTask.COLOR_NOTIFICATION;
-		
+
 		if ( task_title_color instanceof Function )
 		task_title_color = task_title_color();
 
 		ctx.font = 11*scale + "px Verdana";
-		
+
 		const PutMultilineText = ( text, subtext=false )=>
 		{
 			let later_text = null;
-			
-			const break_each = 40;
-			
-			if ( text.length > break_each )
+
+			if ( max_width !== null )
 			{
-				let parts = text.split(' ');
-				let length = 0;
-				for ( let p = 0; p < parts.length; p++ )
+				// Pixel-accurate wrap: only break once the actual rendered width would exceed max_width,
+				// so widening max_width (ex. for the expanded view) actually results in fewer/longer lines
+				// instead of always wrapping at a fixed character count regardless of available space.
+				if ( ctx.measureText( text ).width > max_width )
 				{
-					let word_size = parts[ p ].length;
-					if ( p > 0 )
-					if ( length + word_size > break_each )
+					let parts = text.split(' ');
+					let line = '';
+					for ( let p = 0; p < parts.length; p++ )
 					{
-						text = parts.slice( 0, p ).join(' ');
-						later_text = parts.slice( p ).join(' ');
-						break;
+						let candidate = line ? ( line + ' ' + parts[ p ] ) : parts[ p ];
+						if ( line && ctx.measureText( candidate ).width > max_width )
+						{
+							text = line;
+							later_text = parts.slice( p ).join(' ');
+							break;
+						}
+						line = candidate;
 					}
-					length += word_size;
 				}
 			}
-			
+			else
+			{
+				const break_each = 40;
+
+				if ( text.length > break_each )
+				{
+					let parts = text.split(' ');
+					let length = 0;
+					for ( let p = 0; p < parts.length; p++ )
+					{
+						let word_size = parts[ p ].length;
+						if ( p > 0 )
+						if ( length + word_size > break_each )
+						{
+							text = parts.slice( 0, p ).join(' ');
+							later_text = parts.slice( p ).join(' ');
+							break;
+						}
+						length += word_size;
+					}
+				}
+			}
+
 			let last_style = ctx.fillStyle;
 			ctx.fillStyle = '#000000';
 			ctx.fillText( text, subtext ? 5 * scale : 1, 1 );

--- a/game/entities/sdTask.js
+++ b/game/entities/sdTask.js
@@ -567,13 +567,45 @@ class sdTask extends sdEntity
 		}
 
 		let expanded = sdRenderer.show_leader_board === 3; // Dedicated tasks-only view - give full details for every task
-		let shown = expanded ? visible_tasks.length : Math.min( visible_tasks.length, sdTask.MAX_COMPACT_TASKS );
 
 		// The caller (sdRenderer) translates to x = 15 * scale before this draws, so this is the width remaining
 		// to the right screen edge (with a matching margin) - null keeps the narrow, fixed-character-count wrap
 		// used by the compact HUD column, since that one was never meant to use the whole screen.
 		let max_width = expanded ? ( sdRenderer.screen_width - 30 * scale ) : null;
 
+		let shown;
+
+		if ( !expanded )
+		shown = Math.min( visible_tasks.length, sdTask.MAX_COMPACT_TASKS );
+		else
+		{
+			// Full list can easily run taller than the screen (each task can span several wrapped lines) - use a
+			// denser layout (compact=true) so more fit, and hard-stop once we'd draw past the bottom of the screen
+			// instead of letting the rest silently render off-screen, listing whatever didn't fit as "+N more".
+			const bottom_margin = 40 * scale;
+			const max_y = sdRenderer.screen_height - bottom_margin;
+
+			shown = 0;
+
+			for ( let t = 0; t < visible_tasks.length; t++ )
+			{
+				let y_before = ctx.getTransform().f;
+
+				visible_tasks[ t ].DrawTaskInterface( ctx, scale, max_width, true );
+
+				if ( ctx.getTransform().f > max_y )
+				{
+					let m = ctx.getTransform();
+					m.f = y_before; // Undo this task's translate - it either didn't fit at all, or only partially did, so don't count or leave a half-drawn gap for it
+					ctx.setTransform( m );
+					break;
+				}
+
+				shown++;
+			}
+		}
+
+		if ( !expanded )
 		for ( let t = 0; t < shown; t++ )
 		visible_tasks[ t ].DrawTaskInterface( ctx, scale, max_width );
 
@@ -584,7 +616,7 @@ class sdTask extends sdEntity
 			ctx.fillStyle = '#aaaaaa';
 			ctx.font = 11*scale + "px Verdana";
 			ctx.textAlign = 'left';
-			ctx.fillText( '+' + hidden_count + ' more ' + T('task') + ( hidden_count === 1 ? '' : 's' ) + ' (' + T('Tab to expand') + ')', 0, 11*scale );
+			ctx.fillText( '+' + hidden_count + ' more ' + T('task') + ( hidden_count === 1 ? '' : 's' ) + ( expanded ? '' : ' (' + T('Tab to expand') + ')' ), 0, 11*scale );
 			ctx.translate( 0, ( 11 + 5 ) * scale );
 			ctx.globalAlpha = 1;
 		}
@@ -1268,7 +1300,7 @@ class sdTask extends sdEntity
 		ctx.filter = 'none';
 	}
 	
-	DrawTaskInterface( ctx, scale, max_width=null ) // max_width (in pixels, post-translate): when given, wraps text by actually measured pixel width instead of the fixed 40-character guess, so it can be widened for the expanded (Tab) view instead of staying stuck in the narrow default HUD column
+	DrawTaskInterface( ctx, scale, max_width=null, compact=false ) // max_width (in pixels, post-translate): when given, wraps text by actually measured pixel width instead of the fixed 40-character guess, so it can be widened for the expanded (Tab) view instead of staying stuck in the narrow default HUD column. compact: smaller font/line-pitch, used by the expanded (Tab) view so more tasks fit on screen
 	{
 		if ( sdRenderer.show_leader_board === 0 || sdRenderer.show_leader_board === 2 )
 		return;
@@ -1285,7 +1317,10 @@ class sdTask extends sdEntity
 		if ( task_title_color instanceof Function )
 		task_title_color = task_title_color();
 
-		ctx.font = 11*scale + "px Verdana";
+		const font_size = compact ? 9 : 11;
+		const line_pitch = compact ? ( 9 + 3 ) : ( 11 + 5 );
+
+		ctx.font = font_size*scale + "px Verdana";
 
 		const PutMultilineText = ( text, subtext=false )=>
 		{
@@ -1342,8 +1377,8 @@ class sdTask extends sdEntity
 			ctx.fillStyle = last_style;
 			
 			ctx.fillText( text, subtext ? 5 * scale : 0, 0 );
-			ctx.translate( 0, ( 11 + 5 ) * scale );
-			
+			ctx.translate( 0, line_pitch * scale );
+
 			if ( later_text !== null )
 			PutMultilineText( later_text, subtext );
 		};
@@ -1386,7 +1421,7 @@ class sdTask extends sdEntity
 		
 		ctx.globalAlpha = 1;
 		ctx.filter = 'none';
-		ctx.translate( 0, ( 11 + 5 ) * scale );
+		ctx.translate( 0, line_pitch * scale );
 	}
 }
 export default sdTask;

--- a/game/entities/sdTask.js
+++ b/game/entities/sdTask.js
@@ -34,8 +34,14 @@ class sdTask extends sdEntity
 		sdTask.COLOR_PROTECT = ()=>{ return sdWorld.time % 2000 < 1000 ? '#7777ff' : '#3333ff'; };
 		
 		sdTask.completed_tasks_count = 0; // Whenever someone completes a task, this increases value by 1. Used to spawn SD Item pods
-		
+
 		//sdTask.reward_claim_task_amount = 0.5; // was 1 // EG: Let's not have too many multipliers all over the project
+
+		// Shared with sdRescueTeleport.js, which creates the RTP-HINT task under one of these exact titles depending on
+		// state. Kept as constants (rather than matching literal strings at sort time) so the two can't drift apart.
+		sdTask.TITLE_RESCUE_TELEPORT_REQUIRED = 'Rescue Teleport required';
+		sdTask.TITLE_RESCUE_TELEPORT_SIGNAL_LOST = 'Rescue Teleport signal lost';
+		sdTask.TITLE_RESCUE_TELEPORT_SIGNAL_WEAK = 'Rescue Teleport signal is weak';
 		
 		sdTask.missions = [];
 		
@@ -1067,13 +1073,22 @@ class sdTask extends sdEntity
 		}
 	}
 	
+	static IsAlwaysTopPriority( task ) // All 3 RTP-HINT states must always rank above every other task, regardless of _difficulty - checked by title (not baked in at creation time) since MakeSureCharacterHasTask can update an existing RTP-HINT task's title in place rather than recreating it
+	{
+		return task.title === sdTask.TITLE_RESCUE_TELEPORT_REQUIRED || task.title === sdTask.TITLE_RESCUE_TELEPORT_SIGNAL_LOST || task.title === sdTask.TITLE_RESCUE_TELEPORT_SIGNAL_WEAK;
+	}
 	static GlobalThink( GSPEED )
 	{
 		if ( sdTask.sort_tasks )
 		{
 			sdTask.sort_tasks = false;
-			
-			sdTask.tasks.sort( (a,b)=>b._difficulty-a._difficulty );
+
+			sdTask.tasks.sort( (a,b)=>{
+				let a_top = sdTask.IsAlwaysTopPriority( a ) ? 1 : 0;
+				let b_top = sdTask.IsAlwaysTopPriority( b ) ? 1 : 0;
+
+				return ( b_top - a_top ) || ( b._difficulty - a._difficulty );
+			});
 		}
 	}
 	

--- a/game/entities/sdTask.js
+++ b/game/entities/sdTask.js
@@ -543,8 +543,42 @@ class sdTask extends sdEntity
 		
 		sdTask.tasks = [];
 		sdTask.sort_tasks = false;
+
+		sdTask.MAX_COMPACT_TASKS = 3; // Default HUD shows only the top-priority tasks plus a collapsed count for the rest, to avoid clogging the left side of the screen
 	}
-	
+	static DrawTaskList( ctx, scale ) // Draws sdTask.tasks as a compact HUD list (top-priority tasks + collapsed count), or the full list when the player expands it via Tab (sdRenderer.show_leader_board === 3)
+	{
+		if ( sdRenderer.show_leader_board === 0 || sdRenderer.show_leader_board === 2 )
+		return;
+
+		let visible_tasks = [];
+		for ( let t = 0; t < sdTask.tasks.length; t++ )
+		{
+			let task = sdTask.tasks[ t ];
+			if ( task._is_being_removed )
+			continue;
+			visible_tasks.push( task );
+		}
+
+		let expanded = sdRenderer.show_leader_board === 3; // Dedicated tasks-only view - give full details for every task
+		let shown = expanded ? visible_tasks.length : Math.min( visible_tasks.length, sdTask.MAX_COMPACT_TASKS );
+
+		for ( let t = 0; t < shown; t++ )
+		visible_tasks[ t ].DrawTaskInterface( ctx, scale );
+
+		let hidden_count = visible_tasks.length - shown;
+		if ( hidden_count > 0 )
+		{
+			ctx.globalAlpha = 0.75;
+			ctx.fillStyle = '#aaaaaa';
+			ctx.font = 11*scale + "px Verdana";
+			ctx.textAlign = 'left';
+			ctx.fillText( '+' + hidden_count + ' more ' + T('task') + ( hidden_count === 1 ? '' : 's' ) + ' (' + T('Tab to expand') + ')', 0, 11*scale );
+			ctx.translate( 0, ( 11 + 5 ) * scale );
+			ctx.globalAlpha = 1;
+		}
+	}
+
 	static WakeUpTasksFor( character )
 	{
 		for ( let i = 0; i < sdTask.tasks.length; i++ )

--- a/game/entities/sdTask.js
+++ b/game/entities/sdTask.js
@@ -1317,8 +1317,8 @@ class sdTask extends sdEntity
 		if ( task_title_color instanceof Function )
 		task_title_color = task_title_color();
 
-		const font_size = compact ? 9 : 11;
-		const line_pitch = compact ? ( 9 + 3 ) : ( 11 + 5 );
+		const font_size = compact ? 12 : 11; // compact (expanded Tab view) was 9 - too small to comfortably read
+		const line_pitch = compact ? ( 12 + 3 ) : ( 11 + 5 );
 
 		ctx.font = font_size*scale + "px Verdana";
 

--- a/game/entities/sdTask.js
+++ b/game/entities/sdTask.js
@@ -593,11 +593,11 @@ class sdTask extends sdEntity
 
 				visible_tasks[ t ].DrawTaskInterface( ctx, scale, max_width, true );
 
-				if ( ctx.getTransform().f > max_y )
+				let y_after = ctx.getTransform().f;
+
+				if ( y_after > max_y )
 				{
-					let m = ctx.getTransform();
-					m.f = y_before; // Undo this task's translate - it either didn't fit at all, or only partially did, so don't count or leave a half-drawn gap for it
-					ctx.setTransform( m );
+					ctx.translate( 0, y_before - y_after ); // Undo this task's translate (relative, not an absolute setTransform - FakeCanvasContext's getTransform() is read-only) - it either didn't fit at all, or only partially did, so don't count or leave a half-drawn gap for it
 					break;
 				}
 

--- a/game/entities/sdTeleport.js
+++ b/game/entities/sdTeleport.js
@@ -163,14 +163,13 @@ class sdTeleport extends sdEntity
 	}
     Draw( ctx, attached )
 	{
-        if ( this.delay === 0 )
-		ctx.apply_shading = false;
+        let com_near = this.GetComWiredCache();
 
         let xx = 0;
 		let yy = 0;
-		
-		
-		if ( this.GetComWiredCache() || sdShop.isDrawing )
+
+
+		if ( com_near || sdShop.isDrawing )
 		{
 			if ( this.delay === 0 || sdShop.isDrawing )
 			yy = 0;
@@ -179,6 +178,9 @@ class sdTeleport extends sdEntity
 		}
 		else
 		yy = 2;
+
+		if ( yy === 0 ) // Only the wired-and-ready state should glow fullbright. Previously this only checked `this.delay === 0`, which is also true for an unwired/disconnected teleport (delay defaults to 0 and never changes without a com_near), making disabled teleports incorrectly render fullbright too.
+		ctx.apply_shading = false;
 		
 		if ( this.half_size === 16 )
 		{

--- a/game/entities/sdTurret.js
+++ b/game/entities/sdTurret.js
@@ -88,43 +88,6 @@ class sdTurret extends sdEntity
         
         sdTurret.img_turret9 = sdWorld.CreateImageFromFile( 'turret9' );
 		
-		sdTurret.targetable_classes = new WeakSet( [ 
-			sdCharacter, 
-			sdVirus, 
-			sdQuickie, 
-			sdOctopus, 
-			sdCube, 
-			//sdBomb, 
-			sdAsp, 
-			sdSandWorm, 
-			sdSlug, 
-			sdGrub, 
-			sdGuanako, 
-			sdShark, 
-			sdEnemyMech, 
-			sdDrone, 
-			sdBadDog, 
-			sdShark, 
-			sdSpider, 
-			sdTutel,
-			sdFaceCrab,
-			sdSetrDestroyer,
-			sdWorld.entity_classes.sdOverlord,
-			sdWorld.entity_classes.sdPlayerDrone,
-			sdWorld.entity_classes.sdAmphid,
-			sdWorld.entity_classes.sdPlayerOverlord,
-			sdBiter,
-			sdAbomination,
-			sdMimic,
-			sdTzyrgAbsorber,
-			sdVeloxMiner,
-			sdWorld.entity_classes.sdShurgTurret,
-			sdZektaronDreadnought,
-			sdStealer,
-			sdCouncilIncinerator,
-			sdMeow
-			
-		] ); // Module random load order that causes error prevention
         
         sdTurret.disallowed_weapons = [
             sdGun.CLASS_LOST_CONVERTER,
@@ -164,6 +127,50 @@ class sdTurret extends sdEntity
 		sdTurret.portable_fake_com = { _net_id: 0, subscribers:[ 'sdCharacter', 'sdPlayerDrone' ] };
 		
 		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
+	}
+	static get targetable_classes() // Built lazily on first use (not in init_class()) since some of these classes are only reachable via sdWorld.entity_classes.X - which depends on THEIR init_class() having already run, and dynamic-import resolution order across ~150+ entity files is not guaranteed. Built eagerly here it would intermittently throw (WeakSet rejects the undefined entries) and take the whole client bootstrap down with it depending on load order.
+	{
+		if ( sdTurret._targetable_classes_cache )
+		return sdTurret._targetable_classes_cache;
+
+		sdTurret._targetable_classes_cache = new WeakSet( [
+			sdCharacter,
+			sdVirus,
+			sdQuickie,
+			sdOctopus,
+			sdCube,
+			//sdBomb,
+			sdAsp,
+			sdSandWorm,
+			sdSlug,
+			sdGrub,
+			sdGuanako,
+			sdShark,
+			sdEnemyMech,
+			sdDrone,
+			sdBadDog,
+			sdShark,
+			sdSpider,
+			sdTutel,
+			sdFaceCrab,
+			sdSetrDestroyer,
+			sdWorld.entity_classes.sdOverlord,
+			sdWorld.entity_classes.sdPlayerDrone,
+			sdWorld.entity_classes.sdAmphid,
+			sdWorld.entity_classes.sdPlayerOverlord,
+			sdBiter,
+			sdAbomination,
+			sdMimic,
+			sdTzyrgAbsorber,
+			sdVeloxMiner,
+			sdWorld.entity_classes.sdShurgTurret,
+			sdZektaronDreadnought,
+			sdStealer,
+			sdCouncilIncinerator,
+			sdMeow
+		].filter( ( cls )=>cls ) ); // Defensive: skip any class that still somehow was not registered yet, rather than throwing and losing just that one class as a valid turret target
+
+		return sdTurret._targetable_classes_cache;
 	}
 	get hitbox_x1() { return this.kind === sdTurret.KIND_SENTRY ? -8 : -this.GetSize(); }
 	get hitbox_x2() { return this.kind === sdTurret.KIND_SENTRY ? 8 : this.GetSize(); }

--- a/game/game.js
+++ b/game/game.js
@@ -445,6 +445,7 @@ let class_names = ( await ( await fetch( '/get_classes.txt' ) ).text() ).split('
 
 	import sdAtlasMaterial from './client/sdAtlasMaterial.js';
 	import sdRenderer from './client/sdRenderer.js';
+	import sdLoadingScreen from './client/sdLoadingScreen.js';
 	import sdShop from './client/sdShop.js';
 	import sdChat from './client/sdChat.js';
 	import sdContextMenu from './client/sdContextMenu.js';
@@ -656,7 +657,9 @@ let enf_once = true;
 	imported_entity_classes[ i ].init_class();
 
 	sdEntity.AllEntityClassesLoadedAndInitiated();
-	
+
+	sdLoadingScreen.init_class();
+
 	/*sdEntity.init_class();
 	sdCharacter.init_class();
 	sdPlayerDrone.init_class();
@@ -740,6 +743,7 @@ let enf_once = true;
 	globalThis.online_socket = socket;
 	
 	globalThis.sdRenderer = sdRenderer;
+	globalThis.sdLoadingScreen = sdLoadingScreen;
 	globalThis.sdSound = sdSound;
 	globalThis.sdShop = sdShop;
 	globalThis.sdChat = sdChat;

--- a/game/libs/FakeCanvasContext.js
+++ b/game/libs/FakeCanvasContext.js
@@ -764,11 +764,18 @@ class FakeCanvasContext
 	resetTransform()
 	{
 		this.save_stack.length = 0;
-		
+
 		if ( sdRenderer.visual_settings === 4 )
 		this._matrix3.identity();
 		else
 		this.transform.identity();
+	}
+	getTransform() // Minimal, read-only - only ever used by sdTask.js's expanded-task-list overflow check, which only reads the Y-translation component (.f) to measure how far a task's render moved the cursor down. Not a full DOMMatrix - callers should use ctx.translate() to adjust position, not feed this back into setTransform().
+	{
+		if ( sdRenderer.visual_settings === 4 )
+		return { f: this._matrix3.elements[ 7 ] };
+
+		return { f: this.transform.elements[ 13 ] };
 	}
 	fillText( text, x, y, max_width=undefined )
 	{	

--- a/game/loading_tips.json
+++ b/game/loading_tips.json
@@ -1,0 +1,1151 @@
+{
+	"_readme": "Tooltip text shown on the loading screen carousel while cycling through each entity/gun. Fill in \"tip\" for each entry (leave \"\" to skip - that entry will just show its title with no tip text). \"title\" is a suggested display name and can be edited too.",
+	"entities": {
+		"sdAbomination": {
+			"title": "sdAbomination",
+			"tip": ""
+		},
+		"sdAmphid": {
+			"title": "sdAmphid",
+			"tip": ""
+		},
+		"sdAntigravity": {
+			"title": "sdAntigravity",
+			"tip": ""
+		},
+		"sdArea": {
+			"title": "sdArea",
+			"tip": ""
+		},
+		"sdAsp": {
+			"title": "sdAsp",
+			"tip": ""
+		},
+		"sdAsteroid": {
+			"title": "sdAsteroid",
+			"tip": ""
+		},
+		"sdBG": {
+			"title": "sdBG",
+			"tip": ""
+		},
+		"sdBSUTurret": {
+			"title": "sdBSUTurret",
+			"tip": ""
+		},
+		"sdBadDog": {
+			"title": "sdBadDog",
+			"tip": ""
+		},
+		"sdBall": {
+			"title": "sdBall",
+			"tip": ""
+		},
+		"sdBarrel": {
+			"title": "sdBarrel",
+			"tip": ""
+		},
+		"sdBaseShieldingUnit": {
+			"title": "sdBaseShieldingUnit",
+			"tip": ""
+		},
+		"sdBeacon": {
+			"title": "sdBeacon",
+			"tip": ""
+		},
+		"sdBeamProjector": {
+			"title": "sdBeamProjector",
+			"tip": ""
+		},
+		"sdBiter": {
+			"title": "sdBiter",
+			"tip": ""
+		},
+		"sdBlock": {
+			"title": "sdBlock",
+			"tip": ""
+		},
+		"sdBloodDecal": {
+			"title": "sdBloodDecal",
+			"tip": ""
+		},
+		"sdBomb": {
+			"title": "sdBomb",
+			"tip": ""
+		},
+		"sdBone": {
+			"title": "sdBone",
+			"tip": ""
+		},
+		"sdBot": {
+			"title": "sdBot",
+			"tip": ""
+		},
+		"sdBotCharger": {
+			"title": "sdBotCharger",
+			"tip": ""
+		},
+		"sdBotFactory": {
+			"title": "sdBotFactory",
+			"tip": ""
+		},
+		"sdBubbleShield": {
+			"title": "sdBubbleShield",
+			"tip": ""
+		},
+		"sdBullet": {
+			"title": "sdBullet",
+			"tip": ""
+		},
+		"sdButton": {
+			"title": "sdButton",
+			"tip": ""
+		},
+		"sdCable": {
+			"title": "sdCable",
+			"tip": ""
+		},
+		"sdCamera": {
+			"title": "sdCamera",
+			"tip": ""
+		},
+		"sdCapsulePod": {
+			"title": "sdCapsulePod",
+			"tip": ""
+		},
+		"sdCaption": {
+			"title": "sdCaption",
+			"tip": ""
+		},
+		"sdCharacter": {
+			"title": "sdCharacter",
+			"tip": ""
+		},
+		"sdCom": {
+			"title": "sdCom",
+			"tip": ""
+		},
+		"sdCommandCentre": {
+			"title": "sdCommandCentre",
+			"tip": ""
+		},
+		"sdConveyor": {
+			"title": "sdConveyor",
+			"tip": ""
+		},
+		"sdCouncilIncinerator": {
+			"title": "sdCouncilIncinerator",
+			"tip": ""
+		},
+		"sdCouncilMachine": {
+			"title": "sdCouncilMachine",
+			"tip": ""
+		},
+		"sdCouncilNullifier": {
+			"title": "sdCouncilNullifier",
+			"tip": ""
+		},
+		"sdCraftingBench": {
+			"title": "sdCraftingBench",
+			"tip": ""
+		},
+		"sdCrystal": {
+			"title": "sdCrystal",
+			"tip": ""
+		},
+		"sdCrystalCombiner": {
+			"title": "sdCrystalCombiner",
+			"tip": ""
+		},
+		"sdCube": {
+			"title": "sdCube",
+			"tip": ""
+		},
+		"sdDeepSleep": {
+			"title": "sdDeepSleep",
+			"tip": ""
+		},
+		"sdDoor": {
+			"title": "sdDoor",
+			"tip": ""
+		},
+		"sdDrone": {
+			"title": "sdDrone",
+			"tip": ""
+		},
+		"sdDropPod": {
+			"title": "sdDropPod",
+			"tip": ""
+		},
+		"sdEffect": {
+			"title": "sdEffect",
+			"tip": ""
+		},
+		"sdEnemyMech": {
+			"title": "sdEnemyMech",
+			"tip": ""
+		},
+		"sdEssenceExtractor": {
+			"title": "sdEssenceExtractor",
+			"tip": ""
+		},
+		"sdExcavator": {
+			"title": "sdExcavator",
+			"tip": ""
+		},
+		"sdFaceCrab": {
+			"title": "sdFaceCrab",
+			"tip": ""
+		},
+		"sdFactionSpawner": {
+			"title": "sdFactionSpawner",
+			"tip": ""
+		},
+		"sdFactionTools": {
+			"title": "sdFactionTools",
+			"tip": ""
+		},
+		"sdFactions": {
+			"title": "sdFactions",
+			"tip": ""
+		},
+		"sdFactionskin": {
+			"title": "sdFactionskin",
+			"tip": ""
+		},
+		"sdFleshGrabber": {
+			"title": "sdFleshGrabber",
+			"tip": ""
+		},
+		"sdGib": {
+			"title": "sdGib",
+			"tip": ""
+		},
+		"sdGrass": {
+			"title": "sdGrass",
+			"tip": ""
+		},
+		"sdGrub": {
+			"title": "sdGrub",
+			"tip": ""
+		},
+		"sdGuanako": {
+			"title": "sdGuanako",
+			"tip": ""
+		},
+		"sdGuanakoStructure": {
+			"title": "sdGuanakoStructure",
+			"tip": ""
+		},
+		"sdGun": {
+			"title": "sdGun",
+			"tip": ""
+		},
+		"sdHover": {
+			"title": "sdHover",
+			"tip": ""
+		},
+		"sdJunk": {
+			"title": "sdJunk",
+			"tip": ""
+		},
+		"sdLamp": {
+			"title": "sdLamp",
+			"tip": ""
+		},
+		"sdLandMine": {
+			"title": "sdLandMine",
+			"tip": ""
+		},
+		"sdLandScanner": {
+			"title": "sdLandScanner",
+			"tip": ""
+		},
+		"sdLifeBox": {
+			"title": "sdLifeBox",
+			"tip": ""
+		},
+		"sdLiquidAbsorber": {
+			"title": "sdLiquidAbsorber",
+			"tip": ""
+		},
+		"sdLongRangeAntenna": {
+			"title": "sdLongRangeAntenna",
+			"tip": ""
+		},
+		"sdLongRangeTeleport": {
+			"title": "sdLongRangeTeleport",
+			"tip": ""
+		},
+		"sdLost": {
+			"title": "sdLost",
+			"tip": ""
+		},
+		"sdManualTurret": {
+			"title": "sdManualTurret",
+			"tip": ""
+		},
+		"sdMatterAmplifier": {
+			"title": "sdMatterAmplifier",
+			"tip": ""
+		},
+		"sdMatterContainer": {
+			"title": "sdMatterContainer",
+			"tip": ""
+		},
+		"sdMatterMatrix": {
+			"title": "sdMatterMatrix",
+			"tip": ""
+		},
+		"sdMeow": {
+			"title": "sdMeow",
+			"tip": ""
+		},
+		"sdMimic": {
+			"title": "sdMimic",
+			"tip": ""
+		},
+		"sdMothershipContainer": {
+			"title": "sdMothershipContainer",
+			"tip": ""
+		},
+		"sdNode": {
+			"title": "sdNode",
+			"tip": ""
+		},
+		"sdObelisk": {
+			"title": "sdObelisk",
+			"tip": ""
+		},
+		"sdOctopus": {
+			"title": "sdOctopus",
+			"tip": ""
+		},
+		"sdOverlord": {
+			"title": "sdOverlord",
+			"tip": ""
+		},
+		"sdPlayerDrone": {
+			"title": "sdPlayerDrone",
+			"tip": ""
+		},
+		"sdPlayerOverlord": {
+			"title": "sdPlayerOverlord",
+			"tip": ""
+		},
+		"sdPlayerSpectator": {
+			"title": "sdPlayerSpectator",
+			"tip": ""
+		},
+		"sdPortal": {
+			"title": "sdPortal",
+			"tip": ""
+		},
+		"sdPresetEditor": {
+			"title": "sdPresetEditor",
+			"tip": ""
+		},
+		"sdQuadro": {
+			"title": "sdQuadro",
+			"tip": ""
+		},
+		"sdQuickie": {
+			"title": "sdQuickie",
+			"tip": ""
+		},
+		"sdRescueTeleport": {
+			"title": "sdRescueTeleport",
+			"tip": ""
+		},
+		"sdRift": {
+			"title": "sdRift",
+			"tip": ""
+		},
+		"sdRoach": {
+			"title": "sdRoach",
+			"tip": ""
+		},
+		"sdRotator": {
+			"title": "sdRotator",
+			"tip": ""
+		},
+		"sdSampleBuilder": {
+			"title": "sdSampleBuilder",
+			"tip": ""
+		},
+		"sdSandWorm": {
+			"title": "sdSandWorm",
+			"tip": ""
+		},
+		"sdScriptInstructor": {
+			"title": "sdScriptInstructor",
+			"tip": ""
+		},
+		"sdSensorArea": {
+			"title": "sdSensorArea",
+			"tip": ""
+		},
+		"sdSetrBeholder": {
+			"title": "sdSetrBeholder",
+			"tip": ""
+		},
+		"sdSetrDestroyer": {
+			"title": "sdSetrDestroyer",
+			"tip": ""
+		},
+		"sdShark": {
+			"title": "sdShark",
+			"tip": ""
+		},
+		"sdShurgConverter": {
+			"title": "sdShurgConverter",
+			"tip": ""
+		},
+		"sdShurgExcavator": {
+			"title": "sdShurgExcavator",
+			"tip": ""
+		},
+		"sdShurgManualTurret": {
+			"title": "sdShurgManualTurret",
+			"tip": ""
+		},
+		"sdShurgTurret": {
+			"title": "sdShurgTurret",
+			"tip": ""
+		},
+		"sdSlug": {
+			"title": "sdSlug",
+			"tip": ""
+		},
+		"sdSolarMatterDistributor": {
+			"title": "sdSolarMatterDistributor",
+			"tip": ""
+		},
+		"sdSpider": {
+			"title": "sdSpider",
+			"tip": ""
+		},
+		"sdStalker": {
+			"title": "sdStalker",
+			"tip": ""
+		},
+		"sdStatusEffect": {
+			"title": "sdStatusEffect",
+			"tip": ""
+		},
+		"sdStealer": {
+			"title": "sdStealer",
+			"tip": ""
+		},
+		"sdSteeringWheel": {
+			"title": "sdSteeringWheel",
+			"tip": ""
+		},
+		"sdStorage": {
+			"title": "sdStorage",
+			"tip": ""
+		},
+		"sdStorageTank": {
+			"title": "sdStorageTank",
+			"tip": ""
+		},
+		"sdSunPanel": {
+			"title": "sdSunPanel",
+			"tip": ""
+		},
+		"sdTask": {
+			"title": "sdTask",
+			"tip": ""
+		},
+		"sdTeleport": {
+			"title": "sdTeleport",
+			"tip": ""
+		},
+		"sdTheatre": {
+			"title": "sdTheatre",
+			"tip": ""
+		},
+		"sdThruster": {
+			"title": "sdThruster",
+			"tip": ""
+		},
+		"sdTurret": {
+			"title": "sdTurret",
+			"tip": ""
+		},
+		"sdTutel": {
+			"title": "sdTutel",
+			"tip": ""
+		},
+		"sdTzyrgAbsorber": {
+			"title": "sdTzyrgAbsorber",
+			"tip": ""
+		},
+		"sdTzyrgMortar": {
+			"title": "sdTzyrgMortar",
+			"tip": ""
+		},
+		"sdUpgradeStation": {
+			"title": "sdUpgradeStation",
+			"tip": ""
+		},
+		"sdVeloxFortifier": {
+			"title": "sdVeloxFortifier",
+			"tip": ""
+		},
+		"sdVeloxMiner": {
+			"title": "sdVeloxMiner",
+			"tip": ""
+		},
+		"sdVirus": {
+			"title": "sdVirus",
+			"tip": ""
+		},
+		"sdWanderer": {
+			"title": "sdWanderer",
+			"tip": ""
+		},
+		"sdWater": {
+			"title": "sdWater",
+			"tip": ""
+		},
+		"sdWeaponBench": {
+			"title": "sdWeaponBench",
+			"tip": ""
+		},
+		"sdWeaponMerger": {
+			"title": "sdWeaponMerger",
+			"tip": ""
+		},
+		"sdWeather": {
+			"title": "sdWeather",
+			"tip": ""
+		},
+		"sdWorkbench": {
+			"title": "sdWorkbench",
+			"tip": ""
+		},
+		"sdZektaronDreadnought": {
+			"title": "sdZektaronDreadnought",
+			"tip": ""
+		}
+	},
+	"guns": {
+		"CLASS_PISTOL": {
+			"title": "Pistol",
+			"tip": ""
+		},
+		"CLASS_RIFLE": {
+			"title": "Assault rifle",
+			"tip": ""
+		},
+		"CLASS_SHOTGUN": {
+			"title": "Shotgun",
+			"tip": ""
+		},
+		"CLASS_RAILGUN": {
+			"title": "Railgun",
+			"tip": ""
+		},
+		"CLASS_ROCKET": {
+			"title": "Rocket launcher",
+			"tip": ""
+		},
+		"CLASS_MEDIKIT": {
+			"title": "Defibrillator",
+			"tip": ""
+		},
+		"CLASS_SPARK": {
+			"title": "Spark",
+			"tip": ""
+		},
+		"CLASS_BUILD_TOOL": {
+			"title": "Build tool",
+			"tip": ""
+		},
+		"CLASS_CRYSTAL_SHARD": {
+			"title": "Crystal shard",
+			"tip": ""
+		},
+		"CLASS_GRENADE_LAUNCHER": {
+			"title": "Grenade launcher",
+			"tip": ""
+		},
+		"CLASS_NEEDLE": {
+			"title": "Needle",
+			"tip": ""
+		},
+		"CLASS_SWORD": {
+			"title": "Sword",
+			"tip": ""
+		},
+		"CLASS_STIMPACK": {
+			"title": "Stimpack",
+			"tip": ""
+		},
+		"CLASS_FALKOK_RIFLE": {
+			"title": "Assault Rifle C-01r",
+			"tip": ""
+		},
+		"CLASS_TRIPLE_RAIL": {
+			"title": "Cube-gun",
+			"tip": ""
+		},
+		"CLASS_FISTS": {
+			"title": "Fists",
+			"tip": ""
+		},
+		"CLASS_SABER": {
+			"title": "Saber",
+			"tip": ""
+		},
+		"CLASS_RAIL_PISTOL": {
+			"title": "Cube-pistol",
+			"tip": ""
+		},
+		"CLASS_RAYGUN": {
+			"title": "Ray Gun C-01y",
+			"tip": ""
+		},
+		"CLASS_FALKOK_PSI_CUTTER": {
+			"title": "Falkonian PSI-cutter",
+			"tip": ""
+		},
+		"CLASS_RAIL_SHOTGUN": {
+			"title": "Cube-shotgun",
+			"tip": ""
+		},
+		"CLASS_RAIL_CANNON": {
+			"title": "Velox Rail Cannon",
+			"tip": ""
+		},
+		"CLASS_CUBE_SHARD": {
+			"title": "Cube shard",
+			"tip": ""
+		},
+		"CLASS_LASER_PISTOL": {
+			"title": "Laser Pistol",
+			"tip": ""
+		},
+		"CLASS_LMG": {
+			"title": "Light Machine Gun",
+			"tip": ""
+		},
+		"CLASS_BUILDTOOL_UPG": {
+			"title": "Build tool upgrade",
+			"tip": ""
+		},
+		"CLASS_LVL1_LIGHT_ARMOR": {
+			"title": "SD-01 Light Armor",
+			"tip": ""
+		},
+		"CLASS_LVL1_MEDIUM_ARMOR": {
+			"title": "SD-01 Duty Armor",
+			"tip": ""
+		},
+		"CLASS_LVL1_HEAVY_ARMOR": {
+			"title": "SD-01 Combat Armor",
+			"tip": ""
+		},
+		"CLASS_SHOTGUN_MK2": {
+			"title": "Shotgun MK2",
+			"tip": ""
+		},
+		"CLASS_LASER_DRILL": {
+			"title": "Laser Drill",
+			"tip": ""
+		},
+		"CLASS_SMG": {
+			"title": "Burst SMG",
+			"tip": ""
+		},
+		"CLASS_KVT_SMG": {
+			"title": "KVT SMG P49 \"The Advocate\"",
+			"tip": ""
+		},
+		"CLASS_ROCKET_MK2": {
+			"title": "Guided Rocket Launcher",
+			"tip": ""
+		},
+		"CLASS_HEALING_RAY": {
+			"title": "Cube-Medgun",
+			"tip": ""
+		},
+		"CLASS_SHOVEL": {
+			"title": "Shovel",
+			"tip": ""
+		},
+		"CLASS_SHOVEL_MK2": {
+			"title": "Shovel MK2",
+			"tip": ""
+		},
+		"CLASS_DECONSTRUCTOR_HAMMER": {
+			"title": "Deconstructor Hammer",
+			"tip": ""
+		},
+		"CLASS_ADMIN_REMOVER": {
+			"title": "Admin tool for removing",
+			"tip": ""
+		},
+		"CLASS_LOST_CONVERTER": {
+			"title": "Cube overcharge cannon",
+			"tip": ""
+		},
+		"CLASS_CABLE_TOOL": {
+			"title": "Cable management tool",
+			"tip": ""
+		},
+		"CLASS_POWER_PACK": {
+			"title": "Power pack",
+			"tip": ""
+		},
+		"CLASS_TIME_PACK": {
+			"title": "Time pack",
+			"tip": ""
+		},
+		"CLASS_LVL2_LIGHT_ARMOR": {
+			"title": "SD-02 Light Armor",
+			"tip": ""
+		},
+		"CLASS_LVL2_MEDIUM_ARMOR": {
+			"title": "SD-02 Duty Armor",
+			"tip": ""
+		},
+		"CLASS_LVL2_HEAVY_ARMOR": {
+			"title": "SD-02 Combat Armor",
+			"tip": ""
+		},
+		"CLASS_ADMIN_TELEPORTER": {
+			"title": "Admin tool for teleporting",
+			"tip": ""
+		},
+		"CLASS_POWER_STIMPACK": {
+			"title": "Power-Stimpack",
+			"tip": ""
+		},
+		"CLASS_LVL1_ARMOR_REGEN": {
+			"title": "SD-11 Armor Repair Module",
+			"tip": ""
+		},
+		"CLASS_LVL2_ARMOR_REGEN": {
+			"title": "SD-12 Armor Repair Module",
+			"tip": ""
+		},
+		"CLASS_LVL3_ARMOR_REGEN": {
+			"title": "SD-13 Armor Repair Module",
+			"tip": ""
+		},
+		"CLASS_LVL3_LIGHT_ARMOR": {
+			"title": "SD-03 Light Armor",
+			"tip": ""
+		},
+		"CLASS_LVL3_MEDIUM_ARMOR": {
+			"title": "SD-03 Duty Armor",
+			"tip": ""
+		},
+		"CLASS_LVL3_HEAVY_ARMOR": {
+			"title": "SD-03 Combat Armor",
+			"tip": ""
+		},
+		"CLASS_EMERGENCY_INSTRUCTOR": {
+			"title": "Emergency instructor",
+			"tip": ""
+		},
+		"CLASS_POPCORN": {
+			"title": "Popcorn",
+			"tip": ""
+		},
+		"CLASS_ERTHAL_BURST_RIFLE": {
+			"title": "Erthal Burst Rifle",
+			"tip": ""
+		},
+		"CLASS_ERTHAL_PLASMA_PISTOL": {
+			"title": "Erthal Plasma Pistol",
+			"tip": ""
+		},
+		"CLASS_FMECH_MINIGUN": {
+			"title": "Velox Flying Mech Minigun",
+			"tip": ""
+		},
+		"CLASS_SNIPER": {
+			"title": "Sniper rifle",
+			"tip": ""
+		},
+		"CLASS_VELOX_PISTOL": {
+			"title": "Velox Burst Pistol",
+			"tip": ""
+		},
+		"CLASS_SARRONIAN_GAUSS_RIFLE": {
+			"title": "Sarronian Gauss Rifle",
+			"tip": ""
+		},
+		"CLASS_VELOX_COMBAT_RIFLE": {
+			"title": "Velox Combat Rifle",
+			"tip": ""
+		},
+		"CLASS_F_HEAVY_RIFLE": {
+			"title": "Falkonian Heavy Rifle",
+			"tip": ""
+		},
+		"CLASS_ZAPPER": {
+			"title": "Zapper",
+			"tip": ""
+		},
+		"CLASS_COUNCIL_PISTOL": {
+			"title": "Council Pistol",
+			"tip": ""
+		},
+		"CLASS_COUNCIL_BURST_RAIL": {
+			"title": "Council Burst Rail",
+			"tip": ""
+		},
+		"CLASS_METAL_SHARD": {
+			"title": "Alienic metal shard",
+			"tip": ""
+		},
+		"CLASS_GRENADE_LAUNCHER_MK2": {
+			"title": "Grenade launcher MK2",
+			"tip": ""
+		},
+		"CLASS_TRIPLE_RAIL2": {
+			"title": "Cube-gun v2",
+			"tip": ""
+		},
+		"CLASS_RAIL_SHOTGUN2": {
+			"title": "Cube-shotgun v2",
+			"tip": ""
+		},
+		"CLASS_SARRONIAN_ENERGY_RIFLE": {
+			"title": "Sarronian Energy Rifle",
+			"tip": ""
+		},
+		"CLASS_WYRMHIDE": {
+			"title": "Wyrmhide",
+			"tip": ""
+		},
+		"CLASS_SNOWBALL": {
+			"title": "Snowball",
+			"tip": ""
+		},
+		"CLASS_PORTAL": {
+			"title": "ASHPD",
+			"tip": ""
+		},
+		"CLASS_OVERLORD_BLASTER": {
+			"title": "Overlord\\'s blaster",
+			"tip": ""
+		},
+		"CLASS_TOPS_DMR": {
+			"title": "Task Ops DMR",
+			"tip": ""
+		},
+		"CLASS_TOPS_SHOTGUN": {
+			"title": "Task Ops Shotgun",
+			"tip": ""
+		},
+		"CLASS_CUBE_SPEAR": {
+			"title": "Cube Empty Speargun",
+			"tip": ""
+		},
+		"CLASS_COMBAT_INSTRUCTOR": {
+			"title": "Combat instructor",
+			"tip": ""
+		},
+		"CLASS_SETR_PLASMA_SHOTGUN": {
+			"title": "Setr Plasma Shotgun",
+			"tip": ""
+		},
+		"CLASS_SETR_ROCKET": {
+			"title": "Setr Rocket Launcher",
+			"tip": ""
+		},
+		"CLASS_CUBE_TELEPORTER": {
+			"title": "Cube-teleporter",
+			"tip": ""
+		},
+		"CLASS_RAYRIFLE": {
+			"title": "Ray Rifle TCoRR",
+			"tip": ""
+		},
+		"CLASS_LIQUID_CARRIER": {
+			"title": "Liquid carrier",
+			"tip": ""
+		},
+		"CLASS_CUSTOM_RIFLE": {
+			"title": "Rifle",
+			"tip": ""
+		},
+		"CLASS_SCORE_SHARD": {
+			"title": "Score shard",
+			"tip": ""
+		},
+		"CLASS_LVL4_ARMOR_REGEN": {
+			"title": "Task Ops Armor Repair Module",
+			"tip": ""
+		},
+		"CLASS_ADMIN_DAMAGER": {
+			"title": "Admin tool for damaging",
+			"tip": ""
+		},
+		"CLASS_MOP": {
+			"title": "Mop",
+			"tip": ""
+		},
+		"CLASS_TELEPORT_SWORD": {
+			"title": "Time shifter blade",
+			"tip": ""
+		},
+		"CLASS_TZYRG_SHOTGUN": {
+			"title": "Tzyrg Shotgun",
+			"tip": ""
+		},
+		"CLASS_COUNCIL_SHOTGUN": {
+			"title": "Council Shotgun",
+			"tip": ""
+		},
+		"CLASS_THROWABLE_GRENADE": {
+			"title": "Hand grenade",
+			"tip": ""
+		},
+		"CLASS_MINING_FOCUS_CUTTER": {
+			"title": "Mining Focus Cutter",
+			"tip": ""
+		},
+		"CLASS_ZEKTARON_FOCUS_BEAM": {
+			"title": "Zektaron Focus Beam",
+			"tip": ""
+		},
+		"CLASS_RAIL_PISTOL2": {
+			"title": "Cube-pistol v2",
+			"tip": ""
+		},
+		"CLASS_AREA_AMPLIFIER": {
+			"title": "Area amplifier",
+			"tip": ""
+		},
+		"CLASS_ILLUSION_MAKER": {
+			"title": "Illusion maker",
+			"tip": ""
+		},
+		"CLASS_SHURG_PISTOL": {
+			"title": "Shurg Pistol",
+			"tip": ""
+		},
+		"CLASS_SETR_REPULSOR": {
+			"title": "Setr Repulsor",
+			"tip": ""
+		},
+		"CLASS_SHURG_SNIPER": {
+			"title": "Shurg sniper rifle",
+			"tip": ""
+		},
+		"CLASS_SETR_LMG": {
+			"title": "Setr Light Machine Gun",
+			"tip": ""
+		},
+		"CLASS_CRYSTAL_CUTTER": {
+			"title": "Crystal cutter",
+			"tip": ""
+		},
+		"CLASS_CRYOGUN": {
+			"title": "Cryogun",
+			"tip": ""
+		},
+		"CLASS_TZYRG_RIFLE": {
+			"title": "Tzyrg Assault Rifle",
+			"tip": ""
+		},
+		"CLASS_DRAIN_RIFLE": {
+			"title": "Drain-rifle",
+			"tip": ""
+		},
+		"CLASS_SARRONIAN_SMG": {
+			"title": "Sarronian SMG",
+			"tip": ""
+		},
+		"CLASS_SARRONIAN_RAY": {
+			"title": "Sarronian Ray",
+			"tip": ""
+		},
+		"CLASS_SARRONIAN_ENERGY_DISPLACER": {
+			"title": "Sarronian Energy Displacer",
+			"tip": ""
+		},
+		"CLASS_SARRONIAN_BIO_ENERGY_LAUNCHER": {
+			"title": "Sarronian Bio-Energy Launcher",
+			"tip": ""
+		},
+		"CLASS_ZEKTARON_COMBAT_RIFLE": {
+			"title": "Zektaron Combat Rifle",
+			"tip": ""
+		},
+		"CLASS_ZEKTARON_RAILGUN": {
+			"title": "Zektaron Railgun",
+			"tip": ""
+		},
+		"CLASS_ZEKTARON_PLASMA_CANNON": {
+			"title": "Zektaron Plasma Cannon",
+			"tip": ""
+		},
+		"CLASS_ZEKTARON_PLASMA_REPEATER": {
+			"title": "Zektaron Plasma Repeater",
+			"tip": ""
+		},
+		"CLASS_MERGER_CORE": {
+			"title": "Weapon merger core",
+			"tip": ""
+		},
+		"CLASS_TOPS_PLASMA_RIFLE": {
+			"title": "Task Ops Plasma Rifle",
+			"tip": ""
+		},
+		"CLASS_ERTHAL_ENERGY_CELL": {
+			"title": "Erthal energy cell",
+			"tip": ""
+		},
+		"CLASS_ERTHAL_DMR": {
+			"title": "Erthal Marksman Rifle",
+			"tip": ""
+		},
+		"CLASS_WELD_TOOL": {
+			"title": "Elevator weld tool",
+			"tip": ""
+		},
+		"CLASS_ADMIN_MASS_DELETER": {
+			"title": "Admin tool for mass removing",
+			"tip": ""
+		},
+		"CLASS_UPGRADE_STATION_CHIPSET": {
+			"title": "Upgrade station chipset",
+			"tip": ""
+		},
+		"CLASS_EXALTED_CORE": {
+			"title": "Exalted core",
+			"tip": ""
+		},
+		"CLASS_CUBE_FUSION_CORE": {
+			"title": "Cube fusion core",
+			"tip": ""
+		},
+		"CLASS_DRINK": {
+			"title": "Drink",
+			"tip": ""
+		},
+		"CLASS_CUBE_VOID_CAPACITOR": {
+			"title": "Cube void capacitor",
+			"tip": ""
+		},
+		"CLASS_BANANA": {
+			"title": "Banana",
+			"tip": ""
+		},
+		"CLASS_UNSTABLE_CORE": {
+			"title": "Unstable core",
+			"tip": ""
+		},
+		"CLASS_STALKER_CANNON": {
+			"title": "Stalker Annihilator",
+			"tip": ""
+		},
+		"CLASS_STALKER_BEAM": {
+			"title": "Stalker Psychotic Beam",
+			"tip": ""
+		},
+		"CLASS_STALKER_RIFLE": {
+			"title": "Stalker Rapid Rifle",
+			"tip": ""
+		},
+		"CLASS_STALKER_CLONER": {
+			"title": "Stalker Clone Ray",
+			"tip": ""
+		},
+		"CLASS_ACCESS_KEY": {
+			"title": "Access key",
+			"tip": ""
+		},
+		"CLASS_REPAIR_TOOL": {
+			"title": "Vehicle repair tool",
+			"tip": ""
+		},
+		"CLASS_TELEKINETICS": {
+			"title": "Gravity gun",
+			"tip": ""
+		},
+		"CLASS_DRAIN_SHOTGUN": {
+			"title": "Drain-shotgun",
+			"tip": ""
+		},
+		"CLASS_DRAIN_SNIPER": {
+			"title": "Drain-sniper-rifle",
+			"tip": ""
+		},
+		"CLASS_HIGH_COUNCIL_SWORD": {
+			"title": "Council Energy Blade",
+			"tip": ""
+		},
+		"CLASS_MATTER_CONTAINER_CHIPSET": {
+			"title": "Matter container chipset",
+			"tip": ""
+		},
+		"CLASS_CHAINSAW": {
+			"title": "Chainsaw",
+			"tip": ""
+		},
+		"CLASS_TOPS_GRENADE_LAUNCHER": {
+			"title": "Task Ops Grenade Launcher",
+			"tip": ""
+		},
+		"CLASS_ETERNAL_SHARD": {
+			"title": "Eternal shard",
+			"tip": ""
+		},
+		"CLASS_PHASE_RIFLE": {
+			"title": "Phased Plasma Rifle SD-74",
+			"tip": ""
+		},
+		"CLASS_SD_MINIGUN": {
+			"title": "Laser Minigun SD-134",
+			"tip": ""
+		},
+		"CLASS_IMPACTOR": {
+			"title": "SD-Impactor",
+			"tip": ""
+		},
+		"CLASS_OVERLORD_BLASTER2": {
+			"title": "Overlord\\'s shotgun",
+			"tip": ""
+		},
+		"CLASS_COUNCIL_BURST_RAIL2": {
+			"title": "Council Burst Rail v2",
+			"tip": ""
+		},
+		"CLASS_COUNCIL_SHOTGUN2": {
+			"title": "Council Shotgun v2",
+			"tip": ""
+		},
+		"CLASS_COUNCIL_PISTOL2": {
+			"title": "Council Pistol v2",
+			"tip": ""
+		},
+		"CLASS_ANTI_TANK": {
+			"title": "Anti Tank Rifle SD-57",
+			"tip": ""
+		},
+		"CLASS_TZYRG_GRENADE_LAUNCHER": {
+			"title": "Tzyrg Grenade Launcher",
+			"tip": ""
+		},
+		"CLASS_BATTLE_RIFLE": {
+			"title": "Battle Rifle SD-97",
+			"tip": ""
+		},
+		"CLASS_ELECTROSHOCK": {
+			"title": "Velox Taser",
+			"tip": ""
+		},
+		"CLASS_HEAVY_ROCKET": {
+			"title": "Rocket Launcher SD-202",
+			"tip": ""
+		}
+	}
+}

--- a/game/sdWorld.js
+++ b/game/sdWorld.js
@@ -8,7 +8,7 @@
 	HandleWorldLogic
 
 */
-/* global sdShop, THREE, globalThis, sdServerToServerProtocol, sdMobileKeyboard, fs, sdMusic */
+/* global sdShop, THREE, globalThis, sdServerToServerProtocol, sdMobileKeyboard, fs, sdMusic, sdLoadingScreen */
 
 // sdShop is global on client-side
 
@@ -5720,6 +5720,8 @@ class sdWorld
 	{
 		sdRenderer.canvas.style.display = 'block';
 		globalThis.page_container.style.display = 'none';
+
+		sdLoadingScreen.Show(); // Covers the gap between the canvas appearing and the first real snapshot arriving (previously just black) - hides itself once sdWorld.my_entity resolves
 
 		if ( globalThis.preview_interval !== null )
 		{

--- a/game/style.css
+++ b/game/style.css
@@ -161,9 +161,12 @@ section div, section span
 }
 section_header
 {
-    display: block;
+    display: inline-block;
     border-bottom: 1px solid rgba(255,255,255,0.4);
-    
+    background: rgba(20,20,20,0.35);
+    border-radius: 6px;
+    padding: 0.3vh 1vh;
+
     font-family: ui_font2 !important;
     font-size: 5vh;
     color: white;
@@ -199,6 +202,7 @@ menu_button, .menu_rect
     font-family: ui_font2 !important;
     font-size: 2.6vh;
     border: 0.2vh solid rgba(255,255,255,0.09);
+    background: rgba(20,20,20,0.35);
     margin-top: 1vh;
     color: white;
     text-transform: uppercase;
@@ -483,6 +487,8 @@ server_details div
     padding: 2vh;
     color: white;
     z-index: 4;
+    background: rgba(20,20,20,0.35);
+    border-bottom-right-radius: 6px;
 }
 
 body, .password_screen
@@ -1045,8 +1051,13 @@ settings_line left
     display: inline-block;
     text-align: right;
     vertical-align: top;
-    
+
     padding-right: 1vw;
+    padding-top: 0.15vw;
+    padding-bottom: 0.15vw;
+    background: rgba(20,20,20,0.35);
+    border-radius: 4px;
+    box-sizing: border-box;
 }
 settings_line right
 {
@@ -1067,6 +1078,8 @@ settings_line right settings_option
     padding-bottom: 0.1vw;
     margin-right: 0.5vw;
     color: #ffffff66;
+    background: rgba(20,20,20,0.35);
+    border-radius: 4px;
     position: relative;
     transition: color 0.2s ease;
 }
@@ -1121,6 +1134,10 @@ settings_option.selected::after,
 div.server_info
 {
     color: #ffffff54;
+    display: inline-block;
+    background: rgba(20,20,20,0.35);
+    border-radius: 4px;
+    padding: 0.3vh 1vh;
 }
 #game_title_text, #server_playing, #server_online
 {

--- a/game/style.css
+++ b/game/style.css
@@ -1083,6 +1083,20 @@ settings_line right settings_option
     position: relative;
     transition: color 0.2s ease;
 }
+settings_line input[type=button] /* Overrides the site-wide input[type=button] default (transparent, 0.9vw, no padding) just within settings rows, so Randomize/Save/Update/etc. match the dark-gray-background treatment of the labels and settings_option words around them */
+{
+    background: rgba(20,20,20,0.35);
+    border-radius: 4px;
+    font-size: 1vw;
+    padding: 0.2vw 0.4vw;
+    box-sizing: border-box;
+    margin-right: 0.3vw;
+    margin-bottom: 0.3vw;
+}
+settings_line input[type=button]:hover
+{
+    background: rgba(40,40,40,0.55);
+}
 settings_option.selected, settings_option:hover
 {
     color: #ffffff;

--- a/game/style.css
+++ b/game/style.css
@@ -1055,9 +1055,9 @@ settings_line left
     padding-right: 1vw;
     padding-top: 0.15vw;
     padding-bottom: 0.15vw;
-    background: rgba(20,20,20,0.35);
-    border-radius: 4px;
     box-sizing: border-box;
+
+    text-shadow: 0 0 0.4vh rgba(0,0,0,0.9), 0 0 1vh rgba(0,0,0,0.7); /* Readability against the background image without a button-like pill shape - unlike settings_option/input[type=button] to its right, this label isn't clickable */
 }
 settings_line right
 {
@@ -1148,7 +1148,9 @@ settings_option.selected::after,
 div.server_info
 {
     color: #ffffff54;
-    display: inline-block;
+    display: block; /* Own line, so it doesn't share an inline line box with the logo <img> above it - "inline-block" let the two sit side by side and get centered together as a unit instead of independently */
+    width: fit-content;
+    margin: 0 auto;
     background: rgba(20,20,20,0.35);
     border-radius: 4px;
     padding: 0.3vh 1vh;


### PR DESCRIPTION
## Summary
Bundle of client-side QoL work, all verified live in a real browser session (chrome-devtools MCP) and/or on a running server:

- **Loading screen** (previously a black canvas while connecting): cycles through cards for every entity class and gun, random order, admin/dev-only entries filtered out, sprites scaled from measured opaque pixel bounds (fixes multi-part guns like the KVT Railcannon clipping past the icon canvas), tips loaded from a new `loading_tips.json`. Restyled to match the main menu (shared nebula background, starfield, dark-panel convention, typography). Auto-hides on `sdWorld.my_entity` resolve with a 20s safety timeout.
- **Character profile selector**: local save/rename/delete/export/import for character presets, identity-safe import (never adopts a foreign `my_hash`).
- **Color picker**: swatches labeled by what they actually color (Helmet, Visor, Chest badge, Jacket, Legs, Suit accent, Shoes, Skin, Extra accent), determined by live-testing each against the skin preview.
- **Startup screen readability**: dark backgrounds behind text previously laid directly over the busy nebula background; fixed a `GoToScreen` race where rapid navigation could leave a screen stuck at partial opacity (pre-existing bug, not introduced by this change).
- **Task HUD**: capped to top 3 + collapsed count (expandable via Tab), Rescue Teleport life-safety hints always sort first regardless of difficulty, expanded (Tab) view text-wraps against actual available width instead of a fixed 40-char guess, and hard-stops before overflowing the screen.
- **Misc render fixes**: coordinate display was overflowing off-screen and colliding with the now-playing track indicator (moved to bottom-left); background tiles were randomly drawing in front of normal entities (BG now always sorts first); Velox Rail Cannon beam now respects gun customization color; disabled/unwired teleporters no longer render fullbright.

## Test plan
- [x] `node --check` clean on all touched files
- [x] Clean server boot (fresh world, 0 errors)
- [x] Loading screen verified end-to-end in a real browser: icons render, tips load, gun sound/muzzle fires, creature idle→attack animation cycles, auto-hides on connect, no console errors
- [x] Startup/settings screens verified in a real browser: color picker updates live preview, 8x rapid-navigation stress test settles at opacity 1, no layout breakage, no console errors
- [x] Live on a running server (slot-1003) for several days prior to this PR