### PR TITLE
Keep autobuilders consistent offscreen

### DIFF
--- a/game/entities/sdDeepSleep.js
+++ b/game/entities/sdDeepSleep.js
@@ -126,6 +126,7 @@ import sdTzyrgAbsorber from './sdTzyrgAbsorber.js';
 import sdWanderer from './sdWanderer.js';
 import sdBullet from './sdBullet.js';
 import sdCable from './sdCable.js';
+import sdSampleBuilder from './sdSampleBuilder.js';
 
 import sdRenderer from '../client/sdRenderer.js';
 
@@ -1239,6 +1240,7 @@ class sdDeepSleep extends sdEntity
 								( e.is( sdLongRangeTeleport ) && e.is_server_teleport ) || // No server teleports (unless regular telepors will be available for in-world teleportation at some point?)
 								e.is( sdRescueTeleport ) || // It looks like there is no simple solution at all for these...
 								e.is( sdBeacon ) || // It looks like there is no simple solution at all for these...
+								( e.is( sdSampleBuilder ) && e.type === sdSampleBuilder.TYPE_BUILDER && e.toggle_enabled ) ||
 								!sdWorld.server_config.AllowAggressiveHibernationFor( e )
 							)
 						{

--- a/game/entities/sdSampleBuilder.js
+++ b/game/entities/sdSampleBuilder.js
@@ -289,6 +289,9 @@ class sdSampleBuilder extends sdEntity
 
 							sdCharacter.ApplyPostBuiltProperties( ent, s._sample_shop_item, this._owner );
 							sdEntity.AddEntityToEntitiesArray( ent );
+
+							if ( ent._affected_hash_arrays.length > 0 )
+							sdWorld.UpdateHashPosition( ent, false, false );
 						}
 					}
 					else


### PR DESCRIPTION
## Summary
- keep enabled Sample Builder units simulated when aggressive region hibernation would otherwise serialize them offscreen
- refresh successful autobuild output at its final coordinates with the same conditional, callback-suppressed hash update used by manual building
- preserve existing build cadence, matter cost, placement rules, one-time registration, and sleep behavior for disabled builders and samplers

## Investigation
Enabled Sample Builders deliberately refuse their ordinary entity hibernation, but the older aggressive deep-sleep path can still serialize their offscreen dependency group. Their delay and matter then remain frozen until player vision wakes the region, which explains the spectator workaround and inconsistent timing.

Separately, the build factory constructs candidates before assigning final coordinates. Manual building repairs that provisional hash after registration; the Sample Builder path did not, leaving successful output discoverable in its origin cells but absent from its final cells until an incidental later rehash.

## Validation
- changed source and evidence-harness syntax on Node 18.16.0, 20.19.4, and 24.13.1
- 25/25 BUG-016 production-module assertions on all three Node versions
- 81/81 BUG-006 persistence assertions on all three Node versions, including exactly one primary registration and completed snapshot/reload
- 16/16 isolated Node 20 local multiplayer assertions with two real Socket.IO clients across blocked LOS, alternating proximity, offscreen cadence, exact cost, final hashing, region serialization, reload, and client delivery
- known BUG-010 open-PR snapshot failures are byte-for-byte equivalent to a clean official-main control
- one commit, two files, five additions, zero deletions, and a clean 3,071-file committed raw-byte audit

## Scope
No build/retry rate, cost, legality, ownership, sampling, LOS, global deep-sleep, snapshot-format, configuration, balance, or unrelated refactor change. Evidence harnesses and local-server logs remain outside the game repository and are not included in this PR.

The in-app visual browser was unavailable, so no visual-browser coverage is claimed. The multiplayer gate used real local Socket.IO protocol clients; inspector evaluation was limited to deterministic fixture placement and exact production mechanics.
