### PR TITLE
perf(steeringwheel): rigid-group move fast path (RIGID_MOVE_MODE, default on)

### DIFF
--- a/game/entities/sdSteeringWheel.js
+++ b/game/entities/sdSteeringWheel.js
@@ -1669,12 +1669,12 @@ class sdSteeringWheel extends sdEntity
 
 		if ( will_move || forceful )
 		{
-			// phase-13-rigid-05: when RIGID_MOVE_MODE==='on', defer hash-membership updates for ALL moved members to one
-			// batched two-stage rehash after both commit loops below, and replace the per-member callback fan-out with a
-			// scan-each-cell-once cached pass. Byte-identical to the legacy per-member path; the collision decision above
-			// is untouched so will_move / stuff_to_push / stopping are unchanged. 'off' (default) and 'verify' keep the
-			// legacy path exactly.
-			let rigid_on = ( globalThis.RIGID_MOVE_MODE === 'on' );
+			// phase-13-rigid-05: defer hash-membership updates for ALL moved members to one batched two-stage rehash
+			// after both commit loops below, and replace the per-member callback fan-out with a scan-each-cell-once
+			// cached pass. Byte-identical to the legacy per-member path; the collision decision above is untouched so
+			// will_move / stuff_to_push / stopping are unchanged. Default is ON; explicit RIGID_MOVE_MODE==='off' or
+			// 'verify' (read-only dry-run against the legacy path) opt back out.
+			let rigid_on = ( globalThis.RIGID_MOVE_MODE !== 'off' && globalThis.RIGID_MOVE_MODE !== 'verify' );
 
 			for ( let i = 0; i < scan.length; i++ )
 			{

--- a/game/entities/sdSteeringWheel.js
+++ b/game/entities/sdSteeringWheel.js
@@ -53,7 +53,14 @@ class sdSteeringWheel extends sdEntity
 		sdSteeringWheel.TYPE_ELEVATOR_MOTOR = 1;
 		
 		sdSteeringWheel.button_filter = [ 'sdButton' ];
-		
+
+		// phase-13-rigid-01: trace-only census bucket for the rigid-group move fast path eligibility mix.
+		// Populated only when globalThis.DEBUG_RIGID_MOVE_ELIGIBILITY is on; production pays nothing.
+		sdSteeringWheel.rigid_eligibility_profile = sdSteeringWheel.CreateRigidEligibilityProfile();
+
+		// phase-13-rigid-04: dry-run win-estimate bucket for RIGID_MOVE_MODE==='verify'. Read-only; legacy stays authoritative.
+		sdSteeringWheel.rigid_verify_profile = sdSteeringWheel.CreateRigidVerifyProfile();
+
 		/*
 		const drop_rate = 100; // 30000
 		
@@ -1113,6 +1120,228 @@ class sdSteeringWheel extends sdEntity
 		}
 	}
 	
+	static CreateRigidEligibilityProfile() // phase-13-rigid-01: fresh counter bucket for the rigid-fast-path eligibility census
+	{
+		return {
+			start_time: sdWorld.time,
+			moves_total: 0,
+			moves_fully_rigid: 0,   // moves with zero legacy members (dependents allowed) -> the whole move could take the fast path
+			members_total: 0,
+			rigid_total: 0,
+			dependent_total: 0,
+			legacy_total: 0,
+			rigid_class: Object.create( null ),     // GetClass() => count, rigid bucket
+			dependent_class: Object.create( null ), // GetClass() => count, dependent bucket
+			legacy_class: Object.create( null ),    // GetClass() => count, legacy bucket
+			legacy_reason: Object.create( null )    // reason string => count
+		};
+	}
+	// PURE + READ-ONLY eligibility classifier for the rigid-group move fast path. Returns which lane a steering-wheel
+	// move member WOULD take, never mutates anything. Keyed on GetClass() strings + plain property reads only (no
+	// class-system / import dependency), so it can be driven by mock entities in an offline test harness.
+	// move_set = Set of all scan+push members (for cable endpoint co-move check); partial_set = the partial_push_movement
+	// Map (one-axis movers). Returns { bucket:'rigid'|'dependent'|'legacy', reason:string }.
+	static ClassifyRigidMember( entity, move_set, partial_set )
+	{
+		if ( entity._is_being_removed )
+		return { bucket:'legacy', reason:'removed' };
+
+		// client-side / virtual / global entities never enter the rigid batch
+		if ( entity._net_id === undefined )
+		return { bucket:'legacy', reason:'no-net-id' };
+
+		// partial movers (one-axis push) must stay on the legacy lane
+		if ( partial_set && partial_set.has( entity ) )
+		return { bucket:'legacy', reason:'partial-push' };
+
+		// held / carried / contained: a parent/holder owns the relative position or snapshot dependency
+		if ( entity.held_by || entity._held_by || entity.driver_of || entity.hook_relative_to )
+		return { bucket:'legacy', reason:'held-or-contained' };
+
+		const cls = entity.GetClass();
+
+		switch ( cls )
+		{
+			case 'sdBlock': // simple player-made hull block (the bulk of a base)
+			return { bucket:'rigid', reason:'block' };
+
+			case 'sdBG': // player-made background wall
+			return { bucket:'rigid', reason:'bg' };
+
+			case 'sdNode': // cable/signal node. SOLID static fixture, fixed hitbox, no _sensor_area / owned children /
+			// x0-y0, default (no-op) onMovementInRange, onThink never mutates x/y, and all cable/matter/signal logic is
+			// topology-based (not absolute-position) -> safe rigid member.
+			return { bucket:'rigid', reason:'node' };
+
+			case 'sdTurret':
+			{
+				// KIND_LASER_PORTABLE=6 / KIND_SENTRY=9 are non-static physics turrets -> excluded (mirrors sdTurret.KIND_*)
+				if ( entity.kind === 6 || entity.kind === 9 )
+				return { bucket:'legacy', reason:'turret-portable-or-sentry' };
+				if ( !entity.is_static )
+				return { bucket:'legacy', reason:'turret-nonstatic' };
+				return { bucket:'rigid', reason:'turret-static' }; // dependent _sensor_area handled via the 'dependent' bucket below
+			}
+
+			case 'sdAntigravity': // static body; dependent _sensor_area + exterior-field callbacks handled via the 'dependent' bucket
+			return { bucket:'rigid', reason:'antigravity' };
+
+			case 'sdCable':
+			{
+				// endpoint-locked dependent geometry: co-moves cleanly only when BOTH endpoints are in the same rigid move
+				if ( entity.p && entity.c && move_set.has( entity.p ) && move_set.has( entity.c ) )
+				return { bucket:'dependent', reason:'cable-endpoints-comoving' };
+				return { bucket:'legacy', reason:'cable-endpoint-outside' };
+			}
+
+			case 'sdSensorArea': // invisible dependent trigger volume owned by a door/turret/antigravity field
+			return { bucket:'dependent', reason:'sensor-area' };
+
+			case 'sdDoor': // x/y vs x0/y0 + openness/opening_tim/malfunction -> legacy until a dedicated hook exists
+			return { bucket:'legacy', reason:'door-openness' };
+
+			case 'sdBaseShieldingUnit': // per-protected-entity ProtectedEntityMoved bookkeeping must not be batched away
+			return { bucket:'legacy', reason:'bsu-shield-bookkeeping' };
+
+			default: // crystals/amplifiers/water/storage/mobs/items and everything not yet audited -> conservative legacy
+			return { bucket:'legacy', reason:'not-audited:' + cls };
+		}
+	}
+	static DumpRigidEligibilityProfile( reset = true ) // phase-13-rigid-01: print the census, % of members + % of fully-rigid moves
+	{
+		let p = sdSteeringWheel.rigid_eligibility_profile;
+		let dt = Math.max( 0.001, ( sdWorld.time - p.start_time ) / 1000 );
+		function pct( n, d ){ return d > 0 ? ( 100 * n / d ).toFixed( 1 ) : '0.0'; }
+		function Top( obj, limit )
+		{
+			let e = [];
+			for ( let k in obj )
+			e.push( [ k, obj[ k ] ] );
+			e.sort( ( a, b )=>b[ 1 ] - a[ 1 ] );
+			return e.slice( 0, limit ).map( x=>x[ 0 ] + '=' + x[ 1 ] ).join( ', ' );
+		}
+
+		console.warn( '[RIGID_ELIG] ' + dt.toFixed( 1 ) + 's moves=' + p.moves_total +
+			' fully_rigid_moves=' + p.moves_fully_rigid + ' (' + pct( p.moves_fully_rigid, p.moves_total ) + '%)' +
+			' | members=' + p.members_total +
+			' rigid=' + p.rigid_total + ' (' + pct( p.rigid_total, p.members_total ) + '%)' +
+			' dependent=' + p.dependent_total + ' (' + pct( p.dependent_total, p.members_total ) + '%)' +
+			' legacy=' + p.legacy_total + ' (' + pct( p.legacy_total, p.members_total ) + '%)' );
+		if ( p.rigid_total > 0 )
+		console.warn( '[RIGID_ELIG] rigid classes: ' + Top( p.rigid_class, 10 ) );
+		if ( p.dependent_total > 0 )
+		console.warn( '[RIGID_ELIG] dependent classes: ' + Top( p.dependent_class, 10 ) );
+		if ( p.legacy_total > 0 )
+		{
+			console.warn( '[RIGID_ELIG] legacy classes: ' + Top( p.legacy_class, 10 ) );
+			console.warn( '[RIGID_ELIG] legacy reasons: ' + Top( p.legacy_reason, 12 ) );
+		}
+
+		if ( reset )
+		sdSteeringWheel.rigid_eligibility_profile = sdSteeringWheel.CreateRigidEligibilityProfile();
+	}
+	static CreateRigidVerifyProfile() // phase-13-rigid-04: dry-run win-estimate bucket (RIGID_MOVE_MODE==='verify')
+	{
+		return {
+			start_time: sdWorld.time,
+			moves: 0,                 // committed moves seen
+			eligible: 0,              // moves the fast path would attempt (gate pass)
+			members: 0, rigid: 0, dependent: 0, legacy: 0,
+			fallback_reason: Object.create( null ), // why a move is gate-ineligible
+			// cell-scan reduction (Phase 4 proxy), every move:
+			per_member_cells: 0,      // sum of each rigid/dependent member's hash-cell count
+			union_cells: 0,           // distinct hash cells across the group (scan-once target)
+			// leading-edge split (Phase 3 proxy), SAMPLED moves only (geometry is O(area)):
+			sampled_moves: 0, solid_rigid: 0, interior: 0, leading: 0
+		};
+	}
+	static _MemberCellKeys( m ) // hash cells m's hitbox currently overlaps (mirrors UpdateHashPosition cell math; pure, no mutation)
+	{
+		if ( m._net_id === undefined || m._is_being_removed )
+		return null;
+		const CS = sdWorld.CHUNK_SIZE;
+		let from_x = sdWorld.FastFloor( ( m.x + m._hitbox_x1 ) / CS );
+		let from_y = sdWorld.FastFloor( ( m.y + m._hitbox_y1 ) / CS );
+		let to_x = sdWorld.FastCeil( ( m.x + m._hitbox_x2 ) / CS );
+		let to_y = sdWorld.FastCeil( ( m.y + m._hitbox_y2 ) / CS );
+		if ( to_x === from_x ) to_x++;
+		if ( to_y === from_y ) to_y++;
+		let keys = [];
+		for ( let cx = from_x; cx < to_x; cx++ )
+		for ( let cy = from_y; cy < to_y; cy++ )
+		keys.push( cx + ',' + cy );
+		return keys;
+	}
+	// READ-ONLY dry run for RIGID_MOVE_MODE==='verify'. Called AFTER the legacy commit (members already at final
+	// positions). Measures, on the LIVE base, the fast path's expected win WITHOUT mutating anything: partition mix,
+	// gate-eligibility, and the cell-scan reduction (per-member vs union cells). Wrapped in try/catch by the caller so a
+	// diagnostic bug can NEVER affect the real move.
+	static RigidMoveDryRun( scan, stuff_to_push, partial_push_movement, xx, yy, forceful )
+	{
+		let p = sdSteeringWheel.rigid_verify_profile;
+		if ( sdWorld.time - p.start_time >= 5000 ) // auto-print + reset at most every 5s
+		{
+			sdSteeringWheel.DumpRigidVerifyProfile( true );
+			p = sdSteeringWheel.rigid_verify_profile;
+		}
+
+		let move_set = new Set( scan );
+		for ( let i = 0; i < stuff_to_push.length; i++ )
+		move_set.add( stuff_to_push[ i ] );
+
+		let rigid = [], dependent = [];
+		let rigid_n = 0, dependent_n = 0, legacy_n = 0;
+		const Tally = ( e )=>
+		{
+			let v = sdSteeringWheel.ClassifyRigidMember( e, move_set, partial_push_movement );
+			if ( v.bucket === 'rigid' ) { rigid_n++; rigid.push( e ); }
+			else if ( v.bucket === 'dependent' ) { dependent_n++; dependent.push( e ); }
+			else legacy_n++;
+		};
+		for ( let i = 0; i < scan.length; i++ ) Tally( scan[ i ] );
+		for ( let i = 0; i < stuff_to_push.length; i++ ) Tally( stuff_to_push[ i ] );
+
+		p.moves++;
+		p.members += rigid_n + dependent_n + legacy_n;
+		p.rigid += rigid_n; p.dependent += dependent_n; p.legacy += legacy_n;
+
+		// gate: forceful moves keep legacy; otherwise eligible.
+		if ( forceful )
+		p.fallback_reason[ 'forceful' ] = ( p.fallback_reason[ 'forceful' ] || 0 ) + 1;
+		else
+		p.eligible++;
+
+		// cell-scan reduction proxy over rigid+dependent (cheap; every move).
+		let union = new Set();
+		for ( let i = 0; i < rigid.length; i++ )
+		{
+			let k = sdSteeringWheel._MemberCellKeys( rigid[ i ] );
+			if ( k ) { p.per_member_cells += k.length; for ( let j = 0; j < k.length; j++ ) union.add( k[ j ] ); }
+		}
+		for ( let i = 0; i < dependent.length; i++ )
+		{
+			let k = sdSteeringWheel._MemberCellKeys( dependent[ i ] );
+			if ( k ) { p.per_member_cells += k.length; for ( let j = 0; j < k.length; j++ ) union.add( k[ j ] ); }
+		}
+		p.union_cells += union.size;
+	}
+	static DumpRigidVerifyProfile( reset = true ) // phase-13-rigid-04
+	{
+		let p = sdSteeringWheel.rigid_verify_profile;
+		let dt = Math.max( 0.001, ( sdWorld.time - p.start_time ) / 1000 );
+		function pct( n, d ){ return d > 0 ? ( 100 * n / d ).toFixed( 1 ) : '0.0'; }
+		function Top( obj ){ let e=[]; for ( let k in obj ) e.push( k+'='+obj[k] ); return e.join( ', ' ); }
+
+		console.warn( '[RIGID_VERIFY] ' + dt.toFixed( 1 ) + 's moves=' + p.moves + ' eligible=' + p.eligible + ' (' + pct( p.eligible, p.moves ) + '%)' +
+			' | members=' + p.members + ' rigid=' + pct( p.rigid, p.members ) + '% dep=' + pct( p.dependent, p.members ) + '% legacy=' + pct( p.legacy, p.members ) + '%' );
+		console.warn( '[RIGID_VERIFY] cell-scan: per_member=' + p.per_member_cells + ' union=' + p.union_cells +
+			' -> ' + pct( p.per_member_cells - p.union_cells, p.per_member_cells ) + '% fewer cell-scans' );
+		if ( p.moves - p.eligible > 0 )
+		console.warn( '[RIGID_VERIFY] fallback: ' + Top( p.fallback_reason ) );
+
+		if ( reset )
+		sdSteeringWheel.rigid_verify_profile = sdSteeringWheel.CreateRigidVerifyProfile();
+	}
 	static ComplexElevatorLikeMove( scan, _scan_net_ids, xx, yy, forceful, GSPEED, force_push_bsus=false, initiator=null ) // GSPEED only used for damage scaling
 	{
 		let stuff_to_push = [];
@@ -1440,12 +1669,20 @@ class sdSteeringWheel extends sdEntity
 
 		if ( will_move || forceful )
 		{
+			// phase-13-rigid-05: when RIGID_MOVE_MODE==='on', defer hash-membership updates for ALL moved members to one
+			// batched two-stage rehash after both commit loops below, and replace the per-member callback fan-out with a
+			// scan-each-cell-once cached pass. Byte-identical to the legacy per-member path; the collision decision above
+			// is untouched so will_move / stuff_to_push / stopping are unchanged. 'off' (default) and 'verify' keep the
+			// legacy path exactly.
+			let rigid_on = ( globalThis.RIGID_MOVE_MODE === 'on' );
+
 			for ( let i = 0; i < scan.length; i++ )
 			{
 				let current = scan[ i ];
 
 				current.x += xx;
 				current.y += yy;
+				if ( !rigid_on )
 				sdWorld.UpdateHashPosition( current, false, false );
 				current._last_x = current.x; // Hacky, prevents calling ManageTrackedPhysWakeup in sdWorld entity loop
 				current._last_y = current.y; // Hacky, prevents calling ManageTrackedPhysWakeup in sdWorld entity loop
@@ -1511,6 +1748,7 @@ class sdSteeringWheel extends sdEntity
 				{
 					throw new Error();
 				}
+				if ( !rigid_on )
 				sdWorld.UpdateHashPosition( item, false, false );
 				item._last_x = item.x; // Hacky, prevents calling ManageTrackedPhysWakeup in sdWorld entity loop
 				item._last_y = item.y; // Hacky, prevents calling ManageTrackedPhysWakeup in sdWorld entity loop
@@ -1529,16 +1767,104 @@ class sdSteeringWheel extends sdEntity
 				item.ApplyStatusEffect({ type: sdStatusEffect.TYPE_STEERING_WHEEL_MOVEMENT_SMOOTH, tx:item.x, ty:item.y });
 			}
 			
-			// Call movement in range for everything together, or else motors won't trigger any switches
-			for ( let i = 0; i < scan.length; i++ )
+			// phase-13-rigid-05: fast-path membership rehash. All members are now at final x/y; batch their hash-cell
+			// membership in one two-stage pass (no per-member churn). Only when RIGID_MOVE_MODE==='on'.
+			let rigid_all_moved = null;
+			if ( rigid_on )
 			{
-				let current = scan[ i ];
-				sdWorld.UpdateHashPosition( current, false, true );
+				rigid_all_moved = [];
+				for ( let i = 0; i < scan.length; i++ )
+				rigid_all_moved.push( scan[ i ] );
+				for ( let i = 0; i < stuff_to_push.length; i++ )
+				rigid_all_moved.push( stuff_to_push[ i ] );
+				sdWorld.UpdateHashPositionBatchRigid( rigid_all_moved );
 			}
-			for ( let i = 0; i < stuff_to_push.length; i++ )
+
+			// phase-13-rigid-01: trace-only rigid-fast-path eligibility census (gated; counting only, no behavior change).
+			// Runs once per COMMITTED move and answers: does the live moving base have enough rigid/dependent members
+			// (vs legacy hold-outs) to justify the fast path? Reads the already-final scan + stuff_to_push +
+			// partial_push_movement that were just moved above.
+			if ( globalThis.DEBUG_RIGID_MOVE_ELIGIBILITY )
 			{
-				let current = stuff_to_push[ i ];
-				sdWorld.UpdateHashPosition( current, false, true );
+				if ( sdWorld.time - sdSteeringWheel.rigid_eligibility_profile.start_time >= 5000 ) // auto-print + reset at most every 5s
+				sdSteeringWheel.DumpRigidEligibilityProfile( true );
+
+				let prof = sdSteeringWheel.rigid_eligibility_profile;
+
+				let move_set = new Set( scan );
+				for ( let i = 0; i < stuff_to_push.length; i++ )
+				move_set.add( stuff_to_push[ i ] );
+
+				let rigid_n = 0, dependent_n = 0, legacy_n = 0;
+				const Tally = ( entity )=>
+				{
+					let v = sdSteeringWheel.ClassifyRigidMember( entity, move_set, partial_push_movement );
+					let cls = entity.GetClass();
+					if ( v.bucket === 'rigid' )
+					{
+						rigid_n++;
+						prof.rigid_class[ cls ] = ( prof.rigid_class[ cls ] || 0 ) + 1;
+					}
+					else if ( v.bucket === 'dependent' )
+					{
+						dependent_n++;
+						prof.dependent_class[ cls ] = ( prof.dependent_class[ cls ] || 0 ) + 1;
+					}
+					else
+					{
+						legacy_n++;
+						prof.legacy_class[ cls ] = ( prof.legacy_class[ cls ] || 0 ) + 1;
+						prof.legacy_reason[ v.reason ] = ( prof.legacy_reason[ v.reason ] || 0 ) + 1;
+					}
+				};
+				for ( let i = 0; i < scan.length; i++ )
+				Tally( scan[ i ] );
+				for ( let i = 0; i < stuff_to_push.length; i++ )
+				Tally( stuff_to_push[ i ] );
+
+				prof.moves_total++;
+				prof.members_total += rigid_n + dependent_n + legacy_n;
+				prof.rigid_total += rigid_n;
+				prof.dependent_total += dependent_n;
+				prof.legacy_total += legacy_n;
+				if ( legacy_n === 0 )
+				prof.moves_fully_rigid++;
+			}
+
+			// phase-13-rigid-04: verify/dry-run mode - read-only fast-path win estimate on the live base (legacy stays
+			// authoritative). Wrapped so a diagnostic bug can NEVER affect the real move - verify mode is strictly zero-risk.
+			if ( globalThis.RIGID_MOVE_MODE === 'verify' )
+			{
+				try { sdSteeringWheel.RigidMoveDryRun( scan, stuff_to_push, partial_push_movement, xx, yy, forceful ); }
+				catch ( e ) { if ( !sdSteeringWheel._rigid_verify_warned ) { sdSteeringWheel._rigid_verify_warned = true; console.warn( '[RIGID_VERIFY] dry-run error (suppressed, legacy unaffected): ' + e ); } }
+			}
+
+			if ( rigid_on )
+			{
+				// phase-13-rigid-05: fast-path callback fan-out. Membership is already final (batch above), so scan the
+				// union of the group's cells ONCE to find reactive occupants, then dispatch per member in the SAME
+				// scan-then-push order as legacy. Byte-identical onMovementInRange multiset+order; the cache is pinned to
+				// the membership seq so any callback that mutates the hash mid-pass safely drops the rest to a full scan.
+				let cache = sdWorld.BuildRigidReactiveCache( rigid_all_moved );
+				let cache_seq = sdWorld._rigid_membership_seq;
+				for ( let i = 0; i < scan.length; i++ )
+				sdWorld.RigidMemberCallbacks( scan[ i ], cache, cache_seq );
+				for ( let i = 0; i < stuff_to_push.length; i++ )
+				sdWorld.RigidMemberCallbacks( stuff_to_push[ i ], cache, cache_seq );
+			}
+			else
+			{
+				// Call movement in range for everything together, or else motors won't trigger any switches
+				for ( let i = 0; i < scan.length; i++ )
+				{
+					let current = scan[ i ];
+					sdWorld.UpdateHashPosition( current, false, true );
+				}
+				for ( let i = 0; i < stuff_to_push.length; i++ )
+				{
+					let current = stuff_to_push[ i ];
+					sdWorld.UpdateHashPosition( current, false, true );
+				}
 			}
 		}
 		else

--- a/game/sdWorld.js
+++ b/game/sdWorld.js
@@ -139,6 +139,14 @@ class sdWorld
 		// phase-13-fanout-03: live byte-identical check for the sensor-area index (SENSOR_SCAN_MODE==='verify').
 		sdWorld.sensor_verify_profile = sdWorld.CreateSensorVerifyProfile();
 
+		// phase-13-rigid-05: monotonic counter bumped ONLY when UpdateHashPosition / the rigid batch actually change a
+		// hash-cell membership. The rigid fast-path callback fan-out (sdSteeringWheel.ComplexElevatorLikeMove when
+		// globalThis.RIGID_MOVE_MODE==='on') builds a per-cell reactive-occupant cache once and trusts it only while this
+		// counter is unchanged; if a movement callback moves/removes an entity mid-pass (real membership change) the
+		// counter advances and the remaining members fall back to a full per-cell scan, keeping the fast path
+		// byte-identical to the legacy per-member path regardless of what callbacks do.
+		sdWorld._rigid_membership_seq = 0;
+
 		sdWorld.target_scale = 2; // Current one, this one depends on screen size
 		sdWorld.default_zoom = 2;
 		sdWorld.current_zoom = sdWorld.default_zoom; // Synced from server, for example when player is in vehicle or steering wheel
@@ -2843,12 +2851,14 @@ class sdWorld
 		//if ( entity._hash_position !== new_hash_position )
 		if ( !sdWorld.ArraysEqualIgnoringOrder( entity._affected_hash_arrays, new_affected_hash_arrays ) )
 		{
+			sdWorld._rigid_membership_seq++; // phase-13-rigid-05: real hash-membership change -> invalidate any in-flight rigid reactive cache
+
 			for ( var i = 0; i < entity._affected_hash_arrays.length; i++ )
 			{
 				var ind = entity._affected_hash_arrays[ i ].arr.indexOf( entity );
 				if ( ind === -1 )
 				throw new Error('Bad hash object - it should contain this entity but it does not');
-			
+
 				entity._affected_hash_arrays[ i ].arr.splice( ind, 1 );
 				sdWorld._SensorIndexRemove( entity._affected_hash_arrays[ i ], entity ); // phase-13-fanout-03
 				//entity._affected_hash_arrays[ i ].RecreateWithout( ind );
@@ -3087,6 +3097,219 @@ class sdWorld
 				});
 			}
 		}
+	}
+	// ================================================================================================================
+	// phase-13-rigid-05: authoritative rigid-group move fast path, used ONLY by sdSteeringWheel.ComplexElevatorLikeMove
+	// when globalThis.RIGID_MOVE_MODE === 'on'. A steering-wheel move translates a whole base rigidly; the legacy code
+	// above treats it as many independent entity moves, each of which (a) rehashes its own cells and (b) re-scans all of
+	// its cells for movement-callback neighbours, so a dense base-interior cell gets re-iterated once per co-located
+	// member. These helpers rehash the whole group in two stages and scan each shared cell ONCE, producing the SAME
+	// world_hash_positions membership and the SAME onMovementInRange invocation multiset+order as the legacy per-member
+	// path. All members must already be at their FINAL x/y (the steering commit loops move them) before these run.
+	// Deliberately independent of the sensor_relevant_arr (phase-13-fanout-03) SENSOR_SCAN_MODE branch above: that branch
+	// only ever activates for an sdSensorArea mover, and sdSensorArea is never a `scan`/`stuff_to_push` member itself
+	// (sdSteeringWheel.ClassifyRigidMember buckets it as 'dependent'), so it never reaches RigidMemberCallbacks as `entity`.
+
+	static RigidComputeNewCells( entity ) // mirror of the cell-list math in UpdateHashPosition (cells the hitbox overlaps)
+	{
+		let cells = [];
+		if ( entity._is_being_removed || entity._net_id === undefined )
+		return cells;
+
+		let from_x = sdWorld.FastFloor( ( entity.x + entity._hitbox_x1 ) * CHUNK_SIZE_INV );
+		let from_y = sdWorld.FastFloor( ( entity.y + entity._hitbox_y1 ) * CHUNK_SIZE_INV );
+		let to_x = sdWorld.FastCeil( ( entity.x + entity._hitbox_x2 ) * CHUNK_SIZE_INV );
+		let to_y = sdWorld.FastCeil( ( entity.y + entity._hitbox_y2 ) * CHUNK_SIZE_INV );
+
+		if ( to_x === from_x )
+		to_x++;
+		if ( to_y === from_y )
+		to_y++;
+
+		if ( ( to_x - from_x < CHUNK_SIZE && to_y - from_y < CHUNK_SIZE ) || entity.is( sdDeepSleep ) )
+		{
+			for ( let cx = from_x; cx < to_x; cx++ )
+			for ( let cy = from_y; cy < to_y; cy++ )
+			cells.push( sdWorld.RequireHashPosition( cx * CHUNK_SIZE, cy * CHUNK_SIZE, true ) );
+		}
+		else
+		debugger; // ~~ operation overflow / object too huge (matches legacy UpdateHashPosition guard)
+
+		return cells;
+	}
+
+	// Two-stage batched rehash. Equivalent to calling UpdateHashPosition( m, false, false ) for every member IN THE
+	// GIVEN ORDER, but removes all members from their old cells first and only then adds them to their new cells, so a
+	// cell emptied by member A and refilled by member B never gets deleted-and-recreated (the churn). Skip-if-unchanged
+	// is kept per member so a member whose cells did not move keeps its exact position inside each cell's arr (legacy
+	// arr order is preserved -> future scans / Set-insertion order stay byte-identical). NOTE: the deepsleep-stuck DEBUG
+	// diagnostic in UpdateHashPosition (gated by sdDeepSleep.debug_track_entity_stucking..., off in production) is
+	// intentionally not replicated here; it has no behavioural effect.
+	static UpdateHashPositionBatchRigid( members )
+	{
+		// Stage 0: refresh hitboxes + compute each member's new cells; collect the ones whose cells actually moved.
+		// NOTE: game entities are Object.seal'd (non-extensible) so we CANNOT stash scratch state on the member -
+		// the changed members + their new cells are held in two parallel local arrays.
+		let changed_m = [];
+		let changed_nc = [];
+		for ( let i = 0; i < members.length; i++ )
+		{
+			let m = members[ i ];
+			m.UpdateHitbox();
+			let nc = sdWorld.RigidComputeNewCells( m );
+			if ( !sdWorld.ArraysEqualIgnoringOrder( m._affected_hash_arrays, nc ) ) // unchanged -> do not touch the hash for this member
+			{
+				changed_m.push( m );
+				changed_nc.push( nc );
+			}
+		}
+
+		if ( changed_m.length === 0 )
+		return; // nothing moved cells (rare for a real move, but cheap to short-circuit)
+
+		sdWorld._rigid_membership_seq++; // phase-13-rigid-05: real membership change (matches the per-member bump UpdateHashPosition would have done)
+
+		// Stage 1: remove every changed member from its OLD cells. Defer empty-cell deletion (a cell emptied here may be
+		// refilled in stage 2 by another member; deleting+recreating it would churn world_hash_positions for nothing).
+		let maybe_empty = [];
+		for ( let i = 0; i < changed_m.length; i++ )
+		{
+			let m = changed_m[ i ];
+			let old = m._affected_hash_arrays;
+			for ( let j = 0; j < old.length; j++ )
+			{
+				let cell = old[ j ];
+				let ind = cell.arr.indexOf( m );
+				if ( ind === -1 )
+				throw new Error( 'Bad hash object - rigid batch: member missing from one of its old cells' );
+				cell.arr.splice( ind, 1 );
+				sdWorld._SensorIndexRemove( cell, m ); // phase-13-fanout-03
+				maybe_empty.push( cell );
+			}
+		}
+
+		// Stage 2: add every changed member to its NEW cells, in member order (matches legacy append order), then commit.
+		for ( let i = 0; i < changed_m.length; i++ )
+		{
+			let m = changed_m[ i ];
+			let nc = changed_nc[ i ];
+			for ( let j = 0; j < nc.length; j++ )
+			{
+				nc[ j ].arr.push( m );
+				sdWorld._SensorIndexAdd( nc[ j ], m ); // phase-13-fanout-03
+				if ( nc[ j ].arr.length > 1000 ) // legacy NaN-bounds guard
+				debugger;
+			}
+			m._affected_hash_arrays = nc; // pre-existing property -> safe to assign on a sealed entity
+		}
+
+		// Stage 3: delete any old cell that ended up genuinely empty (no member or external re-added). Safe now all adds ran.
+		for ( let i = 0; i < maybe_empty.length; i++ )
+		{
+			let cell = maybe_empty[ i ];
+			if ( cell.arr.length === 0 )
+			sdWorld.world_hash_positions.delete( cell.hash );
+		}
+	}
+
+	// Scan the union of the group's final cells ONCE and record, per cell, the entities that actually have a
+	// movement-callback handler (onMovementInRange overridden). Shared dense cells are visited a single time (the win).
+	// Returns Map<Cell, Entity[]|null>; null entry = cell scanned, no reactive occupants (the common case for base hull).
+	static BuildRigidReactiveCache( members )
+	{
+		const default_handler = sdEntity.prototype.onMovementInRange;
+		let cache = new Map();
+		for ( let i = 0; i < members.length; i++ )
+		{
+			let cells = members[ i ]._affected_hash_arrays;
+			for ( let j = 0; j < cells.length; j++ )
+			{
+				let cell = cells[ j ];
+				if ( cache.has( cell ) )
+				continue; // already scanned (shared cell) -> scan-each-cell-once
+				let arr = cell.arr;
+				let reactive = null;
+				for ( let k = 0; k < arr.length; k++ )
+				if ( arr[ k ].onMovementInRange !== default_handler )
+				{
+					if ( reactive === null )
+					reactive = [];
+					reactive.push( arr[ k ] );
+				}
+				cache.set( cell, reactive );
+			}
+		}
+		return cache;
+	}
+
+	// Per-member movement-callback fan-out, byte-identical to the allow_calling_movement_in_range=true branch of
+	// UpdateHashPosition for a member whose hash membership is ALREADY final (set by the batch above). For a member with
+	// a default onMovementInRange (the rigid mass: blocks/BG/nodes) the legacy queue condition reduces to
+	// `another_has_handler && CanReactToMovement( another, member )`, so only a cell's reactive occupants can ever be
+	// queued -> iterate just those (from the cache), giving an identical Set (membership AND order, since the cache
+	// preserves arr order) with far fewer iterations. A member that DOES have a handler must still see every neighbour,
+	// so it scans the full cell. cache_seq pins the cache to the membership state at build time; if a prior callback
+	// changed hash membership (seq advanced) the cache may be stale, so this member falls back to the full per-cell scan
+	// (= legacy).
+	static RigidMemberCallbacks( entity, reactive_cache, cache_seq )
+	{
+		if ( entity._is_being_removed )
+		return;
+
+		entity._last_x = entity.x;
+		entity._last_y = entity.y;
+
+		const default_handler = sdEntity.prototype.onMovementInRange;
+		let m1 = ( entity.onMovementInRange !== default_handler );
+		let cache_ok = ( sdWorld._rigid_membership_seq === cache_seq );
+		let cells = entity._affected_hash_arrays;
+		let map = new Set();
+
+		for ( let i2 = 0; i2 < cells.length; i2++ )
+		{
+			let cell = cells[ i2 ];
+			let list = ( m1 || !cache_ok ) ? cell.arr : reactive_cache.get( cell );
+			if ( !list )
+			continue;
+			for ( let i = 0; i < list.length; i++ )
+			{
+				let another_entity = list[ i ];
+				if ( another_entity !== entity )
+				{
+					let m2 = ( another_entity.onMovementInRange !== default_handler );
+					if ( m1 || m2 )
+					if ( entity.x + entity._hitbox_x2 > another_entity.x + another_entity._hitbox_x1 &&
+						 entity.x + entity._hitbox_x1 < another_entity.x + another_entity._hitbox_x2 &&
+						 entity.y + entity._hitbox_y2 > another_entity.y + another_entity._hitbox_y1 &&
+						 entity.y + entity._hitbox_y1 < another_entity.y + another_entity._hitbox_y2 )
+					{
+						if ( ( m1 && sdWorld.CanReactToMovement( entity, another_entity ) ) ||
+							 ( m2 && sdWorld.CanReactToMovement( another_entity, entity ) ) )
+						map.add( another_entity );
+					}
+				}
+			}
+		}
+
+		let water = sdWater.all_swimmers.get( entity );
+		if ( water )
+		map.add( water );
+
+		map.forEach( ( another_entity )=>
+		{
+			if ( !another_entity._is_being_removed )
+			if ( !entity._is_being_removed )
+			{
+				let mm1 = ( entity.onMovementInRange !== default_handler );
+				let mm2 = ( another_entity.onMovementInRange !== default_handler );
+
+				if ( mm1 )
+				entity.onMovementInRange( another_entity );
+
+				if ( mm2 )
+				another_entity.onMovementInRange( entity );
+			}
+		});
 	}
     static GetTimeWarpSpeedForEntity( e )  // Anything distance/range base is better to handle with sdSensorArea-s, even crystal glow probably
     {


### PR DESCRIPTION
## Summary
- Moving a large flying base ("Skybase") via `sdSteeringWheel` measured sustained 90-110%+ CPU for 90+ seconds on a live production server (baseline ~70%), captured directly via `top` sampling while a player moved their base. Root cause: `ComplexElevatorLikeMove()` treats a rigid base translation as N independent entity moves — each of which rehashes its own collision cells AND re-scans every one of those cells for `onMovementInRange` neighbours, every tick. A dense base-interior cell gets re-scanned once per co-located member.
- Adds a `RIGID_MOVE_MODE`-gated fast path, **default on**:
  - default/unset/`'on'`: batches the whole group's hash-cell membership rehash into one two-stage pass (`UpdateHashPositionBatchRigid` - remove from old cells, then add to new cells, deferring empty-cell deletion so a cell emptied-then-refilled by another member doesn't churn) and scans each shared cell once via `BuildRigidReactiveCache`/`RigidMemberCallbacks` instead of per-member. A monotonic `sdWorld._rigid_membership_seq` counter invalidates the cache if any callback mutates hash membership mid-pass, falling back to a full per-cell scan for the rest - so this can't silently desync even under adversarial callback behavior.
  - `'off'`: opt out entirely, byte-identical to the pre-fast-path legacy behavior - every behavior change is gated behind `if (!rigid_on)` / `if (rigid_on) {...} else { <original> }`, the collision/stop decision logic above is untouched.
  - `'verify'`: forces the legacy path (authoritative) and additionally runs a read-only dry-run (`RigidMoveDryRun`, try/catch-wrapped so a bug in it can never affect the real move) that measures the fast path's would-be partition mix and cell-scan reduction for a live win estimate with zero risk.
- `ClassifyRigidMember` conservatively buckets each attached entity as `rigid` (blocks/BG/nodes/static turrets/antigravity), `dependent` (sensor areas, co-moving cable endpoints - handled via the shared-cell scan), or `legacy` (doors, BSU shield bookkeeping, non-static physics, partial-axis pushers, anything not yet audited) - unrecognized classes default to `legacy`, so the fast path only ever activates for entities it explicitly understands.

## Test plan
- [x] `node --check` on both touched files
- [x] Offline fuzz harness (gitignored `devtests/` tooling, not in this diff): hundreds of thousands of randomized rigid-group-move scenarios, including entities removed by a callback mid-pass, asserting byte-identical resulting hash-cell membership (including per-cell order) and identical `onMovementInRange` invocation multiset+order between the legacy path and `RIGID_MOVE_MODE='on'`, driven from independent world instances seeded from identical initial state
- [x] Deployed inert (`RIGID_MOVE_MODE` unset, matching the then-default of legacy-only) to VPS slot-1003
- [ ] Live before/after profile of a real Skybase move with the fast path active on a populated server - still outstanding; the offline fuzz coverage is the only evidence backing this default flip
- [ ] Multi-player soak test before wider rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
