### PR TITLE
installer: stop the player-warning signal from hard-killing the server mid-save (world corruption)

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-SCRIPT_VERSION="1.0.13"
+SCRIPT_VERSION="1.0.14"
 DEFAULT_REPO_URL="https://github.com/Eric-Gurt/StarDefenders2D.git"
 DEFAULT_BRANCH="main"
 DEFAULT_SERVICE_NAME="stardefenders"
@@ -13,7 +13,14 @@ DEFAULT_BACKUP_INTERVAL="2d"
 DEFAULT_NODE_VERSION="lts/*"
 DEFAULT_WORLD_SLOT="0"
 DEFAULT_BACKUP_RETENTION_DAYS="30"
-DEFAULT_CRASH_LIMIT="5"
+# Deliberately generous: a burst of restarts in a short window is not always a
+# real crash loop (a deploy stop/start, a config-triggered restart and a cert
+# renewal can legitimately stack up), and exhausting the limit wedges the unit
+# into "Start request repeated too quickly" -- systemd then refuses to start it
+# at all, turning a transient hiccup into an extended outage that needs a manual
+# `systemctl reset-failed`. A genuine crash loop (RestartSec seconds apart) still
+# trips this well inside the window.
+DEFAULT_CRASH_LIMIT="20"
 DEFAULT_CRASH_WINDOW_SEC="600"
 DEFAULT_CRASH_RESTART_SEC="15"
 DEFAULT_CRASH_REPORT_KEEP="50"
@@ -1734,12 +1741,32 @@ forward_signal() {
 }
 trap 'forward_signal TERM' TERM
 trap 'forward_signal INT' INT
+# SIGUSR2 is the player-broadcast signal (deploy.sh's send_player_notice ->
+# sdServerConfig.js's SIGUSR2 handler). It MUST be trapped here: bash's default
+# disposition for SIGUSR2 is to terminate, so an untrapped SIGUSR2 kills this
+# wrapper outright, and KillMode=control-group then tears down the game process
+# with it -- no SIGTERM, no world save, corrupted chunks. Trapping it keeps the
+# wrapper alive and passes the signal to the game, which is all it was ever
+# meant to do.
+trap 'forward_signal USR2' USR2
 
 set +e
 eval "exec ${LAUNCH_COMMAND}" &
 child_pid="$!"
+# `wait` returns as soon as a TRAPPED signal has been handled, with status
+# 128+signum, even though the child is still running. Taking that as the child's
+# exit status made this wrapper exit the moment it forwarded a SIGTERM -- so
+# systemd saw the main process die, considered the unit stopped, and reaped the
+# rest of the control group while the game was still writing its world snapshot.
+# Keep waiting until the child has genuinely exited so the game's own
+# SIGTERM/SIGINT handler (world snapshot save) can finish, which is what the
+# forwarding above exists to guarantee in the first place.
 wait "${child_pid}"
 status="$?"
+while (( status > 128 )) && kill -0 "${child_pid}" 2>/dev/null; do
+  wait "${child_pid}"
+  status="$?"
+done
 set -e
 
 if [[ "${status}" == "0" ]]; then
@@ -1989,7 +2016,12 @@ send_player_notice() {
   local message="$1"
   printf '%s\n' "${message}" > "${APP_DIR}/sd2d_update_notice.txt"
   chown "${APP_USER}:${APP_GROUP}" "${APP_DIR}/sd2d_update_notice.txt" 2>/dev/null || true
-  systemctl kill --signal=SIGUSR2 "${SERVICE_NAME}.service" 2>/dev/null || log "WARNING: failed to signal ${SERVICE_NAME}.service for a player notice."
+  # --kill-whom=main is essential: the default is `all`, which sprays SIGUSR2 at
+  # every process in the control group -- including the `tee` used for run
+  # logging, which has no SIGUSR2 handler and dies (default disposition is
+  # terminate), breaking the game's stdout. Only the wrapper needs the signal;
+  # it traps SIGUSR2 and forwards it to the game process.
+  systemctl kill --kill-whom=main --signal=SIGUSR2 "${SERVICE_NAME}.service" 2>/dev/null || log "WARNING: failed to signal ${SERVICE_NAME}.service for a player notice."
 }
 
 # Warns connected players an update is coming, then re-notices every minute


### PR DESCRIPTION
## Summary
**Data-loss bug.** The pre-update player-warning feature (#273) has been hard-killing servers mid-save on every auto-update. Found on a live production host running three slots — **30 hard kills in 7 days** — and confirmed from its journal.

The irony is direct: the feature added to stop players being dropped abruptly was itself dropping them abruptly, and corrupting chunks doing it.

### 1. The broadcast signal killed the wrapper (and the game with it)
`send_player_notice()` sent the countdown with `systemctl kill --signal=SIGUSR2` and **no `--kill-whom`**. The default is `all` — every process in the control group. Since #275 added the `run.sh` wrapper, that group is `bash` + `tee` + `node`. Neither bash nor tee has a SIGUSR2 handler, and **bash's default disposition for SIGUSR2 is terminate**:

```
Sent signal SIGUSR2 to main process 2783817 (bash)
Main process exited, code=killed, status=12/USR2
Failed with result 'signal'
```

`KillMode=control-group` then reaped node with it — no SIGTERM, no world save. And because the countdown re-notices once a minute, this fired *once per minute for the whole warning window*:

```
22:00:02 status=12/USR2   22:03:02 status=12/USR2
22:01:02 status=12/USR2   22:04:02 status=12/USR2
22:02:02 status=12/USR2   22:05:02 status=12/USR2
```

Now scoped with `--kill-whom=main`, which also spares `tee` (killing it breaks the game's stdout).

### 2. `run.sh` never trapped SIGUSR2
Even scoped to the main process, the signal would still kill the wrapper. It now traps `USR2` and forwards it to the game — all the signal was ever meant to do.

### 3. `run.sh` truncated *every* graceful shutdown
Separately and more broadly: the wrapper took `wait`'s return as the child's exit status. **`wait` returns as soon as a _trapped_ signal is handled** (status 128+signum) while the child is still running — so the wrapper exited the instant it forwarded a SIGTERM. systemd saw the main process die, considered the unit stopped, and reaped the control group while the game was still writing its snapshot.

The wrapper added to *harden* graceful shutdown was defeating it — on every stop, deploy, config-restart and cert renewal. On the production host a clean save takes **up to 32 s**; it was getting roughly none. Now re-waits until the child has genuinely exited. Also stops a bogus `143` crash report being filed on every normal stop.

### 4. `DEFAULT_CRASH_LIMIT` 5 → 20
Five kills inside `StartLimitIntervalSec` tripped `StartLimitBurst`, after which systemd refused to start the unit at all (*"Start request repeated too quickly"*). The deploy's final `systemctl start` then failed, `deployed_rev` was never written, and every later timer tick took the *"checkout already at target but not picked up"* branch — which calls `systemctl restart` with **no warning at all**. That accounts for both the unwarned restarts and the long outages. A genuine crash loop still trips the limit well inside the window.

## Test plan
- [x] `bash -n` on `install-linux.sh` and on the generated `run.sh`
- [x] Signal-behaviour harness on Linux (fake game child: broadcasts on USR2, saves-then-exits on TERM):
  - old wrapper: **dies** on USR2; on TERM logs `WRAPPER_EXIT=143` **before** `SAVING`/`SAVED`
  - new wrapper: survives USR2 and delivers the broadcast; on TERM logs `SAVING → SAVED → WRAPPER_EXIT=0`
- [x] End-to-end on the production host, all three slots patched and restarted with a clean manual save first (`SaveSnapshot called callback (error=false)` on each):
  - `systemctl kill --kill-whom=main --signal=SIGUSR2` → wrapper and game PIDs **unchanged**, notice file consumed (broadcast delivered to players)
  - the old default (`whom=all`) still restarts the unit — confirming the scoping is required, not cosmetic
  - **0** USR2 kills across all slots since; warnings re-enabled at 5 min
- [ ] Full unattended auto-update cycle with players connected, observing the countdown in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)
