### PR TITLE
Fix flying base (Skybase) getting permanently stuck with a door or matter container/amplifier aboard

### DIFF
--- a/game/entities/sdSteeringWheel.js
+++ b/game/entities/sdSteeringWheel.js
@@ -1525,6 +1525,23 @@ class sdSteeringWheel extends sdEntity
 			return current.GetIgnoredEntityClasses();
 		};
 
+		// Pure (no side effects, unlike Filter above) post-move overlap predicate: only entities that are
+		// NOT part of this same rigid move count as blockers. Members of scan/stuff_to_push are expected to
+		// legitimately overlap each other by construction (e.g. a door built flush into its frame, or a
+		// merged matter container/amplifier whose hitbox was widened onto its neighbours) - without this,
+		// the wedged_after_move revalidation below treats every such base as permanently "wedged" and rolls
+		// back every move, since a null filter makes CheckWallExistsBox count ANY hard-collision overlap.
+		const IsForeignBlocker = ( ent2 )=>
+		{
+			if ( scan_set.has( ent2 ) )
+			return false;
+
+			if ( stuff_to_push_set.has( ent2 ) )
+			return false;
+
+			return true;
+		};
+
 		const AddItemToPushWithAnythingOnTop = ( ent2, ignore_physically_movable_test=false )=>
 		{
 			if ( !ent2._is_being_removed )
@@ -1802,13 +1819,13 @@ class sdSteeringWheel extends sdEntity
 			for ( let i = 0; i < scan.length && !wedged_after_move; i++ )
 			{
 				let current = scan[ i ];
-				if ( !current.CanMoveWithoutOverlap( current.x, current.y, 0, null, GetIgnoredEntityClassesFor( current ) ) )
+				if ( !current.CanMoveWithoutOverlap( current.x, current.y, 0, IsForeignBlocker, GetIgnoredEntityClassesFor( current ) ) )
 				wedged_after_move = true;
 			}
 			for ( let i = 0; i < stuff_to_push.length && !wedged_after_move; i++ )
 			{
 				let current = stuff_to_push[ i ];
-				if ( !current.CanMoveWithoutOverlap( current.x, current.y, 0, null, GetIgnoredEntityClassesFor( current ) ) )
+				if ( !current.CanMoveWithoutOverlap( current.x, current.y, 0, IsForeignBlocker, GetIgnoredEntityClassesFor( current ) ) )
 				wedged_after_move = true;
 			}
 


### PR DESCRIPTION
## Summary
Multiple players reported that a flying base ("Skybase", moved via `sdSteeringWheel`) becomes permanently stuck as soon as it contains a door or a matter container/amplifier — the base won't move at all until that part is removed.

Root cause is **not** #282 (the rigid-group move fast path) — that PR only touches post-move hash-rehash/callback bookkeeping and never changes which moves are allowed or rolled back.

It's **#283**'s "roll back flying base moves that wedge an entity into a seam" safety check. In `ComplexElevatorLikeMove`, the post-move `wedged_after_move` revalidation calls:

```js
current.CanMoveWithoutOverlap( current.x, current.y, 0, null, GetIgnoredEntityClassesFor( current ) )
```

passing `null` for the filter — unlike every other overlap probe in this same function, which passes the `Filter` closure that excludes members of the base's own moving group (`scan_set`/`stuff_to_push_set`). Per `sdWorld.CheckWallExistsBox`, a `null` filter means **any** hard-collision entity found overlapping counts as a blocker, including the base's own other parts.

Two entity types legitimately overlap their own base-mates by construction:
- **Doors**: `sdDoor.ignored_entity_classes_travel` is an empty array — zero class-based exemptions — and a door built flush into its frame/wall overlaps that block's hitbox by design.
- **Matter containers/amplifiers**: merging (`container.containers++; // ... also widens its hitbox`) permanently widens a merged container's hitbox onto its neighbours, and `GetIgnoredEntityClasses()` is unoverridden (returns `null`) — no exemption there either.

Since the overlap is a permanent structural fact rather than a transient collision, the wedge check fires on **every** move attempt for such a base, rolling it back every time — matching the "base remains stuck until I remove it" reports.

## Fix
Add `IsForeignBlocker`, a pure predicate (no side effects, unlike `Filter`, which pushes to `stopping_entities`) that excludes `scan_set`/`stuff_to_push_set` members, and pass it instead of `null` in both `wedged_after_move` probes. Genuine wedges against foreign entities (someone else's base, terrain, a player in the way) are unaffected.

## Test plan
- [x] `node --check` on the touched file
- [x] Offline regression (gitignored `devtests/` tooling, not in this diff): extended the existing `_audit_steeringwheel_seam_jam_test.cjs` coverage with a new test that models `CheckWallExistsBox`'s actual `filter === null || filter(other)` semantics (the existing test mocked the overlap check as an opaque oracle and couldn't have caught this) — confirms the buggy `null` filter false-positives on a door-flush-with-frame base and a merged-container base, the fix resolves both, and a genuine foreign-entity wedge still correctly rolls back. 18/18 passing (6 new + 12 pre-existing, unaffected).
- [ ] Live before/after verification of a real Skybase (with a door + matter amplifier aboard) moving on a populated server — not yet deployed to a live slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
