### PR TITLE
Always auto-save/select the last-used character; make "forget character" actually delete it

### DIFF
--- a/game/client/sdStartupScreen_v2.js
+++ b/game/client/sdStartupScreen_v2.js
@@ -981,6 +981,12 @@
 				const LOCAL_PROFILES_KEY = 'sd_character_profiles_v1';
 				const PROFILE_IDENTITY_FIELDS = [ 'my_hash' ]; // Only ever restored from profiles that were saved on THIS browser (see SelectLocalProfile) - never from an imported file
 
+				// Reserved slot that always mirrors whatever character is currently active, kept up to date automatically
+				// (see SyncLastUsedProfile) so the list is never misleadingly empty/unselected just because the player
+				// never pressed "Save as new" - this is what makes rejoining resume the same character by default.
+				const LAST_USED_PROFILE_ID = '__last_used__';
+				const LAST_USED_PROFILE_NAME = '(Last used character)';
+
 				globalThis.GetLocalProfiles = ()=>
 				{
 					try
@@ -1026,13 +1032,27 @@
 					placeholder.textContent = list.length ? '- Select a saved character -' : '- No saved characters yet -';
 					profile_select.append( placeholder );
 
+					// Whichever saved profile's identity matches what's currently active should show as selected -
+					// a later match in the list wins, so an explicitly named profile takes priority over the
+					// reserved "(Last used character)" entry (which is unshifted to the front) when both line up.
+					// Read straight from the DOM (a static element in index.html) rather than the inputs_hash
+					// closure map - this can run before AcceptField() has populated that map for the first time.
+					let my_hash_el = document.getElementById( 'my_hash' );
+					let current_hash = my_hash_el ? my_hash_el.value : null;
+					let active_id = '';
+
 					for ( let i = 0; i < list.length; i++ )
 					{
 						let option_el = document.createElement( 'option' );
 						option_el.value = list[ i ].id;
 						option_el.textContent = list[ i ].name;
 						profile_select.append( option_el );
+
+						if ( current_hash !== null && list[ i ].save && list[ i ].save.my_hash === current_hash )
+						active_id = list[ i ].id;
 					}
+
+					profile_select.value = active_id;
 				};
 
 				globalThis.SaveCurrentAsLocalProfile = ( existing_id=null )=>
@@ -1229,6 +1249,50 @@
 						alert( 'Character appearance imported. If the server has no character under your current identity yet, you will spawn as a new character with this appearance.' );
 					};
 					reader.readAsText( file );
+				};
+
+				// Keeps the reserved "(Last used character)" slot's snapshot pinned to whatever is currently active.
+				// Called from SavePlayerSettings, so it runs on every settings change and (critically) right before
+				// connecting - meaning a character is always auto-saved even if the player never explicitly used
+				// "Save as new". This also covers players upgrading into this build with a pre-existing server-side
+				// character: their first settings save bookmarks it here instead of the list starting out empty.
+				globalThis.SyncLastUsedProfile = ()=>
+				{
+					let list = globalThis.GetLocalProfiles();
+					let save = globalThis.SavePlayerSettingsAsObject();
+
+					let entry = { id: LAST_USED_PROFILE_ID, name: LAST_USED_PROFILE_NAME, timestamp: Date.now(), save };
+
+					let idx = list.findIndex( p=>p.id === LAST_USED_PROFILE_ID );
+					if ( idx === -1 )
+					list.unshift( entry );
+					else
+					list[ idx ] = entry;
+
+					globalThis.SetLocalProfiles( list );
+					RefreshProfileList();
+				};
+
+				// Forgets the local side of a character that was just deleted server-side (see sdCharacter's
+				// "Quit and forget this character"): drops any local profile pointing at it, including the
+				// reserved slot if that's what was active, and rolls this browser onto a brand new identity so it
+				// can never stumble back into the now-deleted character by reconnecting with the old my_hash.
+				globalThis.ForgetLocalCharacterIdentity = ()=>
+				{
+					let my_hash_el = inputs_hash[ 'my_hash' ] ? inputs_hash[ 'my_hash' ].el : null;
+
+					if ( !my_hash_el )
+					return;
+
+					let old_hash = my_hash_el.value;
+
+					let list = globalThis.GetLocalProfiles().filter( p=>!p.save || p.save.my_hash !== old_hash );
+					globalThis.SetLocalProfiles( list );
+
+					my_hash_el.value = GenerateHash( 30 );
+
+					globalThis.GetPlayerSettings();
+					globalThis.SavePlayerSettings(); // Also re-syncs "(Last used character)" onto the fresh identity
 				};
 
 				AddHTML(`
@@ -1605,6 +1669,9 @@
 					localStorage.setItem( obj.el.id, obj.el.value );
 				} catch(e){}
 			}
+
+			if ( globalThis.SyncLastUsedProfile )
+			globalThis.SyncLastUsedProfile();
 	    };
 	    globalThis.SavePlayerSettingsAsObject = function() // Should be done after validation which is done by globalThis.GetPlayerSettings
 	    {
@@ -1638,9 +1705,9 @@
 	    
 	
 	    document.getElementById( 'last_local_time_start' ).value = Date.now();
-	    globalThis.SavePlayerSettings();
-	    
-	    
+	    globalThis.SavePlayerSettings(); // Also seeds/refreshes "(Last used character)" via SyncLastUsedProfile
+
+
 	    globalThis.ResetSkin = function()
 	    {
 			for ( let i = 0; i < inputs.length; i++ )

--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -8063,7 +8063,7 @@ THING is cosmic mic drop!`;
 							
 							this.AddClientSideActionContextOption( 'Quit and forget this character', ()=>
 							{
-								if ( sdWorld.my_score < 50 || confirm( 'Are you sure you want to forget this character? This will permanently delete it and cannot be undone.' ) )
+								if ( confirm( 'Are you sure you want to forget this character? This will permanently delete it and cannot be undone.' ) )
 								{
 									globalThis.socket.emit( 'ENTITY_CONTEXT_ACTION', [ this.GetClass(), this._net_id, 'SELF_DELETE_CHARACTER', [] ] );
 
@@ -8073,7 +8073,7 @@ THING is cosmic mic drop!`;
 									globalThis.manually_disconnected = true;
 									globalThis.socket.disconnect();
 								}
-							});
+							}, true, { color:'ff0000' } );
 							this.AddContextOption( 'Teleport to closest/cheapest claimed rescue teleport', 'RTP', [] );
 
 							this.AddClientSideActionContextOption( 'Copy character hash ID', ()=>

--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -7803,6 +7803,17 @@ THING is cosmic mic drop!`;
 						this.ManualRTPSequence( false );
 					}
 
+					if ( command_name === 'SELF_DELETE_CHARACTER' ) // "Quit and forget this character" - permanently removes the character requesting its own deletion
+					{
+						if ( executer_socket )
+						executer_socket.character = null;
+
+						this._socket = null;
+						this._my_hash = undefined; // Detach identity - never to be reconnected to again, even if this entity somehow lingered
+
+						this.remove();
+					}
+
 					if ( command_name === 'EMOTE' )
 					{
 						if ( parameters_array[ 0 ] === 'HEARTS' )
@@ -8052,9 +8063,15 @@ THING is cosmic mic drop!`;
 							
 							this.AddClientSideActionContextOption( 'Quit and forget this character', ()=>
 							{
-								if ( sdWorld.my_score < 50 || confirm( 'Are you sure you want to forget this character?' ) )
+								if ( sdWorld.my_score < 50 || confirm( 'Are you sure you want to forget this character? This will permanently delete it and cannot be undone.' ) )
 								{
-									sdWorld.Stop();
+									globalThis.socket.emit( 'ENTITY_CONTEXT_ACTION', [ this.GetClass(), this._net_id, 'SELF_DELETE_CHARACTER', [] ] );
+
+									if ( globalThis.ForgetLocalCharacterIdentity )
+									globalThis.ForgetLocalCharacterIdentity();
+
+									globalThis.manually_disconnected = true;
+									globalThis.socket.disconnect();
 								}
 							});
 							this.AddContextOption( 'Teleport to closest/cheapest claimed rescue teleport', 'RTP', [] );


### PR DESCRIPTION
## Summary

Follow-up to #266 (character profile selector). Two related gaps in that feature meant a player's character was never reliably remembered on reconnect, and the "delete my character" option didn't do anything:

- **Reconnecting didn't resume the last character by default.** The local profile selector always opened on a blank `- Select a saved character -` placeholder, and nothing ever auto-saved a profile unless the player explicitly clicked "Save as new". A new reserved `(Last used character)` entry now mirrors whatever character/settings are currently active, refreshed on every settings save (including the very first save for brand-new characters, and for players who already had a server-side character before this feature existed). The dropdown now auto-selects whichever saved profile matches the currently active identity, so rejoining always shows (and uses) the right character without any manual action.
- **"Quit and forget this character" didn't forget anything.** It was a stub that just called `sdWorld.Stop()` (equivalent to closing the tab) - no server request, no local cleanup. It now sends the server a `SELF_DELETE_CHARACTER` command that permanently removes the character entity, and the client rolls onto a brand-new identity (clearing any local profile(s) pointed at the now-deleted character) so the old character can never be reconnected to again.

## Changes

- `game/client/sdStartupScreen_v2.js`
  - `SyncLastUsedProfile()`: keeps a reserved `(Last used character)` local-profile slot pinned to the currently active settings/identity, called from `SavePlayerSettings()` so it stays fresh automatically.
  - `RefreshProfileList()`: auto-selects whichever saved profile (reserved or explicitly named) matches the currently active `my_hash`.
  - `ForgetLocalCharacterIdentity()`: drops local profiles tied to a deleted character and generates a fresh identity.
- `game/entities/sdCharacter.js`
  - New self-targeted `SELF_DELETE_CHARACTER` context command that removes the requesting character server-side.
  - "Quit and forget this character" now emits that command, forgets the local identity, and disconnects - instead of only disconnecting.

## Test plan

- [x] Verified in a local dev server: fresh browser session gets a `(Last used character)` entry auto-created and auto-selected; the same identity/entry persists correctly across page reloads.
- [x] `node --check` on both changed files.
- [ ] Manual multiplayer test of "Quit and forget this character" (delete a character, confirm it can't be reconnected to, confirm a fresh character spawns next join) - not yet verified against a live multi-client session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)