### PR TITLE
Keep gravity walls consistent after placement

### DIFF
--- a/game/sdWorld.js
+++ b/game/sdWorld.js
@@ -2954,6 +2954,44 @@ class sdWorld
 		
 		if ( entity._is_being_removed )
 		return;
+
+		// Final wall/door placement can suppress generic movement callbacks for build safety. Keep existing
+		// antigravity sensor topology in sync without enabling any of the unrelated movement reactions.
+		if ( !delay_callback_calls && allow_calling_movement_in_range === false )
+		{
+			const ec = sdWorld.entity_classes;
+			if ( ( ec.sdBlock && entity.constructor === ec.sdBlock ) ||
+				 ( ec.sdDoor && entity.constructor === ec.sdDoor ) )
+			{
+				let notified_sensors = null;
+				for ( let i2 = 0; i2 < entity._affected_hash_arrays.length; i2++ )
+				{
+					const scan_src = entity._affected_hash_arrays[ i2 ].sensor_relevant_arr;
+					if ( scan_src === null )
+					continue;
+
+					for ( let i = 0; i < scan_src.length; i++ )
+					{
+					const sensor = scan_src[ i ];
+					if ( sensor !== entity && ( notified_sensors === null || !notified_sensors.has( sensor ) ) )
+					if ( ec.sdSensorArea && sensor.constructor === ec.sdSensorArea )
+					if ( !sensor._is_being_removed )
+					if ( sensor.on_movement_target && !sensor.on_movement_target._is_being_removed )
+					if ( ec.sdAntigravity && sensor.on_movement_target.constructor === ec.sdAntigravity )
+					if ( entity.x + entity._hitbox_x2 > sensor.x + sensor._hitbox_x1 &&
+						 entity.x + entity._hitbox_x1 < sensor.x + sensor._hitbox_x2 &&
+						 entity.y + entity._hitbox_y2 > sensor.y + sensor._hitbox_y1 &&
+						 entity.y + entity._hitbox_y1 < sensor.y + sensor._hitbox_y2 )
+					{
+						if ( notified_sensors === null )
+						notified_sensors = new Set();
+						notified_sensors.add( sensor );
+						sensor.onMovementInRange( entity );
+					}
+					}
+				}
+			}
+		}
 		
 		if ( delay_callback_calls || !allow_calling_movement_in_range )
 		{


### PR DESCRIPTION
## Summary

- update an established gravity pad's sensor topology when a later wall or door completes its callback-suppressed final hash
- restrict the notification to exact-overlap live sensor areas owned by live antigravity pads, with multi-cell deduplication
- preserve generic build-callback suppression and all existing force, LOS, material, power, and removal behavior

## Investigation

Gravity pads enumerate affected entities and blockers through an `sdSensorArea`. A wall placed before the pad is registered when that sensor is created, but a wall built later takes the manual-build finalization path that deliberately calls `UpdateHashPosition` with generic movement callbacks suppressed.

The later wall is already present in its final hash cells and blocks production LOS, but the established gravity sensor never receives it. The server therefore continues applying the field through that wall; this is authoritative behavior, not only a client prediction issue.

The fix leaves the suppression contract intact. After the existing final hash update, it narrowly delegates only a final `sdBlock`/`sdDoor` to exact-overlap antigravity-owned sensor areas from the maintained sensor index.

## Validation

- changed source and evidence-harness syntax on Node 18.16.0, 20.19.4, and 24.13.1
- 495/495 BUG-015 desired-contract assertions on all three Node versions across four directions, two hash placements, walls/trapshields/reinforced walls/doors, negatives, dedup, removal, hibernation, snapshot reconstruction, and hash/LOS controls
- the frozen old-bug inverse changes only its exact 141 assertions; the original 18-check observation changes only its two reported-bug assertions
- neighboring BUG-008 27/27, BUG-016 control 24/24, BUG-006 81/81, movement 30/30, sensor-index 341,011/341,011, rigid 516/516, and LOS-cache 11/11 on all three Node versions
- 12/12 isolated local Node 20 multiplayer assertions with two independent Chrome clients: later wall delivery and zero velocity, removal delivery and resumed `-0.27`, same sensor across pad sleep/wake, and zero page errors
- one commit, one file, 38 additions, zero deletions, and a clean 3,071-file committed raw-byte audit

## Scope

No gravity strength/range/direction, wall-material rule, power control, LOS algorithm, hash membership, generic movement callback, snapshot format, balance, gameplay redesign, or unrelated refactor change. Evidence harnesses, local-server artifacts, and screenshots remain outside the game repository and are not included in this PR.

Official clean `main` has no LOS-cache epoch field. This change performs no additional hash mutation and makes no claim about the separate VPS-only integrated cache.
