### PR TITLE
Fix graceful snapshot saves during systemd restarts

### DIFF
--- a/game/server/sdServerConfig.js
+++ b/game/server/sdServerConfig.js
@@ -2043,6 +2043,7 @@ class sdServerConfigFull extends sdServerConfigShort
 
 		// World save test
 		let snapshot_save_busy = false;
+		let snapshot_save_completion_callbacks = [];
 		async function SaveSnapshot( snapshot_path, callback )
 		{
 			if ( snapshot_save_busy || is_terminating )
@@ -2293,6 +2294,11 @@ class sdServerConfigFull extends sdServerConfigShort
 
 				if ( callback )
 				callback( err );
+
+				let callbacks = snapshot_save_completion_callbacks;
+				snapshot_save_completion_callbacks = [];
+				for ( let i = 0; i < callbacks.length; i++ )
+				callbacks[ i ]( err );
 			}
 
 			// --- backup-tail-decouple: hand deflate + file write + rename to the dedicated snapshot
@@ -2370,7 +2376,7 @@ class sdServerConfigFull extends sdServerConfigShort
 						{
 							console.warn( 'Snapshot was not saved: ', err );
 
-							Report( false );
+							Report( true );
 							snapshot_save_busy = false;
 						}
 						else
@@ -2395,7 +2401,7 @@ class sdServerConfigFull extends sdServerConfigShort
 									else
 									console.log( 'TEMP file renamed.' );
 
-									Report( false );
+									Report( !!err );
 									snapshot_save_busy = false;
 								});
 							}
@@ -2505,7 +2511,7 @@ class sdServerConfigFull extends sdServerConfigShort
 			};
 
 			if ( snapshot_save_busy )
-			setTimeout( proceed, 5000 ); // Let 5 seconds to complete saving
+			snapshot_save_completion_callbacks.push( proceed );
 			else
 			SaveSnapshot( sdWorld.snapshot_path_const, proceed );
 		}

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1724,15 +1724,12 @@ echo "Working directory: ${APP_DIR}"
 echo "Launch command: ${LAUNCH_COMMAND}"
 
 # Explicitly forward stop signals to the actual node child and wait for it to
-# exit on its own, instead of relying on systemd's control-group signal
-# broadcast (KillMode=control-group) reaching node independently of this
-# wrapper. That broadcast should already do the right thing on its own, but
-# this wrapper is the one thing every stop path shares in common - a manual
+# exit on its own. KillMode=mixed sends the initial stop signal only to this
+# main wrapper, keeping the logging tee alive while node logs and saves; the
+# wrapper then forwards that signal to node. Every stop path - a manual
 # `systemctl stop`, deploy.sh's own stop-before-update, and the uninstall
-# helper's `systemctl disable --now` all go through this same script - so
-# making the forwarding explicit here removes any dependency on KillMode
-# staying exactly as configured and gives the game's own SIGTERM/SIGINT
-# handler (world snapshot save) the best chance to run in every case.
+# helper's `systemctl disable --now` - goes through this same script. systemd
+# still sends SIGKILL to the full control group if TimeoutStopSec is exceeded.
 child_pid=""
 forward_signal() {
   local sig="$1"
@@ -1744,8 +1741,8 @@ trap 'forward_signal INT' INT
 # SIGUSR2 is the player-broadcast signal (deploy.sh's send_player_notice ->
 # sdServerConfig.js's SIGUSR2 handler). It MUST be trapped here: bash's default
 # disposition for SIGUSR2 is to terminate, so an untrapped SIGUSR2 kills this
-# wrapper outright, and KillMode=control-group then tears down the game process
-# with it -- no SIGTERM, no world save, corrupted chunks. Trapping it keeps the
+# wrapper outright, after which systemd tears down the remaining service
+# processes -- no SIGTERM, no world save, corrupted chunks. Trapping it keeps the
 # wrapper alive and passes the signal to the game, which is all it was ever
 # meant to do.
 trap 'forward_signal USR2' USR2
@@ -2373,7 +2370,7 @@ WorkingDirectory=${APP_DIR}
 EnvironmentFile=/etc/default/${SERVICE_NAME}
 ExecStartPre=+/usr/local/bin/${SERVICE_NAME}-fixperms.sh
 ExecStart=/usr/local/bin/${SERVICE_NAME}-run.sh
-KillMode=control-group
+KillMode=mixed
 KillSignal=SIGTERM
 TimeoutStopSec=300
 Restart=always


### PR DESCRIPTION
## Summary

- generate `KillMode=mixed` so the logging `tee` survives while the wrapper forwards SIGTERM to Node
- wait for an already-running snapshot to reach its existing completion callback instead of exiting after five seconds
- propagate snapshot TEMP-write/final-rename failures so shutdown cannot report false success

## Why

The installer-managed config watcher ends in `systemctl restart`. With `KillMode=control-group`, systemd signals the Bash wrapper, Node, and the wrapper's logging `tee` together. Node's shutdown logging can then hit a closed pipe and exit before saving. A separate application fallback also exits after five seconds when a snapshot is already active, even though the unit allows five minutes for graceful stop.

## Validation

- pre-fix six-failure set reproduced on Node 18 and Node 24
- fixed nine-assertion suite passes on Node 18.16.0, VPS Node 20.19.4, and Node 24.13.1
- inline and worker-tail active saves finalize and reload
- repeated shutdown stays idempotent
- injected TEMP write failure preserves the prior snapshot, reports `error=true`, and exits 1
- Linux wrapper negative/positive controls pass
- transient user-systemd `.path` event performs one graceful restart with one completed snapshot
- `node --check`, `bash -n`, `git diff --check`, clean-status, and two-file scope audits pass

## Operational note

Existing installations must re-run `install-linux.sh` after merge to regenerate their unit with `KillMode=mixed`; this PR does not deploy or modify installed units.