### PR TITLE
Preserve elevator speed while welding

### DIFF
--- a/game/entities/sdSteeringWheel.js
+++ b/game/entities/sdSteeringWheel.js
@@ -542,6 +542,7 @@ class sdSteeringWheel extends sdEntity
 			sdSound.PlaySound({ name:'gun_buildtool2', x:entity.x, y:entity.y, volume:1, pitch:0.5 });
 		}
 		
+		if ( this.type === sdSteeringWheel.TYPE_STEERING_WHEEL )
 		this.speed = ( this._scan.length > 0 ) ? 4 : 0;
 	}
 	


### PR DESCRIPTION
## Summary

- preserve an elevator motor's configured speed when blocks are manually welded or unwelded
- retain the existing scan-based speed recalculation for ordinary steering wheels
- leave automatic re-weld, movement, membership, safety, and persistence behavior unchanged

## Investigation

Elevator speed is persistent configuration selected through `SET_SPEED`, consumed directly by movement, and stored in snapshots. Manual weld-tool add/remove routes through `ToggleSingleScanItem`, whose final unconditional steering-wheel bookkeeping assignment overwrites every elevator setting with internal speed 4 / displayed speed 2.

Automatic `Scan` already guards the equivalent recalculation to `TYPE_STEERING_WHEEL`, preserving elevator configuration during re-weld. The fix applies that established type boundary to the remaining manual-toggle path.

## Validation

- changed source and evidence-harness syntax on Node 18.16.0, 20.19.4, and 24.13.1
- 203/203 BUG-018 desired-contract assertions on all three Node versions across six speed settings, manual weld/unweld, automatic re-weld, movement, UI selection, lifecycle, snapshots, invalid input, rejected targets, and ordinary-steering-wheel controls
- the frozen old-bug inverse changes only its exact 47 assertions; the original 102-check observation changes only its exact 15 reported-bug/downstream assertions
- neighboring BUG-010 48/48, rigid batch 516/516, rigid eligibility 48/48, leading-edge 9/9, and rigid snapshot 3,716,526/3,716,526 on all three Node versions
- 27/27 isolated local Node 20 multiplayer assertions with two throttled Chrome clients: both retain displayed speed 4 and observe identical 16 px movement before, after weld, and after unweld, with zero page/console errors
- one commit, one file, one addition, zero deletions, and a clean 3,071-file committed raw-byte audit

## Scope

No speed value, acceleration, direction, collision/track rule, weld membership, pointer/ID behavior, UI option, snapshot format, balance, gameplay redesign, or unrelated refactor change. Evidence harnesses, local-server artifacts, and screenshots remain outside the game repository and are not included in this PR.

Open PR #300 changes the same file in a separate `Scan` hunk for elevator-background retention. A merge-tree audit is conflict-free; BUG-018 changes only `ToggleSingleScanItem`.
