### PR TITLE
Revert skybase seam-wedge safety net (#283/#288/#289); scope 16px grid-gap block to dirt only

### DIFF
--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -6923,7 +6923,7 @@ THING is cosmic mic drop!`;
 						return false;
 					}
 
-					if ( fake_ent.is( sdBlock ) )
+					if ( fake_ent.is( sdBlock ) && fake_ent.material === sdBlock.MATERIAL_GROUND ) // Only dirt is denied for a grid-gap mismatch - other block types (walls, reinforced, etc.) are placeable regardless of grid pitch
 					if ( sdCharacter.WouldLeaveGridGap( fake_ent, initiator ) )
 					{
 						sdCharacter.last_build_deny_reason = [

--- a/game/entities/sdSteeringWheel.js
+++ b/game/entities/sdSteeringWheel.js
@@ -1453,21 +1453,11 @@ class sdSteeringWheel extends sdEntity
 		
 			if ( ent2.is( sdCrystal ) )
 			if ( ent2.held_by )
+			if ( ent2.held_by.is( sdGrass ) )
 			{
-				// Held by a part of THIS same base (matter amplifier, crystal combiner, essence extractor, or any
-				// other current/future holder) - such holders re-derive the crystal's x/y from their own position
-				// every tick, so the crystal needs neither pushing nor scanning of its own. Without this, a held
-				// crystal's IsPhysicallyMovable() is false and it isn't itself in scan_set, so it would fall into
-				// the "foreign obstacle" branch below and permanently block the whole base from moving.
-				if ( scan_set.has( ent2.held_by ) )
-				return false;
-
-				if ( ent2.held_by.is( sdGrass ) )
-				{
-					ent2.held_by.DropCrystal( ent2 );
-				}
+				ent2.held_by.DropCrystal( ent2 );
 			}
-
+			
 			/*if ( scan_set.has( ent2 ) )
 			return false;
 		
@@ -1533,23 +1523,6 @@ class sdSteeringWheel extends sdEntity
 			return sdDoor.ignored_entity_classes_travel;
 
 			return current.GetIgnoredEntityClasses();
-		};
-
-		// Pure (no side effects, unlike Filter above) post-move overlap predicate: only entities that are
-		// NOT part of this same rigid move count as blockers. Members of scan/stuff_to_push are expected to
-		// legitimately overlap each other by construction (e.g. a door built flush into its frame, or a
-		// merged matter container/amplifier whose hitbox was widened onto its neighbours) - without this,
-		// the wedged_after_move revalidation below treats every such base as permanently "wedged" and rolls
-		// back every move, since a null filter makes CheckWallExistsBox count ANY hard-collision overlap.
-		const IsForeignBlocker = ( ent2 )=>
-		{
-			if ( scan_set.has( ent2 ) )
-			return false;
-
-			if ( stuff_to_push_set.has( ent2 ) )
-			return false;
-
-			return true;
 		};
 
 		const AddItemToPushWithAnythingOnTop = ( ent2, ignore_physically_movable_test=false )=>
@@ -1703,16 +1676,6 @@ class sdSteeringWheel extends sdEntity
 			// 'verify' (read-only dry-run against the legacy path) opt back out.
 			let rigid_on = ( globalThis.RIGID_MOVE_MODE !== 'off' && globalThis.RIGID_MOVE_MODE !== 'verify' );
 
-			// Snapshot pre-move positions so the final combined-configuration check below (which can
-			// still find scan and stuff_to_push entities wedged into each other despite each having
-			// individually passed its own probe above) can cleanly roll everything back instead of
-			// committing an invalid overlapping configuration.
-			let pre_move_positions = new Map();
-			for ( let i = 0; i < scan.length; i++ )
-			pre_move_positions.set( scan[ i ], { x: scan[ i ].x, y: scan[ i ].y } );
-			for ( let i = 0; i < stuff_to_push.length; i++ )
-			pre_move_positions.set( stuff_to_push[ i ], { x: stuff_to_push[ i ].x, y: stuff_to_push[ i ].y } );
-
 			for ( let i = 0; i < scan.length; i++ )
 			{
 				let current = scan[ i ];
@@ -1815,42 +1778,6 @@ class sdSteeringWheel extends sdEntity
 				for ( let i = 0; i < stuff_to_push.length; i++ )
 				rigid_all_moved.push( stuff_to_push[ i ] );
 				sdWorld.UpdateHashPositionBatchRigid( rigid_all_moved );
-			}
-
-			// Final revalidation of the combined configuration: each entity above only checked itself
-			// against the world *before* anything moved, exempting other scan/stuff_to_push members on
-			// the assumption they would also get out of the way - but two of them can independently end
-			// up with incompatible (e.g. differing partial-axis) resolutions and still collide with each
-			// other once actually moved. Roll back everything if that happened instead of leaving an
-			// entity wedged into a seam between blocks. Runs after the rehash above (rigid path) so the
-			// overlap probes below see each moved member's final, correctly-indexed hash position.
-			let wedged_after_move = false;
-
-			for ( let i = 0; i < scan.length && !wedged_after_move; i++ )
-			{
-				let current = scan[ i ];
-				if ( !current.CanMoveWithoutOverlap( current.x, current.y, 0, IsForeignBlocker, GetIgnoredEntityClassesFor( current ) ) )
-				wedged_after_move = true;
-			}
-			for ( let i = 0; i < stuff_to_push.length && !wedged_after_move; i++ )
-			{
-				let current = stuff_to_push[ i ];
-				if ( !current.CanMoveWithoutOverlap( current.x, current.y, 0, IsForeignBlocker, GetIgnoredEntityClassesFor( current ) ) )
-				wedged_after_move = true;
-			}
-
-			if ( wedged_after_move )
-			{
-				for ( let [ ent, pos ] of pre_move_positions )
-				{
-					ent.x = pos.x;
-					ent.y = pos.y;
-					sdWorld.UpdateHashPosition( ent, false, false ); // equivalent to UpdateHashPositionBatchRigid for a single member; safe regardless of rigid_on
-					ent._last_x = ent.x;
-					ent._last_y = ent.y;
-				}
-
-				return false;
 			}
 
 			// phase-13-rigid-01: trace-only rigid-fast-path eligibility census (gated; counting only, no behavior change).


### PR DESCRIPTION
## Summary
Two narrow fixes to previously-merged item/object interaction work:

- **Full revert of the skybase "seam-wedge" safety net.** #283 added a post-move `wedged_after_move` revalidation to `ComplexElevatorLikeMove` (`sdSteeringWheel.js`) that rolls back a flying base move if it leaves an entity wedged into a seam. Two follow-ups patched bugs in that same mechanism: #288 (`IsForeignBlocker`, fixing a false-positive on the base's own doors/merged containers) and #289 (exempting a crystal held by the base's own Matter Amplifier/Crystal Combiner from the *pre*-move obstacle probe). In practice this safety net has caused more "my base is stuck" reports than it prevented, so all three are reverted here — `ComplexElevatorLikeMove` is back to its pre-#283 behavior (verified via `git diff` against the commit immediately preceding #283: only a whitespace difference remains).
- **Scope the 16px build-grid gap check to dirt only.** #283 also added `sdCharacter.WouldLeaveGridGap()`, wired up to deny placement of *any* `sdBlock` that would leave a sub-tile gap under the currently-active grid. That was too broad — it should only apply to dirt (`sdBlock.MATERIAL_GROUND`, the 16x16 "Walls" shop item). Other block types (walls, reinforced, etc.) can now be placed under the 16px grid regardless of a resulting gap. Only the call-site gating in `GeneralCheckBuildObjectPossibilityNow` changed; `WouldLeaveGridGap()`'s own neighbor-scan logic, `GetBuildGridMultiplier()`, and the 8px/16px fire-mode toggle (N key) are untouched.

No other part of #283 (water fixes, matter container merge/unmerge, storage transactionality, AND-gate node, weapon bench sync fix, etc.) is affected — confirmed via diff stat (only `sdCharacter.js` and `sdSteeringWheel.js` touched).

## Test plan
- [x] `node --check` on both touched files
- [x] `git diff` of `sdSteeringWheel.js` against the pre-#283 commit shows only a whitespace difference — full behavioral revert confirmed
- [x] `git diff` against `main` shows only the two intended files changed, nothing else from #283/#288/#289 pulled in
- [ ] Live verification not performed as part of this PR (offline-only per request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
