### PR TITLE
Fix SaveSnapshot retry loop reusing stale duplicate-net_id/entity state

### DIFF
--- a/game/server/sdServerConfig.js
+++ b/game/server/sdServerConfig.js
@@ -2124,6 +2124,19 @@ class sdServerConfigFull extends sdServerConfigShort
 
 			while ( true )
 			{
+				// entities/saved_net_ids/duplicate_net_id_skips must be reset on every pass through this loop:
+				// when JSON.stringify(save_obj) throws below, the loop retries with one_by_one=true using the
+				// SAME entities array and saved_net_ids Set. Without this reset, the retry pass finds every
+				// entity's _net_id already present in saved_net_ids from the first pass and skips it as a
+				// "duplicate" via `continue` - before it ever reaches the one_by_one JSON.stringify try/catch
+				// further down. That both floods the log with false duplicate-_net_id warnings for virtually
+				// every entity in the world (nothing was actually duplicated - it's the same entity revisited
+				// on pass 2) and defeats the one-by-one diagnostic entirely, guaranteeing the "...Did not
+				// find?" fallback below fires instead of ever identifying the real unserializable object.
+				entities.length = 0;
+				saved_net_ids.clear();
+				duplicate_net_id_skips = 0;
+
 				for ( var i = 0; i < sdEntity.entities.length; i++ )
 				if ( !sdEntity.entities[ i ]._is_being_removed )
 				if ( !sdWorld.server_config.EntitySaveAllowedTest || sdWorld.server_config.EntitySaveAllowedTest( sdEntity.entities[ i ] ) )


### PR DESCRIPTION
## Summary
Root cause of the SaveSnapshot crash that's been hit twice in production:
```
Trace: SaveSnapshot: skipping duplicate _net_id ... [x thousands]
Trace: SaveSnapshot: skipped 42794 duplicate-_net_id entities...
Error: ...Did not find?
```

`entities`, `saved_net_ids`, and `duplicate_net_id_skips` were declared **outside** the `while ( true )` retry loop in `SaveSnapshot`. That loop's only retry path fires when `JSON.stringify( save_obj )` throws (some entity's snapshot can't be JSON-ed): it sets `one_by_one = true` and loops back, intending to test each entity's snapshot individually via `JSON.stringify` to identify the culprit.

Without resetting that state at the top of each pass, the retry pass re-iterates every live entity while `saved_net_ids` still holds every `_net_id` from the first pass, so `saved_net_ids.has( _dup_net_id )` is true for virtually the entire entity list. Each one hits `continue` (a **false** "duplicate _net_id" warning) *before* the loop body ever reaches the `one_by_one` `JSON.stringify` try/catch further down.

Net effect, observed live twice: a flood of bogus duplicate-`_net_id` warnings for nearly every entity in the world (nothing was actually duplicated - it's the same entity revisited on the retry pass), and the one-by-one diagnostic never actually tests anything, so the fallback `throw new Error( '...Did not find?' )` always fires - crashing the process with no indication of what actually caused the original JSON failure.

## Fix
Reset `entities.length = 0`, `saved_net_ids.clear()`, and `duplicate_net_id_skips = 0` at the top of every `while ( true )` pass, so:
- A genuine duplicate `_net_id` is still correctly detected and reported (once, not compounded across passes).
- The one-by-one diagnostic can actually run on the retry pass and identify the real unserializable entity.

See the companion PR (#TODO) which extends that diagnostic further to also cover `save_obj`'s non-entity fields.

## Test plan
- [x] Offline regression suite: `_audit_savesnapshot_retry_state_leak_test.cjs` (11/11), proving the old code falsely flags all entities as duplicates and never identifies the injected culprit, while the fixed code reports zero false duplicates and correctly identifies it - and that a normal (no-retry) save is unaffected.