### PR TITLE
Fix server crash from corrupted sand worm melee vs. sealed characters

### DIFF
--- a/game/entities/sdSandWorm.js
+++ b/game/entities/sdSandWorm.js
@@ -1384,8 +1384,15 @@ class sdSandWorm extends sdEntity
 				if ( this.kind === sdSandWorm.KIND_CORRUPTED_WORM )
 				if ( from_entity.is( sdCharacter ) ) // Copy-pasted from sdBlock.CorruptAttack();
 				{
-					from_entity._sickness += 30;
-					from_entity._last_sickness_from_ent = this;
+					// _sickness/_last_sickness_from_ent are dead raw properties (sdCharacter never
+					// initializes them - see the commented-out declarations in its constructor), and
+					// every entity gets Object.sealed shortly after creation (sdWorld's to_seal_list
+					// pass) for V8 hidden-class performance. Writing a raw property that was never
+					// part of the sealed shape throws "Cannot add property ..., object is not
+					// extensible" and crashes the whole server the first time a corrupted worm melees
+					// a player. sdBlock.CorruptAttack() (what this block was copy-pasted from) already
+					// goes through the proper status-effect API instead of a raw property - use that.
+					from_entity.ApplyStatusEffect({ type: sdStatusEffect.TYPE_SICKNESS, sickness: 30, intensity: 1, owner: this });
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Every entity gets `Object.seal()`'d shortly after creation (`sdEntity.to_seal_list`, a V8 hidden-class performance optimization), which forbids adding any property that wasn't already part of the object's shape at seal time.
- `sdSandWorm`'s `KIND_CORRUPTED_WORM` melee-vs-`sdCharacter` branch was "copy-pasted from `sdBlock.CorruptAttack()`" per its own comment, but kept an older raw-property style (`from_entity._sickness += 30`) instead of porting the `ApplyStatusEffect(TYPE_SICKNESS)` call `CorruptAttack()` actually uses.
- `sdCharacter` never initializes `_sickness` (its declarations are commented out in the constructor), so this always threw `TypeError: Cannot add property _sickness, object is not extensible` the moment a corrupted worm melee-hit any player - taking down the whole process, since nothing catches an error thrown from inside the main tick loop. This is 100% reproducible, not timing-dependent.
- Routed through `ApplyStatusEffect` instead, matching `sdBlock.CorruptAttack()` exactly (same `sickness`/`intensity` magnitude) - it stores state on a separate tracked `sdStatusEffect` entity rather than mutating the target's own sealed property shape.

## Test plan
- [x] `node --check game/entities/sdSandWorm.js`
- [x] Reproduced the crash and confirmed the fix offline with a standalone script that seals a mock character (mirroring `sdWorld`'s seal pass) and confirms: the old raw-property write throws, the new `ApplyStatusEffect` call does not and forwards the same `sickness: 30, intensity: 1` magnitude `sdBlock.CorruptAttack()` uses.
- [ ] Live-server verification that a Corrupted Worm melee no longer crashes the process (crashed a running server before this fix; running clean on a test slot after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)