### PR TITLE
Identify which save_obj field fails JSON.stringify before giving up in SaveSnapshot

### DIFF
--- a/game/server/sdServerConfig.js
+++ b/game/server/sdServerConfig.js
@@ -2195,10 +2195,37 @@ class sdServerConfigFull extends sdServerConfigShort
 
 				if ( one_by_one )
 				{
+					// Every individual entity snapshot above passed its own JSON.stringify test, so the
+					// unserializable value (whatever made the combined JSON.stringify( save_obj ) below throw
+					// in the first place) must be one of save_obj's OTHER top-level fields - this used to go
+					// completely untested, so this path always fell straight through to the opaque
+					// '...Did not find?' throw with no indication of where to even start looking.
+					let other_fields = [ 'bounds', 'entity_net_ids', 'seed', 'base_ground_level1', 'base_ground_level2' ];
+					let bad_field = null;
+
+					for ( let f = 0; f < other_fields.length; f++ )
+					{
+						try
+						{
+							JSON.stringify( save_obj[ other_fields[ f ] ], replacer );
+						}
+						catch ( e )
+						{
+							bad_field = other_fields[ f ];
+							console.warn( 'Object can not be json-ed! save_obj.' + bad_field + ' likely contains recursion. Error: ', e );
+							console.warn( save_obj[ bad_field ] );
+							break;
+						}
+					}
+
 					debugger;
-					
+
 					snapshot_save_busy = false;
-					throw new Error( '...Did not find?' );
+
+					if ( bad_field )
+					throw new Error( 'Stopping everything because saving is no longer possible... (save_obj.' + bad_field + ' failed to JSON-encode)' );
+					else
+					throw new Error( '...Did not find? (every entity and every other save_obj field individually passed JSON.stringify - the failure only reproduces when they are combined; check for a JSON.stringify replacer/toJSON side effect or a value that mutates between passes)' );
 				}
 
 				try


### PR DESCRIPTION
## Summary
Companion to #284 (SaveSnapshot retry-loop state leak).

When `JSON.stringify( save_obj )` throws, `SaveSnapshot` retries with `one_by_one = true` and tests each entity's own snapshot individually to find the culprit. But `save_obj` also carries several top-level fields that aren't entity snapshots at all - `bounds`, `entity_net_ids`, `seed`, `base_ground_level1`, `base_ground_level2` - and none of those were ever tested in isolation. If the unserializable value lived in one of those instead of in any entity, every entity would legitimately pass its own one-by-one test and the code fell straight through to the opaque `throw new Error( '...Did not find?' )`, with nothing in the log to say where to look next.

## Fix
Each of those fields is now individually `JSON.stringify`-tested (same pattern already used per-entity) before giving up, and the thrown error names the offending field directly (e.g. `save_obj.entity_net_ids failed to JSON-encode`). If truly nothing individually fails (the combination itself is the problem), the fallback message now says so explicitly instead of a bare `"...Did not find?"`.

This is independent of #284 - it applies to the same function but a different, non-overlapping region, and helps regardless of which merges first.

## Test plan
- [x] Offline regression suite: `_audit_savesnapshot_nonentity_field_diagnostic_test.cjs` (4/4), proving the old code gives an uninformative message regardless of where the culprit is, while the fixed code names `bounds`/`entity_net_ids` when they're the culprit and still falls back cleanly (with an improved message) when genuinely nothing is found.