### PR TITLE
Reject invalid server-to-server targets

### DIFF
--- a/game/server/sdServerToServerProtocol.js
+++ b/game/server/sdServerToServerProtocol.js
@@ -246,6 +246,14 @@ class sdServerToServerProtocol
 	}
 	static SendData( remote_server_url, data_object, callback=null )
 	{
+		if ( typeof remote_server_url !== 'string' || remote_server_url.trim().length === 0 )
+		{
+			if ( callback )
+			callback( null );
+
+			return;
+		}
+
 		// Connection will hang for a while actually and auto-restore it seems once established once
 		
 		let route = sdServerToServerProtocol.routes++;


### PR DESCRIPTION
## Summary

- reject null, non-string, empty, and whitespace-only S2S targets before Socket.IO construction
- return the existing `null` failure value exactly once without allocating a route or cached client
- preserve valid target identity, Socket.IO options, caching, timeout, and reconnect behavior

## Why

Socket.IO Client 4.8.1 treats `io(null, options)` as an options-shaped call and creates an active client for an undefined URI. `SendData` cached that client, so automatic reconnects could continue producing `connect_error` spam after the original route timed out on a fully local server.

## Scope

Only `game/server/sdServerToServerProtocol.js` changes. Database/storage transactions, long-range teleportation, UI, valid-remote reconnect policy, logging policy, crash reporting, and gameplay logic are unchanged. The edit also adds the file's missing final newline.

## Validation

- focused invalid-target regression on Node 18.16.0, 20.19.4, and 24.13.1
- full local/remote mothership-storage list/save/get matrix on all three runtimes
- real two-endpoint localhost Socket.IO success, temporary-outage, cached-client reuse, and reconnect integration on all three runtimes
- syntax checks and `git diff --check`
- clean one-commit/one-file/raw-byte scope audit