### PR TITLE
installer: fix auto-update permanently stalling when services share one APP_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ Run the installer from the Linux account that should own and run the server. `su
 
 The installer can set up Node.js through nvm, clone or reuse the repository, install production dependencies, create systemd service/timer units, configure `sslconfig.json`, verify certificate/key permissions, add optional Let's Encrypt support, create world-data backups, and write per-service admin/uninstall helper files.
 
-If you already have the game on the server, run the installer from that directory. For a real Git checkout, use:
+If you already have the game on the server, run the installer from that directory:
 
 ```bash
-sudo -E bash install-linux.sh --existing-checkout
+sudo -E bash install-linux.sh
 ```
+
+For a real Git checkout, answer "y" when asked "Use existing checkout as-is and skip initial clone/reset" (this is asked interactively; for unattended installs set `EXISTING_CHECKOUT_ONLY=yes` in a `--config` file instead).
 
 If the directory has game files but no `.git`, the installer offers:
 

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -79,7 +79,6 @@ StarDefenders2D Linux installer ${SCRIPT_VERSION}
 
 Usage:
   sudo bash install-linux.sh
-  sudo bash install-linux.sh --existing-checkout
   sudo bash install-linux.sh --dry-run
   sudo bash install-linux.sh --config ./install.env --yes
   bash install-linux.sh --help
@@ -93,12 +92,15 @@ sslconfig.json certificate/key paths, or install Let's Encrypt and write
 sslconfig.json from the issued certificate paths, verify service user access,
 and create world-slot-aware file watchers for graceful restarts.
 
+Whether to reconfigure services around an existing Git checkout and skip the
+initial clone/checkout/reset step is asked interactively ("Use existing
+checkout as-is and skip initial clone/reset") rather than a command-line flag.
+For unattended installs, set EXISTING_CHECKOUT_ONLY=yes in a --config file.
+
 Options:
   --config FILE        Load shell-style installer defaults before prompting.
   --yes                Use loaded/default answers without prompting.
   --dry-run            Print the resulting plan without changing the system.
-  --existing-checkout  Reconfigure services around an existing Git checkout;
-                       skip the initial clone/checkout/reset step.
 EOF
 }
 
@@ -118,8 +120,7 @@ parse_args() {
         shift
         ;;
       --existing-checkout|--reuse-existing|--service-only)
-        EXISTING_CHECKOUT_ONLY="yes"
-        shift
+        die "$1 was removed. Answer \"Use existing checkout as-is and skip initial clone/reset\" interactively instead, or set EXISTING_CHECKOUT_ONLY=yes in a --config file for unattended installs."
         ;;
       -y|--yes|--non-interactive|--noninteractive)
         ASSUME_DEFAULTS="yes"
@@ -632,6 +633,41 @@ install_nvm_and_node() {
   run_app_shell "export NVM_DIR=$(shell_quote "${nvm_dir}"); . \"\$NVM_DIR/nvm.sh\"; nvm install $(shell_quote "${NVM_VERSION}"); nvm alias default $(shell_quote "${NVM_VERSION}"); node --version; npm --version"
 }
 
+warn_if_app_dir_shared_with_other_profile() {
+  # Multiple world-slot services deliberately sharing one checkout (same
+  # APP_DIR, different WORLD_SLOT/config) is a supported pattern -- the
+  # generated deploy/backup scripts coordinate their locks by directory so
+  # this is safe -- but each service still restarts independently, so operators
+  # should know they're doing it and keep REPO_BRANCH consistent across them.
+  local f
+  local base
+  local other_app_dir
+  local matches=()
+
+  shopt -s nullglob
+  for f in /etc/default/*; do
+    [[ -f "${f}" && -r "${f}" ]] || continue
+    base="$(basename "${f}")"
+    [[ "${base}" != "${SERVICE_NAME}" ]] || continue
+    grep -qs '^APP_DIR=' "${f}" 2>/dev/null || continue
+    grep -qs '^LAUNCH_COMMAND=' "${f}" 2>/dev/null || continue
+    other_app_dir="$(APP_DIR=""; source "${f}" 2>/dev/null; printf '%s' "${APP_DIR}")"
+    if [[ -n "${other_app_dir}" && "${other_app_dir}" == "${APP_DIR}" ]]; then
+      matches+=("${base}")
+    fi
+  done
+  shopt -u nullglob
+
+  if (( ${#matches[@]} > 0 )); then
+    warn "${APP_DIR} is already used by other service profile(s): ${matches[*]}"
+    warn "This installer supports multiple world-slot services sharing one checkout"
+    warn "(their deploy/backup locks are coordinated by directory), but each service"
+    warn "still restarts independently onto the shared code. Keep REPO_BRANCH the"
+    warn "same across every profile pointed at this directory."
+    prompt_yes_no "Continue installing another service against this same directory" "y" || die "Choose a different install directory or reconfigure the existing service profile instead."
+  fi
+}
+
 prompt_configuration() {
   local detected_user
   local current_dir
@@ -997,6 +1033,7 @@ EOF
     grep -Rsl "^WORLD_SLOT=${WORLD_SLOT}$" /etc/default/stardefenders* 2>/dev/null || true
     prompt_yes_no "Continue with duplicate world slot" "n" || die "Choose a different world slot or service profile."
   fi
+  warn_if_app_dir_shared_with_other_profile
 
   cat <<EOF
 
@@ -1388,6 +1425,18 @@ write_environment_file() {
   write_env_var "${env_file}" "RUN_INITIAL_UPDATE" "${RUN_INITIAL_UPDATE}"
 }
 
+write_initial_deployed_rev() {
+  # Seeds this service's "last deployed" marker (see write_deploy_script) with
+  # whatever HEAD actually is once this install/reconfigure finishes, so its
+  # first auto-update tick does not treat a checkout it just set up itself as
+  # "a sibling service must have updated this without me."
+  local rev
+  [[ -d "${APP_DIR}/.git" ]] || return 0
+  rev="$(run_as_app git -C "${APP_DIR}" rev-parse HEAD 2>/dev/null || true)"
+  [[ -n "${rev}" ]] || return 0
+  printf '%s\n' "${rev}" > "/etc/default/${SERVICE_NAME}.deployed_rev"
+}
+
 write_run_script() {
   local path="/usr/local/bin/${SERVICE_NAME}-run.sh"
   info "Writing ${path}"
@@ -1670,8 +1719,19 @@ write_deploy_script() {
 set -Eeuo pipefail
 
 source "__ENV_FILE__"
-LOCK_FILE="/run/lock/${SERVICE_NAME}-deploy.lock"
+
+# Shared by every service pointed at this same APP_DIR (multiple world slots
+# deliberately running from one checkout, differentiated only by FILE_SUFFIX/
+# config, is a supported pattern) so their deploy/backup git operations
+# mutually exclude each other instead of racing in the same working tree.
+# Keying by SERVICE_NAME alone let two co-located slots run concurrent
+# git reset --hard / npm install in the same directory with no exclusion.
+DIR_KEY="$(printf '%s' "${APP_DIR}" | sha256sum | cut -c1-16)"
+LOCK_FILE="/run/lock/sd2d-deploy-${DIR_KEY}.lock"
 SUPPRESS_FILE="/run/${SERVICE_NAME}-config-restart.suppress_until"
+DEPLOYED_REV_FILE="/etc/default/${SERVICE_NAME}.deployed_rev"
+SKIP_COUNT_FILE="/run/${SERVICE_NAME}-deploy-skip-count"
+STUCK_MARKER="${APP_DIR}/crash_reports/${SERVICE_NAME}-deploy-stuck.txt"
 
 log() {
   printf '[%s] %s\n' "$(date -Is)" "$*"
@@ -1700,9 +1760,63 @@ purge_old_backups() {
   done
 }
 
+# A busy lock used to be a single silent log line forever -- indistinguishable
+# from "nothing to update" with no operator-visible signal. Escalate loudly
+# after a long stretch of consecutive skips (a hung sibling deploy, or a
+# permanently stuck lock, looks identical to "up to date" otherwise).
+record_skip() {
+  local count=0
+  [[ -f "${SKIP_COUNT_FILE}" ]] && count="$(cat "${SKIP_COUNT_FILE}" 2>/dev/null || echo 0)"
+  [[ "${count}" =~ ^[0-9]+$ ]] || count=0
+  count=$(( count + 1 ))
+  echo "${count}" > "${SKIP_COUNT_FILE}"
+  if (( count >= 6 )); then
+    mkdir -p "${APP_DIR}/crash_reports" 2>/dev/null || true
+    {
+      echo "StarDefenders2D auto-update could not acquire its deploy lock for ${count} consecutive attempts."
+      echo "service=${SERVICE_NAME}"
+      echo "lock_file=${LOCK_FILE}"
+      echo "last_checked=$(date -Is)"
+      echo
+      echo "This usually means another process is holding the shared deploy lock for"
+      echo "${APP_DIR} (a co-located world-slot service sharing this directory, or a"
+      echo "hung previous deploy/backup run). Check:"
+      echo "  fuser ${LOCK_FILE} 2>/dev/null"
+      echo "  ls -la ${APP_DIR}/.git/index.lock 2>/dev/null"
+      echo "  systemctl status ${SERVICE_NAME}-update.service --no-pager"
+    } > "${STUCK_MARKER}"
+    chmod 640 "${STUCK_MARKER}" 2>/dev/null || true
+    log "WARNING: deploy lock has been busy for ${count} consecutive attempts; wrote ${STUCK_MARKER}"
+  fi
+}
+
+clear_skip_count() {
+  rm -f "${SKIP_COUNT_FILE}" "${STUCK_MARKER}" 2>/dev/null || true
+}
+
+# git leaves .git/index.lock behind if a git subprocess is killed mid-write
+# (systemd's TimeoutStartSec, an OOM kill, a stalled network fetch). Unlike our
+# own flock, this file does NOT get released when the process dies -- it
+# silently blocks every future git operation in this checkout until removed.
+# Only clear it once it is older than this unit's own TimeoutStartSec, so a
+# run that is genuinely still in flight is never touched.
+clear_stale_index_lock() {
+  local idx_lock="${APP_DIR}/.git/index.lock"
+  local age
+  [[ -f "${idx_lock}" ]] || return 0
+  age=$(( $(date +%s) - $(stat -c %Y "${idx_lock}" 2>/dev/null || echo "$(date +%s)") ))
+  if (( age > 900 )); then
+    log "WARNING: removing stale ${idx_lock} (age ${age}s), left by a killed/crashed git operation."
+    rm -f "${idx_lock}"
+  else
+    log "${idx_lock} is only ${age}s old; leaving it in case a git operation is genuinely still running."
+  fi
+}
+
 exec 9>"${LOCK_FILE}"
 if ! flock -n 9; then
-  log "Another deploy/config restart is already running; exiting."
+  log "Another deploy/config restart is already running for ${APP_DIR}; exiting."
+  record_skip
   exit 0
 fi
 
@@ -1713,18 +1827,36 @@ if [[ "${EXISTING_NON_GIT_ACTION:-}" == "plain" || ! -d "${APP_DIR}/.git" ]]; th
   exit 0
 fi
 
+clear_stale_index_lock
+
 log "Fetching ${REPO_URL} ${REPO_BRANCH}..."
 run_as_app git fetch --prune origin
 
 current_rev="$(run_as_app git rev-parse HEAD)"
 target_rev="$(run_as_app git rev-parse "origin/${REPO_BRANCH}")"
+deployed_rev=""
+[[ -f "${DEPLOYED_REV_FILE}" ]] && deployed_rev="$(cat "${DEPLOYED_REV_FILE}" 2>/dev/null || true)"
+
+clear_skip_count
 
 if [[ "${current_rev}" == "${target_rev}" ]]; then
-  if systemctl is-active --quiet "${SERVICE_NAME}.service"; then
-    log "Already up to date at ${current_rev}; no restart needed."
+  if [[ "${deployed_rev}" == "${target_rev}" ]]; then
+    if systemctl is-active --quiet "${SERVICE_NAME}.service"; then
+      log "Already up to date at ${current_rev}; no restart needed."
+    else
+      log "Already up to date at ${current_rev}; starting inactive service."
+      systemctl start "${SERVICE_NAME}.service"
+    fi
   else
-    log "Already up to date at ${current_rev}; starting inactive service."
-    systemctl start "${SERVICE_NAME}.service"
+    # The checkout is already at target_rev, most likely because a co-located
+    # service sharing this APP_DIR already reset it -- but *this* service was
+    # never restarted onto it. Comparing only current_rev vs target_rev here
+    # (as before) would say "already up to date" forever and this service
+    # would silently keep running stale in-memory code. Just restart; no need
+    # to repeat the fetch/reset/npm-install a sibling already did.
+    log "Checkout already at ${current_rev}, but this service has not picked it up yet (last deployed: ${deployed_rev:-<none>}). Restarting..."
+    systemctl restart "${SERVICE_NAME}.service"
+    echo "${target_rev}" > "${DEPLOYED_REV_FILE}"
   fi
   exit 0
 fi
@@ -1750,13 +1882,26 @@ log "Backing up world snapshot/chunks before update..."
 purge_old_backups
 
 log "Resetting checkout to origin/${REPO_BRANCH}..."
-run_as_app git reset --hard "origin/${REPO_BRANCH}"
+run_as_app git reset --hard "${target_rev}"
 
 prefix="$(node_prefix)"
-run_app_shell "cd $(printf '%q' "${APP_DIR}"); ${prefix}npm install --omit=dev --no-audit --no-fund"
+if ! run_app_shell "cd $(printf '%q' "${APP_DIR}"); ${prefix}npm install --omit=dev --no-audit --no-fund"; then
+  # Code already moved to target_rev but dependencies did not finish updating
+  # to match -- starting on this combination risks a crash loop. Roll code
+  # back to what we know works together and retry on the next timer tick,
+  # rather than leaving a new-code/old-or-partial-deps mismatch running.
+  log "WARNING: npm install failed after updating to ${target_rev}; rolling checkout back to ${current_rev} to keep code and dependencies paired."
+  run_as_app git reset --hard "${current_rev}"
+  log "Starting ${SERVICE_NAME}.service on the pre-update revision..."
+  systemctl start "${SERVICE_NAME}.service"
+  deploy_finished="yes"
+  log "Deploy rolled back; still at ${current_rev}. Will retry on the next timer tick."
+  exit 1
+fi
 
 log "Starting ${SERVICE_NAME}.service..."
 systemctl start "${SERVICE_NAME}.service"
+echo "${target_rev}" > "${DEPLOYED_REV_FILE}"
 deploy_finished="yes"
 log "Deploy complete at $(run_as_app git rev-parse --short HEAD)."
 EOF
@@ -1784,7 +1929,8 @@ case "${MODE}" in
   *) echo "Usage: $0 [update|periodic] [--service-already-stopped]" >&2; exit 2 ;;
 esac
 
-LOCK_FILE="/run/lock/${SERVICE_NAME}-deploy.lock"
+DIR_KEY="$(printf '%s' "${APP_DIR}" | sha256sum | cut -c1-16)"
+LOCK_FILE="/run/lock/sd2d-deploy-${DIR_KEY}.lock"
 BACKUP_ROOT="${APP_DIR}/backups/${MODE}"
 
 log() {
@@ -1896,7 +2042,8 @@ write_config_restart_script() {
 set -Eeuo pipefail
 
 source "__ENV_FILE__"
-LOCK_FILE="/run/lock/${SERVICE_NAME}-deploy.lock"
+DIR_KEY="$(printf '%s' "${APP_DIR}" | sha256sum | cut -c1-16)"
+LOCK_FILE="/run/lock/sd2d-deploy-${DIR_KEY}.lock"
 SUPPRESS_FILE="/run/${SERVICE_NAME}-config-restart.suppress_until"
 
 log() {
@@ -2120,9 +2267,12 @@ rm -f \
   "/usr/local/bin/${SERVICE_NAME}-config-restart.sh" \
   "/usr/local/bin/${SERVICE_NAME}-fixperms.sh" \
   "/etc/default/${SERVICE_NAME}" \
+  "/etc/default/${SERVICE_NAME}.deployed_rev" \
   "/usr/local/bin/${SERVICE_NAME}-uninstall.sh" \
   "${APP_DIR}/${SERVICE_NAME}-admin-commands.txt" \
-  "${APP_DIR}/${SERVICE_NAME}-uninstall.sh"
+  "${APP_DIR}/${SERVICE_NAME}-uninstall.sh" \
+  "${APP_DIR}/crash_reports/${SERVICE_NAME}-deploy-stuck.txt"
+rm -f "/run/${SERVICE_NAME}-deploy-skip-count" "/run/${SERVICE_NAME}-config-restart.suppress_until" 2>/dev/null || true
 rm -f "/etc/letsencrypt/renewal-hooks/deploy/${SERVICE_NAME}-restart.sh" 2>/dev/null || true
 # Remove the SSL re-grant hotfix drop-in for this service (added by
 # sd2d-ssl-hotfix.sh on boxes patched before a full reinstall). Drop the shared
@@ -2196,6 +2346,16 @@ Auto-update
   Re-enable: systemctl enable --now ${SERVICE_NAME}-update.timer
   Run once now: systemctl start ${SERVICE_NAME}-update.service
   Approved during install: ${UPDATE_ENABLED}
+  Last commit this service actually restarted onto: /etc/default/${SERVICE_NAME}.deployed_rev
+  If this file's contents lag behind current origin/${REPO_BRANCH} for longer
+  than a few update-timer intervals, auto-update is stuck. Check for:
+    ${APP_DIR}/crash_reports/${SERVICE_NAME}-deploy-stuck.txt (written after
+      6+ consecutive attempts could not acquire the deploy lock -- most often
+      a hung deploy/backup run, or another world-slot service sharing this
+      same ${APP_DIR} whose own deploy/backup is mid-run)
+    ${APP_DIR}/.git/index.lock (a leftover from a killed git operation; the
+      deploy script clears it automatically once it is over 15 minutes old)
+    journalctl -u ${SERVICE_NAME}-update.service -n 100 --no-pager
 
 Periodic world backups
   Disable: systemctl disable --now ${SERVICE_NAME}-backup.timer
@@ -2361,6 +2521,7 @@ main() {
   install_npm_dependencies
   purge_old_managed_backups
   write_environment_file
+  write_initial_deployed_rev
   write_run_script
   write_backup_script
   write_deploy_script


### PR DESCRIPTION
## Summary

Investigated a report of auto-update silently not applying upstream commits. A downloaded server's `.git` reflog showed the smoking gun: `git reset --hard origin/main` firing reliably every ~5 minutes for weeks, then **zero** further reset entries for 5+ days despite 9 new upstream commits landing in that window. Not a gradual failure - a clean, permanent stop.

**Root cause:** the installer's own design lets multiple world-slot services share one `APP_DIR` (that's what the slot file-suffix system - `server_config1.js`, `moderation_data1000.v`, etc. - exists for), but:
- the deploy/backup lock (`/run/lock/${SERVICE_NAME}-deploy.lock`) was keyed by `SERVICE_NAME`, not `APP_DIR` - two co-located slots could run concurrent `git reset --hard` / `npm install` in the *same working tree* with zero mutual exclusion, and
- worse, whichever slot's timer fired first would reset the shared checkout and restart *only itself*. Every co-located sibling's *next* tick would see `current_rev == target_rev` already and log "already up to date; no restart needed" - **permanently**, since nothing in that logic path would ever re-trigger a restart for it again. That sibling's live process just keeps running stale in-memory code forever, completely silently.

That second bug is an exact match for the observed symptom: reliable operation, then a clean, silent, permanent stop.

## Fixes

- **Directory-scoped deploy lock:** `LOCK_FILE` is now keyed by a hash of `APP_DIR` instead of `SERVICE_NAME`, in `write_deploy_script`, `write_backup_script`, and `write_config_restart_script`, so co-located services actually exclude each other.
- **Per-service last-deployed-rev tracking:** each service now records the last commit it actually restarted onto (`/etc/default/${SERVICE_NAME}.deployed_rev`). When the shared checkout is already at `target_rev` but a service's own marker is behind, it restarts (without redundantly repeating the fetch/reset/npm-install a sibling already did) instead of silently doing nothing forever.
- **npm-install-failure rollback:** if `npm install` fails after `git reset --hard` moved to the new commit, the checkout now rolls back to the pre-update commit before restarting, so code and dependencies never end up mismatched.
- **Stale `.git/index.lock` detection:** a git subprocess killed mid-write (systemd's `TimeoutStartSec=900`, an OOM kill, a network stall) leaves `.git/index.lock` behind - unlike our own `flock`, this doesn't get released when the process dies, and silently blocks every future git operation in that checkout forever. Now detected and cleared once older than the unit's own timeout.
- **Escalation on repeated lock contention:** 6+ consecutive skipped ticks now write a loud marker into `crash_reports/` instead of one quiet log line forever.
- **Install-time warning:** the installer now warns when the chosen `APP_DIR` is already used by another service profile, since sharing is supported but easy to under-think.
- **`--existing-checkout`/`--reuse-existing`/`--service-only` reworked from a CLI flag into the interactive prompt that already existed for it** (or `EXISTING_CHECKOUT_ONLY=yes` in a `--config` file for unattended installs). The flag now dies with a pointer to the replacement rather than silently no-op'ing.

## Important operational note

Already-installed servers must **rerun the installer** (existing-checkout mode) to regenerate their `/usr/local/bin/*-deploy.sh` / `*-backup.sh` / `*-config-restart.sh` scripts with these fixes - pulling the updated `install-linux.sh` source via auto-update alone does not touch already-generated scripts living outside the repo.

## Test plan

- [x] `bash -n install-linux.sh` and each embedded heredoc script (deploy/backup/config-restart) individually - all parse cleanly.
- [x] `devtests/_audit_installer_autoupdate_test.sh` (gitignored dev tooling, not part of the game) - mirrors the deploy-script decision logic against real local git repos: 14/14 checks pass, covering lock-key identity across shared-`APP_DIR` profiles, the sibling catch-up-restart path, npm-install-failure rollback, and stale-vs-fresh `index.lock` handling.
- [ ] Manual verification on a real two-slot-sharing-one-directory install - not yet done by a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)