### PR TITLE
Fix sdTurret crashing client bootstrap on unlucky module load order

### DIFF
--- a/game/entities/sdTurret.js
+++ b/game/entities/sdTurret.js
@@ -88,43 +88,6 @@ class sdTurret extends sdEntity
         
         sdTurret.img_turret9 = sdWorld.CreateImageFromFile( 'turret9' );
 		
-		sdTurret.targetable_classes = new WeakSet( [ 
-			sdCharacter, 
-			sdVirus, 
-			sdQuickie, 
-			sdOctopus, 
-			sdCube, 
-			//sdBomb, 
-			sdAsp, 
-			sdSandWorm, 
-			sdSlug, 
-			sdGrub, 
-			sdGuanako, 
-			sdShark, 
-			sdEnemyMech, 
-			sdDrone, 
-			sdBadDog, 
-			sdShark, 
-			sdSpider, 
-			sdTutel,
-			sdFaceCrab,
-			sdSetrDestroyer,
-			sdWorld.entity_classes.sdOverlord,
-			sdWorld.entity_classes.sdPlayerDrone,
-			sdWorld.entity_classes.sdAmphid,
-			sdWorld.entity_classes.sdPlayerOverlord,
-			sdBiter,
-			sdAbomination,
-			sdMimic,
-			sdTzyrgAbsorber,
-			sdVeloxMiner,
-			sdWorld.entity_classes.sdShurgTurret,
-			sdZektaronDreadnought,
-			sdStealer,
-			sdCouncilIncinerator,
-			sdMeow
-			
-		] ); // Module random load order that causes error prevention
         
         sdTurret.disallowed_weapons = [
             sdGun.CLASS_LOST_CONVERTER,
@@ -164,6 +127,50 @@ class sdTurret extends sdEntity
 		sdTurret.portable_fake_com = { _net_id: 0, subscribers:[ 'sdCharacter', 'sdPlayerDrone' ] };
 		
 		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
+	}
+	static get targetable_classes() // Built lazily on first use (not in init_class()) since some of these classes are only reachable via sdWorld.entity_classes.X - which depends on THEIR init_class() having already run, and dynamic-import resolution order across ~150+ entity files is not guaranteed. Built eagerly here it would intermittently throw (WeakSet rejects the undefined entries) and take the whole client bootstrap down with it depending on load order.
+	{
+		if ( sdTurret._targetable_classes_cache )
+		return sdTurret._targetable_classes_cache;
+
+		sdTurret._targetable_classes_cache = new WeakSet( [
+			sdCharacter,
+			sdVirus,
+			sdQuickie,
+			sdOctopus,
+			sdCube,
+			//sdBomb,
+			sdAsp,
+			sdSandWorm,
+			sdSlug,
+			sdGrub,
+			sdGuanako,
+			sdShark,
+			sdEnemyMech,
+			sdDrone,
+			sdBadDog,
+			sdShark,
+			sdSpider,
+			sdTutel,
+			sdFaceCrab,
+			sdSetrDestroyer,
+			sdWorld.entity_classes.sdOverlord,
+			sdWorld.entity_classes.sdPlayerDrone,
+			sdWorld.entity_classes.sdAmphid,
+			sdWorld.entity_classes.sdPlayerOverlord,
+			sdBiter,
+			sdAbomination,
+			sdMimic,
+			sdTzyrgAbsorber,
+			sdVeloxMiner,
+			sdWorld.entity_classes.sdShurgTurret,
+			sdZektaronDreadnought,
+			sdStealer,
+			sdCouncilIncinerator,
+			sdMeow
+		].filter( ( cls )=>cls ) ); // Defensive: skip any class that still somehow was not registered yet, rather than throwing and losing just that one class as a valid turret target
+
+		return sdTurret._targetable_classes_cache;
 	}
 	get hitbox_x1() { return this.kind === sdTurret.KIND_SENTRY ? -8 : -this.GetSize(); }
 	get hitbox_x2() { return this.kind === sdTurret.KIND_SENTRY ? 8 : this.GetSize(); }


### PR DESCRIPTION
## Summary
- `sdTurret.init_class()` eagerly builds a `WeakSet` of "targetable" entity classes, several of which (`sdOverlord`, `sdPlayerDrone`, `sdAmphid`, `sdPlayerOverlord`, `sdShurgTurret`) are resolved via `sdWorld.entity_classes.X` instead of static imports (to dodge circular imports). Depending on the order the ~150+ dynamically-imported entity modules happen to resolve in, one of those can still be `undefined` when this runs - and `WeakSet` throws on non-object entries.
- Since this throw is uncaught, it silently kills the client's entire top-level bootstrap at that exact point. Nothing after it in `game.js` ever runs, including the final `globalThis.sdWorld = sdWorld` assignment - so the client never becomes playable: the main menu still renders (static HTML), but clicking "Play" throws `sdWorld is not defined`, since `sdWorld` was never exposed as a global.
- Fixed by moving the `WeakSet` construction into a lazily-built, cached static getter, first accessed during actual gameplay (well after every entity class has registered), with a defensive filter that skips any still-unregistered class instead of throwing.

## Test plan
- [x] `node --check` on the changed file
- [x] Reproduced the original crash (confirmed via targeted diagnostic instrumentation that `sdTurret.init_class()` was the exact throw site, via the `"Invalid value used in weak set"` error) and confirmed the fix resolves it on a live test server - full client bootstrap completes, `Play Together` works end-to-end