### PR TITLE
Reuse sdCapsulePod's door class-name list instead of a fresh literal

### DIFF
--- a/game/entities/sdCapsulePod.js
+++ b/game/entities/sdCapsulePod.js
@@ -29,7 +29,9 @@ class sdCapsulePod extends sdEntity
 		sdCapsulePod.ACTION_CHECKING_PHONE_IDLING = 3;
 		sdCapsulePod.ACTION_CHECKING_PHONE_STOP1 = 4;
 		sdCapsulePod.ACTION_CHECKING_PHONE_STOP2 = 5;
-		
+
+		sdCapsulePod._door_class_name_list = [ 'sdDoor' ]; // Pre-made and reused by HasNearbySlabDoor() below - GetClassListByClassNameList caches its Set on the array instance itself, so passing a fresh literal every call defeats that cache entirely.
+
 		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
 	}
 		
@@ -362,7 +364,7 @@ class sdCapsulePod extends sdEntity
 		return sdWorld.CheckWallExistsBox(
 			this.x + this._hitbox_x1 - margin, this.y + this._hitbox_y1 - margin,
 			this.x + this._hitbox_x2 + margin, this.y + this._hitbox_y2 + margin,
-			null, null, [ 'sdDoor' ], ( e )=>( e.w < 16 || e.h < 16 )
+			null, null, sdCapsulePod._door_class_name_list, ( e )=>( e.w < 16 || e.h < 16 )
 		);
 	}
 	ExcludeDriver( c, force=false ) // Overridden to guard against the "seal the pod next to a slab door, then wall it in" raid exploit. Away from a slab door, exits stay as permissive as on any other vehicle (never refused) so stacked pods / corner placements can't lock the player in.


### PR DESCRIPTION
## Summary
Unrelated bug surfaced in the same log session as #284/#285's crash investigation:
```
Error: Inefficient class name list (["sdDoor"]) to class object list conversion detected -
you are likely creating a new array in entity methods like .GetIgnoredEntityClasses() every
time method is calling...
    at sdWorld.GetClassListByClassNameList
    at sdWorld.CheckWallExistsBox
    at sdCapsulePod.HasNearbySlabDoor
    at sdCapsulePod.ExcludeDriver
```

`sdWorld.GetClassListByClassNameList( class_names_array )` caches the resolved class `Set` on the array instance itself (`class_names_array._classes`), so the cache only pays off if the *same* array object is passed on every call. `HasNearbySlabDoor()` - which runs on every `ExcludeDriver` check, i.e. every time a player tries to exit a capsule pod - passed a fresh `[ 'sdDoor' ]` array literal on every single call, so the `Set` was rebuilt from scratch every time. After enough calls from the same call site, `sdWorld`'s own inefficiency tracker started logging a `console.error` (plus hitting a `debugger` statement) about exactly this pattern.

## Fix
The array is now built once in `init_class()` as `sdCapsulePod._door_class_name_list` and reused on every call, letting `GetClassListByClassNameList`'s cache work as designed. Purely a perf/log-noise fix - no behavior change.

## Test plan
- [x] Offline regression suite: `_audit_capsulepod_door_classlist_cache_test.cjs` (2/2), proving the old code rebuilds the cache on every call while the fixed code builds it exactly once across repeated calls.