### PR TITLE
Enable atlas render paths by default

### DIFF
--- a/game/client/sdRenderer.js
+++ b/game/client/sdRenderer.js
@@ -34,6 +34,18 @@ class sdRenderer
 		
 		if ( typeof window === 'undefined' )
 		return;
+
+		// PR #279 atlas production paths default on; explicit pre-init values keep their override/fallback behavior.
+		if ( typeof globalThis.ATLAS_DETERMINISTIC_ORDER === 'undefined' )
+		globalThis.ATLAS_DETERMINISTIC_ORDER = true;
+		if ( typeof globalThis.ATLAS_LAYER_SPLIT === 'undefined' )
+		globalThis.ATLAS_LAYER_SPLIT = true;
+		if ( typeof globalThis.ATLAS_LRU === 'undefined' )
+		globalThis.ATLAS_LRU = true;
+		if ( typeof globalThis.ATLAS_SHADER_FILTER === 'undefined' )
+		globalThis.ATLAS_SHADER_FILTER = true;
+		if ( typeof globalThis.ATLAS_FF_TALL === 'undefined' )
+		globalThis.ATLAS_FF_TALL = true;
 	
 		sdRenderer.img_sun = sdWorld.CreateImageFromFile( 'sun' );
     


### PR DESCRIPTION
## Summary
- enable the five production atlas paths from #279 by default during browser initialization
- preserve explicit pre-init overrides so `false` still selects each legacy path
- leave debug overflow logging and headless/server initialization unchanged

## Investigation
The atlas renderer itself already initializes as visual mode 4. The issue was that PR #279's production globals had no default producer, so every truthiness gate stayed on the legacy branch unless injected externally.

## Validation
- `node --check game/client/sdRenderer.js` on Node 18.16.0, 20.19.4, and 24.13.1
- 43/43 Chrome/Firefox default, override, reconnect/reload, and no-WebGL regression assertions
- 80/80 Chrome/Firefox scene, resize, input, lighting, transparency, HUD, and reconnect checks
- 8/8 installed Firefox 154 checks, including the 4,096-pixel atlas height
- direct Node 18/20/24 headless init checks: atlas globals remain undefined
- one commit, one file, 12 additions, and a clean 3,071-file committed raw-byte audit

## Scope
No gameplay logic, balance, renderer algorithms, settings migration, server behavior, or debug logging changes. The test harnesses and evidence remain outside the game repository and are not included in this PR.