### PR TITLE
Fix client bootstrap crash from sdTurret.targetable_classes load order

### DIFF
--- a/game/entities/sdTurret.js
+++ b/game/entities/sdTurret.js
@@ -125,8 +125,9 @@ class sdTurret extends sdEntity
 		sdTurret.matter_capacity = 40; // Was 20, but new cable logic makes entities with 20 or less matter to be ignored
 		
 		sdTurret.portable_fake_com = { _net_id: 0, subscribers:[ 'sdCharacter', 'sdPlayerDrone' ] };
-		
-		
+
+		sdTurret._targetable_classes_cache = null; // Pre-declared here (during init_class(), before sdWorld's ~1s-later Object.seal() of every entity class) so the lazy getter below only ever WRITES this existing property instead of ADDING a new one - sealed objects allow the former but throw on the latter.
+
 		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
 	}
 	static get targetable_classes() // Built lazily on first use (not in init_class()) since some of these classes are only reachable via sdWorld.entity_classes.X - which depends on THEIR init_class() having already run, and dynamic-import resolution order across ~150+ entity files is not guaranteed. Built eagerly here it would intermittently throw (WeakSet rejects the undefined entries) and take the whole client bootstrap down with it depending on load order.

--- a/game/entities/sdTurret.js
+++ b/game/entities/sdTurret.js
@@ -126,24 +126,32 @@ class sdTurret extends sdEntity
 		
 		sdTurret.portable_fake_com = { _net_id: 0, subscribers:[ 'sdCharacter', 'sdPlayerDrone' ] };
 		
-		sdTurret.targetable_classes = new WeakSet( [ 
-			sdCharacter, 
-			sdVirus, 
-			sdQuickie, 
-			sdOctopus, 
-			sdCube, 
-			//sdBomb, 
-			sdAsp, 
-			sdSandWorm, 
-			sdSlug, 
-			sdGrub, 
-			sdGuanako, 
-			sdShark, 
-			sdEnemyMech, 
-			sdDrone, 
-			sdBadDog, 
-			sdShark, 
-			sdSpider, 
+		
+		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
+	}
+	static get targetable_classes() // Built lazily on first use (not in init_class()) since some of these classes are only reachable via sdWorld.entity_classes.X - which depends on THEIR init_class() having already run, and dynamic-import resolution order across ~150+ entity files is not guaranteed. Built eagerly here it would intermittently throw (WeakSet rejects the undefined entries) and take the whole client bootstrap down with it depending on load order.
+	{
+		if ( sdTurret._targetable_classes_cache )
+		return sdTurret._targetable_classes_cache;
+
+		sdTurret._targetable_classes_cache = new WeakSet( [
+			sdCharacter,
+			sdVirus,
+			sdQuickie,
+			sdOctopus,
+			sdCube,
+			//sdBomb,
+			sdAsp,
+			sdSandWorm,
+			sdSlug,
+			sdGrub,
+			sdGuanako,
+			sdShark,
+			sdEnemyMech,
+			sdDrone,
+			sdBadDog,
+			sdShark,
+			sdSpider,
 			sdTutel,
 			sdFaceCrab,
 			sdSetrDestroyer,
@@ -161,12 +169,10 @@ class sdTurret extends sdEntity
 			sdStealer,
 			sdCouncilIncinerator,
 			sdMeow
-			
-		] ); // Module random load order that causes error prevention
-		
-		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
+		].filter( ( cls )=>cls ) ); // Defensive: skip any class that still somehow was not registered yet, rather than throwing and losing just that one class as a valid turret target
+
+		return sdTurret._targetable_classes_cache;
 	}
-	
 	get hitbox_x1() { return this.kind === sdTurret.KIND_SENTRY ? -8 : -this.GetSize(); }
 	get hitbox_x2() { return this.kind === sdTurret.KIND_SENTRY ? 8 : this.GetSize(); }
 	get hitbox_y1() { return this.kind === sdTurret.KIND_SENTRY ? -6 : -this.GetSize(); }


### PR DESCRIPTION
## Summary

`sdTurret.init_class()` eagerly constructs `new WeakSet([ ..., sdWorld.entity_classes.sdOverlord, ... ])`. Several entries are read indirectly through `sdWorld.entity_classes.X` (presumably to avoid a circular import), which only resolves to a real value once that class's own `init_class()` has already run and registered itself.

Client-side module/class registration order across ~150+ entity files is not guaranteed. On some page loads one of these was still `undefined` when `sdTurret`'s own `init_class()` ran, and `WeakSet`'s constructor throws immediately on any non-object entry (`TypeError: Invalid value used in weak set`). Since `init_class()` calls run synchronously in sequence during client bootstrap, this exception aborts everything after `sdTurret` in the init order too - cascading into `sdRenderer is not defined` / `sdWorld is not defined` and a completely broken client (confirmed with this exact stack trace in Chrome; a difference in module evaluation order meant it didn't reproduce in Firefox with a fresh load).

The existing comment on this line (`// Module random load order that causes error prevention`) shows this was already a known hazard, but the mitigation was never actually implemented - it documents the intent without a guard.

## Fix

- Construction of `targetable_classes` is deferred to a lazy static getter, invoked on first actual use (well after all classes have registered in practice, since real gameplay code runs after full bootstrap completes) instead of at `init_class()` time.
- The class list is filtered to drop any entry that is still falsy, defensively, instead of throwing.
- Result is cached after first build so it's only constructed once.
- No other call sites needed changes - `sdTurret.targetable_classes` is only ever read (`.has(...)`), never reassigned, so the getter is a transparent drop-in replacement.

## Test plan

- [x] `node --check game/entities/sdTurret.js` passes
- [x] Verified offline: 7/7 assertions (reproduces the crash against the old eager-construction code, confirms the new lazy getter never throws even with a stubbed-out not-yet-registered class, confirms caching, confirms no regression when every class is already registered)
- [x] Deployed live to a running server instance and confirmed via CDP eval that the getter builds correctly and the class is functional
- [ ] Not yet confirmed against a real browser session post-fix (deployed server-side only so far - the crash itself is client-side)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>