### PR TITLE
Preserve crash context beyond S2S spam

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1644,6 +1644,7 @@ record_failure() {
   local tmp_history
   local recent_count
   local report_file
+  local s2s_connect_error_lines
 
   now_epoch="$(date +%s)"
   now_iso="$(date -Is)"
@@ -1657,6 +1658,7 @@ record_failure() {
 
   recent_count="$(wc -l < "${HISTORY_FILE}" | tr -d ' ')"
   report_file="${CRASH_DIR}/${SERVICE_NAME}-crash-${now_iso//:/-}.txt"
+  s2s_connect_error_lines="$(grep -Fc 'S2SProtocolMessage :: SendData socket: connect_error due to ' "${RUN_LOG}" 2>/dev/null || true)"
 
   {
     echo "StarDefenders2D service crash report"
@@ -1680,6 +1682,11 @@ record_failure() {
     echo "  journalctl -u ${SERVICE_NAME}.service -n 200 -o cat --no-pager"
     echo "  systemctl reset-failed ${SERVICE_NAME}.service"
     echo "  systemctl start ${SERVICE_NAME}.service"
+    echo
+    echo "s2s_connect_error_lines_in_run=${s2s_connect_error_lines}"
+    echo
+    echo "Last 200 service output lines excluding S2S connect_error entries (raw tail follows):"
+    grep -Fv 'S2SProtocolMessage :: SendData socket: connect_error due to ' "${RUN_LOG}" 2>/dev/null | tail -n 200 || true
     echo
     echo "Last 200 service output lines:"
     tail -n 200 "${RUN_LOG}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- count repeated S2S `connect_error` entries in each failed service run
- add a bounded last-200-line report view excluding those repeated entries
- keep the existing raw 200-line tail and all runtime/journal logging unchanged

## Why

The generated crash reporter retained only the final 200 service-output lines. Repeated S2S reconnect errors could push an earlier emitted error/stack context outside that window, and the next service start truncates the only full per-run `latest.log`.

This keeps the raw tail for exact diagnostics while adding a second bounded view and a full-run S2S count, so the spam remains visible without displacing unrelated context.

## Validation

- `bash -n install-linux.sh`
- generated-wrapper regression on Node 18.16.0, 20.19.4, and 24.13.1
- short, context-before-250-spam, mixed-spam, context-after-20,000-spam, real uncaught-error, and silent nonzero-exit cases
- exact S2S counts through 20,000; supplemental view contains zero S2S entries and stays under 200 lines
- raw tail, exit status, crash history, timestamped/latest alias, and normalized child output unchanged
- one commit, one file, 7 additions, `git diff --check`, clean 3,071-file raw worktree audit

## Scope

No game logic, S2S connection behavior, runtime log suppression, signal handling, restart policy, report permissions, or retention policy changes.

## Platform note

The actual generated wrapper and delivered reports were exercised locally under Git Bash with real Node processes. This Windows host has no local systemd environment, and no remote/VPS testing or deployment was performed, so a Linux/systemd smoke run remains follow-up validation.