### PR TITLE
Fix Skybase getting blocked from moving by a crystal held in its own Matter Amplifier/Crystal Combiner

### DIFF
--- a/game/entities/sdSteeringWheel.js
+++ b/game/entities/sdSteeringWheel.js
@@ -1453,11 +1453,21 @@ class sdSteeringWheel extends sdEntity
 		
 			if ( ent2.is( sdCrystal ) )
 			if ( ent2.held_by )
-			if ( ent2.held_by.is( sdGrass ) )
 			{
-				ent2.held_by.DropCrystal( ent2 );
+				// Held by a part of THIS same base (matter amplifier, crystal combiner, essence extractor, or any
+				// other current/future holder) - such holders re-derive the crystal's x/y from their own position
+				// every tick, so the crystal needs neither pushing nor scanning of its own. Without this, a held
+				// crystal's IsPhysicallyMovable() is false and it isn't itself in scan_set, so it would fall into
+				// the "foreign obstacle" branch below and permanently block the whole base from moving.
+				if ( scan_set.has( ent2.held_by ) )
+				return false;
+
+				if ( ent2.held_by.is( sdGrass ) )
+				{
+					ent2.held_by.DropCrystal( ent2 );
+				}
 			}
-			
+
 			/*if ( scan_set.has( ent2 ) )
 			return false;
 		


### PR DESCRIPTION
## Summary
Follow-up to #288 (flying base permanently stuck due to doors/matter containers) — same symptom (a Skybase refuses to move at all), different and distinct root cause in a different code path, found while investigating a player report where the base had no door or container aboard at all.

`sdSteeringWheel.js`'s `Filter()` (the *pre*-move obstacle probe in `ComplexElevatorLikeMove`, upstream of the `wedged_after_move` check #288 fixed) only auto-drops a crystal held by `sdGrass`:

```js
if ( ent2.is( sdCrystal ) )
if ( ent2.held_by )
if ( ent2.held_by.is( sdGrass ) )
{
    ent2.held_by.DropCrystal( ent2 );
}
```

A crystal's `IsPhysicallyMovable()` always returns `!this.held_by` (`sdCrystal.js`), so a **held** crystal is never physically movable. `Filter()` only routes an entity to the "push it along with the base" branch when `onThink.has_ApplyVelocityAndCollisions && ( IsPhysicallyMovable() || is(sdBaseShieldingUnit) )`; a held crystal fails that. The crystal itself is also never auto-scanned into the base's `scan_set` (it's not a block/door/wall, and `IsAttachableToSteeringWheel()` is false for anything with physics). So a crystal held by **any holder other than sdGrass** — `sdMatterAmplifier`, `sdCrystalCombiner`, `sdEssenceExtractor`, or any future holder implementing the same `DropCrystal()` interface — falls into the "foreign obstacle" branch and gets pushed into `stopping_entities`, permanently blocking the whole base from moving for as long as the crystal stays loaded, even when that holder is itself part of the base.

(Storage crates and matter containers are *not* affected — they store items as plain data, `stored_names`/a numeric `matter` field, never as live physical entities, so nothing from them ever reaches this collision scan.)

## Fix
If the crystal's holder is itself part of this base's `scan_set`, dropping the crystal (like the `sdGrass` case does) would be wrong — the player would lose their loaded crystal every time they fly the base. Such holders already re-derive the crystal's `x`/`y` from their own position every tick (e.g. `sdMatterAmplifier.onThink`: `this.crystal.x = this.x; this.crystal.y = this.y + 7 - this.crystal._hitbox_y2;`), so the crystal doesn't need pushing or scanning at all — it's enough to exempt it from the obstacle check:

```js
if ( ent2.is( sdCrystal ) )
if ( ent2.held_by )
{
    if ( scan_set.has( ent2.held_by ) )
    return false;

    if ( ent2.held_by.is( sdGrass ) )
    {
        ent2.held_by.DropCrystal( ent2 );
    }
}
```

Checking `scan_set` membership rather than enumerating holder classes by name means this covers any current or future crystal-holder type without needing to know about it specifically. The existing `sdGrass` auto-drop behavior (for a crystal held by wild, non-base grass) is untouched.

## Test plan
- [x] `node --check` on the touched file
- [x] Offline regression (gitignored `devtests/` tooling, not in this diff): `_audit_steeringwheel_held_crystal_blocker_test.cjs`, modeling `Filter()`'s actual branch decision (movable/pushable vs. foreign-obstacle) rather than an opaque oracle. Covers: crystal held by an in-base Matter Amplifier (no longer blocks), same for a Crystal Combiner (holder-agnostic), crystal held by `sdGrass` (still auto-dropped, unaffected), crystal held by a genuinely foreign (non-base) holder (still correctly blocks), loose/unheld crystal (never blocked either way). 10/10 passing. Re-ran the two related suites from #288 (`_audit_steeringwheel_wedge_selfoverlap_test.cjs`, `_audit_steeringwheel_seam_jam_test.cjs`) — 18/18, unaffected.
- [ ] Live before/after verification of a real Skybase with a crystal loaded in an attached Matter Amplifier/Crystal Combiner, moved on a populated server — not yet deployed to a live slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
