### PR TITLE
Expose weather-event frequency as server config; document drought/evaporation

### DIFF
--- a/game/entities/sdWeather.js
+++ b/game/entities/sdWeather.js
@@ -461,7 +461,8 @@ class sdWeather extends sdEntity
 			//let old_n = n;
 			//let daily_event_count = Math.min( allowed_event_ids.length, sdWorld.server_config.GetAllowedWorldEventCount ? sdWorld.server_config.GetAllowedWorldEventCount() : 6 );
 			let is_already_enabled = false;
-			let weather_event_count = Math.min( allowed_event_ids.length, ~~( ( 1 - Math.pow( Math.random(), 2 ) ) * 4 ) ); // Up to 2 events, can also be 0
+			let configured_weather_event_count = sdWorld.server_config.GetAllowedWeatherEventCount ? sdWorld.server_config.GetAllowedWeatherEventCount() : null;
+			let weather_event_count = Math.min( allowed_event_ids.length, ( configured_weather_event_count !== null && configured_weather_event_count !== undefined ) ? configured_weather_event_count : ~~( ( 1 - Math.pow( Math.random(), 2 ) ) * 4 ) ); // Up to 2 events, can also be 0 - unless a server config override forces a fixed count
 			let time = 1000;
 			while ( weather_event_count > 0 && time > 0 )
 			{
@@ -5462,7 +5463,7 @@ class sdWeather extends sdEntity
 			this._time_until_weather_event -= GSPEED;
 			if ( this._time_until_weather_event < 0 )
 			{
-				this._time_until_weather_event = Math.random() * 30 * 60 * 6; // Need to add a server config option later - Booraz149
+				this._time_until_weather_event = Math.random() * sdWorld.server_config.GetWeatherEventSpeed();
 
 				let allowed_event_ids = this._daily_weather_events;
 				if ( allowed_event_ids.length > 0 )

--- a/game/server/sdServerConfig.js
+++ b/game/server/sdServerConfig.js
@@ -195,7 +195,23 @@ class sdServerConfigShort
 
 	// static GetEventSpeed() { return 30 * 60 * 4; } // Default: 30*60*4. Max time (in steps) until the next event roll - larger = rarer events, smaller = more frequent. Pair with GetAllowedWorldEventCount.
 
+	// static GetWeatherEventSpeed() { return 30 * 60 * 6; } // Default: 30*60*6. Max time (in steps) until the next weather-event roll (rain/snow/drought/etc). Weather events rotate their eligible pool every 20 minutes and are NOT consumed when they fire (unlike SD task events), so a frequent roll interval combined with a small pool is why one weather type (snow included) can feel like it keeps coming back the whole rotation. Raise this to make weather rolls rarer overall.
+
+	// static GetAllowedWeatherEventCount() { return 1; } // Default: null (built-in ~0-3 random count, skewed toward 2-3 out of ~9 weather-event candidates). Return a number to force a fixed max count of weather events eligible per 20-minute rotation instead. Lower (e.g. 1) makes any single weather type noticeably rarer since it shares fewer "slots" - the direct lever if snow/rain/drought feels too frequent.
+
 	// static ForceEarthquakesIfPossible() { return true; } // Default: true. Always enable earthquakes when possible. Return false to disable forced earthquakes.
+
+	// static WaterEvaporationEnabled() { return true; } // Default: true. Naturally dries out sky-exposed, shallow, natural (rain-spawned) water/acid so it does not accumulate forever and pin the CPU. Player-placed water and deep seas are never touched. Set false to disable (e.g. to profile before/after, or if your map depends on rain puddles persisting).
+
+	// Fine-tune evaporation and the drought/heatwave event from onAfterSnapshotLoad() if the defaults do not suit your map. Uncomment & adjust:
+	//   sdWorld.entity_classes.sdWater.EVAP_MAX_DEPTH = 5;         // water columns deeper than this many cells are seas -> never evaporate; raise to protect shallow natural seas
+	//   sdWorld.entity_classes.sdWater.EVAP_BASE_RATE = 0.02;      // volume dried per step at full sun; lower = slower drying
+	//   sdWorld.entity_classes.sdWater.EVAP_BUDGET = 24;           // surface cells swept per frame (CPU cap); lower = cheaper/slower
+	//   sdWorld.entity_classes.sdWater.EVAP_DROUGHT_BUDGET = 48;   // extra cells swept per frame at full drought
+	//   sdWorld.entity_classes.sdWater.WAKE_CASCADE_MAX_DEPTH = 0; // 0 = original wake behavior; set e.g. 2 to tame wake-storms in huge pools (perf)
+
+	// To exclude the drought/heatwave event entirely instead of tuning it, deny-list its id (see GetDisallowedWorldEvents above):
+	// static GetDisallowedWorldEvents() { return [ sdWorld.entity_classes.sdWeather.EVENT_DROUGHT ]; }
 
 	// static EnableForbiddenCubes() { return false; } // Default: false. Enable shield and invisibility cubes? Set true to allow these advanced/forbidden cube types.
 
@@ -523,6 +539,14 @@ class sdServerConfigFull extends sdServerConfigShort
 	static GetEventSpeed()
 	{
 		return 30 * 60 * 4; //3 * ( 3 / 2 ); // Return max possible time until next event rolls
+	}
+	static GetWeatherEventSpeed()
+	{
+		return 30 * 60 * 6; // Return max possible time (in steps) until the next weather-event roll (rain/snow/drought/etc, selected from GetAllowedWeatherEventCount() of them per 20-minute weather rotation). Pair with GetAllowedWeatherEventCount() - a small selected pool combined with frequent rolls is why a given weather type (snow included) can feel like it keeps recurring for its whole ~20-minute rotation window: fired weather events are never removed from that window's pool the way SD task events are.
+	}
+	static GetAllowedWeatherEventCount()
+	{
+		return null; // Return null/undefined to keep the default randomized count (~~((1 - Math.random()**2) * 4), skewed toward 2-3 out of ~9 weather-event candidates), or a number to force a fixed max count of concurrently-eligible weather events per 20-minute rotation. Lower (e.g. 1) makes any single weather type, including snow, noticeably rarer since it has to share fewer "slots" with other candidates.
 	}
 	static ForceEarthquakesIfPossible()
 	{


### PR DESCRIPTION
## Summary

Investigated a report that snow triggers too often, and updated the server config reference for the drought/evaporation event (#248).

**Why snow feels too frequent** (pre-existing, not caused by #248 - drought's addition as a 9th weather-event candidate slightly *dilutes* snow's odds, if anything):
- Weather events (rain/snow/drought/etc) roll on a ~3-minute average interval - previously hardcoded (`Math.random() * 30*60*6`), and literally marked `// Need to add a server config option later - Booraz149` in the code.
- Each 20-minute weather rotation selects only 2-3 events (skewed toward the high end by `(1 - rand^2) * 4`) out of ~9 total weather-event candidates.
- Fired weather events are never consumed/removed from that rotation's pool, unlike SD task events (which are spliced out after firing once).

Net effect: whenever snow lands in a given day's small selected pool, it can keep re-rolling roughly every 3 minutes for the entire 20-minute window. No bug in the drought PR - just a frequency/pool-size interaction that server owners previously had no way to tune.

## Changes

- **`GetWeatherEventSpeed()`** (replaces the hardcoded roll interval) and **`GetAllowedWeatherEventCount()`** (forces a fixed pool size instead of the randomized ~0-3) added to `sdServerConfigFull`, both defaulting to the exact prior behavior. Setting `GetAllowedWeatherEventCount()` to `1` is the direct fix for "snow feels too frequent."
- Backfilled `sdServerConfigShort`'s owner-facing reference (the template copied into every fresh `server_config.js`) with `WaterEvaporationEnabled`, the `EVAP_*` tuning statics, and the drought-exclusion example - all of this only existed, undocumented, on `sdServerConfigFull` since #248 merged. The reference template was never updated to mention the drought/evaporation feature exists at all.

## Test plan

- [x] `node --check` on both modified files.
- [x] `devtests/_audit_weather_event_config_test.cjs` (gitignored dev tooling, not part of the game) - 11/11 checks: numeric `GetAllowedWeatherEventCount()` overrides force an exact (pool-capped) count, `null`/`undefined` preserve the original random distribution unchanged, and `GetWeatherEventSpeed()` is used as the actual roll-delay multiplier.
- [ ] In-game verification that `GetAllowedWeatherEventCount() { return 1; }` measurably reduces perceived weather frequency - not yet done by a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)