### PR TITLE
Persist Sample Builder outputs in snapshots

### DIFF
--- a/game/entities/sdSampleBuilder.js
+++ b/game/entities/sdSampleBuilder.js
@@ -288,6 +288,7 @@ class sdSampleBuilder extends sdEntity
 							this._update_version++;
 
 							sdCharacter.ApplyPostBuiltProperties( ent, s._sample_shop_item, this._owner );
+							sdEntity.AddEntityToEntitiesArray( ent );
 						}
 					}
 					else


### PR DESCRIPTION
## Summary

- register each successful Sample Builder output in the primary entity registry
- make completed snapshots persist and reload autobuilt objects like manual builds
- preserve rejected-build cleanup and the existing save cadence

## Why

`GeneralCreateBuildObject` returns a live but unregistered candidate. The manual build path explicitly inserts successful output into `sdEntity.entities`, while the Sample Builder path stopped after post-build handling.

That left autobuilt objects active, spatially hashed, and addressable by net ID, so they appeared to work until restart. Completed snapshots enumerate only `sdEntity.entities` and therefore omitted them.

## Validation

- pre-fix bug-mode regression: 57/57 checks on Node 18.16.0, 20.19.4, and 24.13.1
- post-fix regression: 81/81 checks on all three runtimes
- before-save and completed-after-save forced-exit/reload controls
- block, shield-shaped, background, and dynamic-device variants
- unaffordable candidate remains removed and unregistered
- exact Node 20.19.4 local multiplayer run with real `SaveSnapshot`, forced process exit, and restart; visible/far-side manual and autobuilt controls all reloaded once at their original net IDs/positions
- Node 18/20/24 syntax, `git diff --check`, and clean 3,071-file raw worktree audit

## Scope

One commit changes one file with one added line. No save cadence, synchronous durability, snapshot format, deep-sleep policy, hash/LOS behavior, manual building, placement, cost, ownership, BSU, balance, or gameplay-design behavior changes.