### PR TITLE
Repair stale rigid snapshot positions

### DIFF
--- a/game/server/sdByteShifter.js
+++ b/game/server/sdByteShifter.js
@@ -413,6 +413,16 @@ class sdByteShifter
 									let is_held_gun = ent.is( sdGun ) && ent._held_by;
 									
 									let is_active_or_rare_update = ( !ent.is_static || ent.awake ) && ( ent._phys_sleep > 0 || ent._net_id % 30 === frame % 30 );
+
+									if ( rsd_info )
+									{
+										let predicted_x = Math.round( ( Math.round( confirmed_state.x * 100 ) / 100 + rsd_info.dxr ) * 100 ) / 100;
+										let predicted_y = Math.round( ( Math.round( confirmed_state.y * 100 ) / 100 + rsd_info.dyr ) * 100 ) / 100;
+										let periodic_position_resync = ( !ent.is_static || ent.awake ) && ent._net_id % 30 === frame % 30;
+
+										if ( periodic_position_resync || Math.abs( predicted_x - Math.round( snap.x * 100 ) / 100 ) >= 0.5 || Math.abs( predicted_y - Math.round( snap.y * 100 ) / 100 ) >= 0.5 )
+										rsd_info = undefined; // Preserve the absolute repair/resync path when a relative delta is not a safe representation.
+									}
 									
 									if ( sdWorld.sockets && sdWorld.sockets.length > 1 ) // phase-13-snapshot-01: >1 client -> hoist client-independent per-prop work (build once, reuse across clients); 1 client -> original inline loop below (no added cost).
 									{


### PR DESCRIPTION
## Summary
- fall back to authoritative x/y when a rigid-group delta would leave the client outside the established subpixel bound
- preserve the existing periodic absolute position-resync turn instead of suppressing it with a group packet
- retain compact rigid deltas for safe aligned consecutive movers

## Investigation
The server-side BSU, hash, damage, earthquake, and persistence paths remain intact. The reproducible defect is in the client snapshot stream and affects ordinary walls as well as trapshield blocks.

A known static can reuse its prior confirmed snapshot during one base movement. When a later movement refreshes that static's version, the rigid-group path currently suppresses the ordinary absolute x/y repair and advances the stale client coordinate by only the current frame's delta. That leaves the client and confirmed bookkeeping a whole move behind until a later absolute packet, producing the reported disappearing/glitching presentation.

The fix predicts the client-side rigid result first. If it would differ from the canonical snapshot by at least 0.5px on either axis, or the entity is on its existing 30-frame absolute-resync slot, the unchanged ordinary diff path sends authoritative x/y.

## Validation
- clean main reproduces the intended-contract failure at 60/78 on Node 18.16.0, 20.19.4, and 24.13.1; exact pre-#267 source passes 78/78
- fixed production encoder contract: 78/78 on all three Node versions for trapshield and ordinary-wall fixtures
- real-class BSU/hash/damage/reload invariants: 317/317 on all three Node versions
- neighboring rigid batch: 516/516; rigid snapshot arithmetic: 3,716,526/3,716,526; snapshot diff fuzz: 200,000/200,000 on all three Node versions
- isolated local multiplayer: 21/21 with two throttled Chrome clients, real forward/reverse browser inputs, both clients aligned, client-2-attributed damage blocked, and no page/console errors
- one commit, one file, 10 additions, zero deletions, and a clean 3,071-file committed raw-byte audit

## Scope
No client decoder, packet shape, BSU/protection rule, damage, range, movement, hash, LOS, persistence, balance, or gameplay redesign. Evidence harnesses and browser artifacts remain outside the game repository and are not included in this PR.

The exact automated encoder gate covers camera removal/re-entry. Multiplayer uses real browser input to gate deterministic production movement while fixture-driver collision is suspended; a fully unscripted continuous steering session was not claimed.
