### PR TITLE
Preserve elevator backgrounds during re-weld

### DIFF
--- a/game/entities/sdSteeringWheel.js
+++ b/game/entities/sdSteeringWheel.js
@@ -318,6 +318,29 @@ class sdSteeringWheel extends sdEntity
 		
 		let reason = null;
 		
+		if ( this.type === sdSteeringWheel.TYPE_ELEVATOR_MOTOR )
+		{
+			for ( let i = 0; i < this._scan.length; i++ )
+			{
+				let existing = this._scan[ i ];
+
+				if ( !existing._is_being_removed )
+				if ( existing.is )
+				if ( existing.is( sdBG ) )
+				{
+					visited.add( existing );
+					collected.push( existing );
+				}
+			}
+
+			if ( collected.length > LIMIT )
+			{
+				reason = 'Entities groups is likely stuck or too big to move (over ' + LIMIT + ' entities in a scan)';
+				collected = null;
+				active.length = 0;
+			}
+		}
+
 		out:
 		while ( active.length > 0 )
 		{


### PR DESCRIPTION
## Summary
- retain live backgrounds that are already welded to an elevator when `Re-weld nearby entities` refreshes its scan
- mark retained backgrounds visited without using them as discovery-frontier nodes, so path and nearby backgrounds remain unattached
- preserve the existing foreground scan, member limit, atomic failure, pointer/ID rebuild, and normal steering-wheel behavior

## Investigation
Elevator backgrounds are manually selected members. The later re-weld command intentionally excludes elevator `sdBG` objects from automatic discovery, but then replaces the old scan wholesale. That combination clears every previously welded background even though the command succeeds.

The minimal fix seeds an elevator's replacement collection with its existing live background members before the unchanged foreground scan.

## Validation
- `node --check` for the changed source and evidence harnesses on Node 18.16.0, 20.19.4, and 24.13.1
- 49/49 production-class regression assertions on all three Node versions
- 21/21 production snapshot serialization/reconstruction assertions on all three Node versions
- 16/16 isolated local multiplayer assertions with two throttled Chrome clients, repeated real context refreshes/moves, correct retained and excluded backgrounds, and no page/console errors
- one commit, one file, 23 additions, zero deletions, and a clean 3,071-file committed raw-byte audit

## Scope
No UI additions, automatic background discovery, movement/merge/collision rewrite, balance change, normal steering-wheel change, or unrelated refactor. Test harnesses and browser evidence remain outside the game repository and are not included in this PR.

The snapshot reload check uses production serialization/reconstruction in-process rather than a full server restart; multiplayer movement was deterministic and inspector-issued while both real clients observed the networked result.
