### PR TITLE
Fix sdSampleBuilder picking wrong color/texture for sampled blocks

### DIFF
--- a/game/entities/sdSampleBuilder.js
+++ b/game/entities/sdSampleBuilder.js
@@ -465,7 +465,15 @@ class sdSampleBuilder extends sdEntity
 							{
 								let prop = props_to_compare[ i2 ];
 
-								let ent_value = from_entity[ prop ] || from_entity[ '_' + prop ] || undefined;
+								// sdBlock strips hue-rotate/brightness out of .filter on construction (onSnapshotApplied),
+								// so a live sdBlock's .filter is never comparable to a shop template's raw .filter string -
+								// the dedicated hue/br comparison below is the correct substitute for sdBlock specifically.
+								if ( prop === 'filter' && _class === 'sdBlock' )
+								continue;
+
+								let ent_value = from_entity[ prop ];
+								if ( ent_value === undefined )
+								ent_value = from_entity[ '_' + prop ]; // 0 / '' / false are valid sampled values and must not be treated as absent
 
 								if ( ent_value !== undefined )
 								{
@@ -478,16 +486,14 @@ class sdSampleBuilder extends sdEntity
 									}
 								}
 							}
-							
-							if ( _class === 'sdBlock' || _class === 'sdDoor' )
-							if ( option.filter )
-							if ( option.filter.indexOf( 'hue-rotate' ) !== -1 || option.filter.indexOf( 'brightness' ) !== -1 )
+
+							if ( _class === 'sdBlock' || _class === 'sdDoor' ) // Always compare, even when option.filter has no color in it - otherwise an uncolored sample loses every tiebreak to a same-brightness but wrong-hue option
 							{
-								let [ hue, br, filter ] = sdWorld.ExtractHueRotate( option.hue||0, option.br||100, option.filter );
-								
+								let [ hue, br ] = sdWorld.ExtractHueRotate( option.hue||0, option.br||100, option.filter||'' );
+
 								if ( from_entity.hue === hue )
 								value += 1;
-								
+
 								if ( from_entity.br === br )
 								value += 1;
 							}


### PR DESCRIPTION
## Summary
- `sdSampleBuilder.UpdateTarget()` picks which `sdShop.options[]` template to build from by scoring every option of the sampled entity's class and taking the highest-scoring one.
- Two bugs in that scoring made it pick the wrong color/texture for `sdBlock` (and reduced fidelity for `sdDoor`):
  1. `ent_value = from_entity[prop] || from_entity['_'+prop] || undefined` treated legitimate falsy sampled values (`texture_id: 0`, `filter: ''`) as absent, so a plain wall's texture tier was silently never compared.
  2. The hue/brightness bonus only ran for candidate options that *already had* a hue-rotate/brightness filter, so a plain (uncolored) option could never earn it - while any same-brightness-but-wrong-hue colored option still could. Sampling a plain gray wall would then tie or lose to a random colored option, with ties settled by array iteration order.
- Also skip the generic `'filter'` string comparison specifically for `sdBlock`, since `sdBlock` strips hue-rotate/brightness out of its own `.filter` on construction (`onSnapshotApplied`) - comparing that already-stripped string against a shop template's raw `.filter` compares two different representations and always mismatches. The dedicated hue/br comparison right below it is the correct substitute.

## Test plan
- Reproduced the real `sdShop.js` sdBlock option-generation shape (colors x texture tiers) in an offline harness and ran `UpdateTarget()`'s real matching logic against it, before and after the fix.
- Before: sampling a plain default (uncolored) wall picked a random hue-tinted option instead of the plain one.
- After: default / colored / colored+reinforced sampling all recover the exact matching option, with zero scoring ties swept across every hue in the real palette.
- `node --check game/entities/sdSampleBuilder.js` passes.