### PR TITLE
Target clicked background cells

### DIFF
--- a/game/entities/sdBullet.js
+++ b/game/entities/sdBullet.js
@@ -476,6 +476,8 @@ class sdBullet extends sdEntity
 		this._detonate_on_impact = true;
 
 		this._bg_shooter = false;
+		this._bg_shooter_target_x = null;
+		this._bg_shooter_target_y = null;
 
 		this.penetrating = false;
 		this._penetrated_list = [];
@@ -540,6 +542,7 @@ class sdBullet extends sdEntity
 		});*/
 		this.SetMethod( 'BouncyCollisionFiltering', this.BouncyCollisionFiltering ); // Here it used for "this" binding so method can be passed to collision logic
 		this.SetMethod( 'RegularCollisionFiltering', this.RegularCollisionFiltering ); // Here it used for "this" binding so method can be passed to collision logic
+		this.SetMethod( 'BackgroundShotCollisionFiltering', this.BackgroundShotCollisionFiltering );
 	}
 	onSnapshotApplied()
 	{
@@ -703,6 +706,69 @@ class sdBullet extends sdEntity
 	{
 		return sdWorld.inDist2D_Boolean( owner_ent.x, owner_ent.y, trap_shield_block.x + trap_shield_block.width/2, trap_shield_block.y + trap_shield_block.height/2, 32 );
 	}
+	BackgroundShotCollisionFiltering( from_entity )
+	{
+		if ( this._bg_shooter && !this._bouncy && from_entity._is_bg_entity === 1 )
+		if ( Number.isFinite( this._bg_shooter_target_x ) && Number.isFinite( this._bg_shooter_target_y ) )
+		{
+			let target_x = this._bg_shooter_target_x;
+			let target_y = this._bg_shooter_target_y;
+			let velocity = sdWorld.Dist2D_Vector( this.sx, this.sy );
+
+			if ( velocity > 0 )
+			{
+				target_x -= this.sx / velocity * 0.0001;
+				target_y -= this.sy / velocity * 0.0001;
+			}
+
+			if ( target_x < from_entity.x + from_entity._hitbox_x1 ||
+				 target_x >= from_entity.x + from_entity._hitbox_x2 ||
+				 target_y < from_entity.y + from_entity._hitbox_y1 ||
+				 target_y >= from_entity.y + from_entity._hitbox_y2 )
+			return false;
+		}
+
+		return true;
+	}
+	TryBackgroundTargetCollision()
+	{
+		if ( !this._bg_shooter || this._bouncy || !Number.isFinite( this._bg_shooter_target_x ) || !Number.isFinite( this._bg_shooter_target_y ) )
+		return;
+
+		let target_x = this._bg_shooter_target_x;
+		let target_y = this._bg_shooter_target_y;
+		let velocity = sdWorld.Dist2D_Vector( this.sx, this.sy );
+
+		if ( velocity > 0 )
+		{
+			target_x -= this.sx / velocity * 0.0001;
+			target_y -= this.sy / velocity * 0.0001;
+		}
+
+		let BG = sdWorld.entity_classes.sdBG;
+		let target_bg = BG.GetBackgroundObjectAt( target_x, target_y, false );
+		if ( !target_bg || target_bg._is_being_removed )
+		return;
+
+		let hitbox_x1 = target_bg.x + target_bg._hitbox_x1;
+		let hitbox_x2 = target_bg.x + target_bg._hitbox_x2;
+		let hitbox_y1 = target_bg.y + target_bg._hitbox_y1;
+		let hitbox_y2 = target_bg.y + target_bg._hitbox_y2;
+
+		if ( target_bg._merged )
+		{
+			hitbox_y1 = target_bg.y + Math.floor( ( target_y - target_bg.y ) / 16 ) * 16;
+			hitbox_y2 = hitbox_y1 + 16;
+		}
+
+		if ( this.x + this._hitbox_x2 <= hitbox_x1 ||
+			 this.x + this._hitbox_x1 >= hitbox_x2 ||
+			 this.y + this._hitbox_y2 <= hitbox_y1 ||
+			 this.y + this._hitbox_y1 >= hitbox_y2 )
+		return;
+
+		this.onMovementInRange( target_bg );
+	}
 
 	RegularCollisionFiltering( from_entity )
 	{
@@ -779,6 +845,9 @@ class sdBullet extends sdEntity
 		return false;
 		
 		if ( from_entity.is( sdBlock ) && from_entity._merged )
+		return false;
+
+		if ( !this.BackgroundShotCollisionFiltering( from_entity ) )
 		return false;
 
 		if ( this._admin_picker )
@@ -888,10 +957,20 @@ class sdBullet extends sdEntity
 				this.sy = this.sy * 0.95;
 			}
 
+			let collision_steps = 1;
+			if ( this._bg_shooter && !this._bouncy && Number.isFinite( this._bg_shooter_target_x ) && Number.isFinite( this._bg_shooter_target_y ) )
+			collision_steps = Math.max( 1, Math.ceil( sdWorld.Dist2D_Vector( this.sx, this.sy ) * GSPEED / 16 ) );
+			let collision_gspeed = GSPEED / collision_steps;
+
 			if ( this.is_grenade || this.affected_by_gravity )
 			{
 				this.sy += sdWorld.gravity * GSPEED * this.gravity_scale;
-				this.ApplyVelocityAndCollisions( GSPEED, 0, true, 1, this.RegularCollisionFiltering );
+				for ( let i = 0; i < collision_steps && !this._is_being_removed; i++ )
+				{
+					this.ApplyVelocityAndCollisions( collision_gspeed, 0, true, 1, this.RegularCollisionFiltering );
+					if ( !this._is_being_removed )
+					this.TryBackgroundTargetCollision();
+				}
 			}
 			else
 			{
@@ -900,7 +979,14 @@ class sdBullet extends sdEntity
 					// Old penetration logic is now handled by GetCollisionMode()
 					//this.x += this.sx * GSPEED;
 					//this.y += this.sy * GSPEED;
-					this.ApplyVelocityAndCollisions( GSPEED, 0, false, 0, null );
+					for ( let i = 0; i < collision_steps && !this._is_being_removed; i++ )
+					{
+						this.ApplyVelocityAndCollisions( collision_gspeed, 0, false, 0,
+							this._bg_shooter && Number.isFinite( this._bg_shooter_target_x ) && Number.isFinite( this._bg_shooter_target_y ) ?
+							this.BackgroundShotCollisionFiltering : null );
+						if ( !this._is_being_removed )
+						this.TryBackgroundTargetCollision();
+					}
 				}
 				else
 				{
@@ -910,7 +996,12 @@ class sdBullet extends sdEntity
 
 					sdWorld.last_hit_entity = null;
 
-					this.ApplyVelocityAndCollisions( GSPEED, 0, true, 0, this._bouncy ? this.BouncyCollisionFiltering : this.RegularCollisionFiltering );
+					for ( let i = 0; i < collision_steps && !this._is_being_removed; i++ )
+					{
+						this.ApplyVelocityAndCollisions( collision_gspeed, 0, true, 0, this._bouncy ? this.BouncyCollisionFiltering : this.RegularCollisionFiltering );
+						if ( !this._is_being_removed )
+						this.TryBackgroundTargetCollision();
+					}
 
 					let vel2 = this.sx * this.sx + this.sy * this.sy;
 
@@ -1154,29 +1245,57 @@ class sdBullet extends sdEntity
 			else
 			return;
 		}
-		// BG shooting works normally even without this, so disabled for now.
-		/*if ( this._bg_shooter && !this._bouncy && from_entity._is_bg_entity === 1 )
+		if ( this._bg_shooter && !this._bouncy && from_entity._is_bg_entity === 1 &&
+			 Number.isFinite( this._bg_shooter_target_x ) && Number.isFinite( this._bg_shooter_target_y ) )
 		{
-			// Essentially the backgrounds split themselves, returning an array of the new spawned backgrounds
-			let ents = from_entity.UnmergeBackgrounds();
-			if ( ents.length > 0 ) 
+			let target_x = this._bg_shooter_target_x;
+			let target_y = this._bg_shooter_target_y;
+
+			let velocity = sdWorld.Dist2D_Vector( this.sx, this.sy );
+			if ( velocity > 0 )
 			{
-				// And we need to determine which block to damage, which is the closest one.
-				let closest = sdWorld.Dist2D( this.x, this.y, ents[ 0 ].x + ( ents[ 0 ].width / 2 ), ents[ 0 ].y + ( ents[ 0 ].height / 2 ) );
-				from_entity = ents[ 0 ];
+				target_x -= this.sx / velocity * 0.0001;
+				target_y -= this.sy / velocity * 0.0001;
+			}
+
+			if ( target_x < from_entity.x + from_entity._hitbox_x1 ||
+				 target_x >= from_entity.x + from_entity._hitbox_x2 ||
+				 target_y < from_entity.y + from_entity._hitbox_y1 ||
+				 target_y >= from_entity.y + from_entity._hitbox_y2 )
+			return;
+
+			if ( from_entity._merged )
+			{
+				let ents = from_entity.UnmergeBackgrounds();
+				let target_entity = null;
+
 				for ( let i = 0; i < ents.length; i++ )
 				{
-					let distance = sdWorld.Dist2D( this.x, this.y, ents[ i ].x + ( ents[ i ].width / 2 ), ents[ i ].y + ( ents[ i ].height / 2 ) );
-					if ( distance < closest )
+					if ( target_x >= ents[ i ].x + ents[ i ]._hitbox_x1 &&
+						 target_x < ents[ i ].x + ents[ i ]._hitbox_x2 &&
+						 target_y >= ents[ i ].y + ents[ i ]._hitbox_y1 &&
+						 target_y < ents[ i ].y + ents[ i ]._hitbox_y2 )
 					{
-						closest = distance;
-						from_entity = ents[ i ];
+						target_entity = ents[ i ];
+						break;
 					}
 				}
+
+				if ( this._is_being_removed )
+				return;
+
+				if ( target_entity === null )
+				return;
+
+				if ( this.x + this._hitbox_x2 <= target_entity.x + target_entity._hitbox_x1 ||
+					 this.x + this._hitbox_x1 >= target_entity.x + target_entity._hitbox_x2 ||
+					 this.y + this._hitbox_y2 <= target_entity.y + target_entity._hitbox_y1 ||
+					 this.y + this._hitbox_y1 >= target_entity.y + target_entity._hitbox_y2 )
+				return;
+
+				from_entity = target_entity;
 			}
-			else
-			return;
-		}*/
+		}
 		
 		if ( this._last_target === from_entity )
 		return; // Prevent bouncing bullets to deal multiple damage when they stuck in something?
@@ -1777,4 +1896,3 @@ class sdBullet extends sdEntity
 //sdBullet.init_class();
 
 export default sdBullet;
-

--- a/game/entities/sdGun.js
+++ b/game/entities/sdGun.js
@@ -1423,6 +1423,28 @@ class sdGun extends sdEntity
                             bullet_obj._owner._recoil += bullet_obj._knock_scale * vel * 0.02 * self_recoil_scale; // 0.01
 
                             bullet_obj._bg_shooter = background_shoot ? true : false;
+                            if ( bullet_obj._bg_shooter )
+                            {
+                                bullet_obj._bg_shooter_target_x = bullet_obj._owner.look_x;
+                                bullet_obj._bg_shooter_target_y = bullet_obj._owner.look_y;
+
+                                if ( sdWorld.is_server )
+                                {
+                                    let target_x = bullet_obj._bg_shooter_target_x;
+                                    let target_y = bullet_obj._bg_shooter_target_y;
+                                    let velocity = sdWorld.Dist2D_Vector( bullet_obj.sx, bullet_obj.sy );
+
+                                    if ( velocity > 0 )
+                                    {
+                                        target_x -= bullet_obj.sx / velocity * 0.0001;
+                                        target_y -= bullet_obj.sy / velocity * 0.0001;
+                                    }
+
+                                    let target_bg = sdBG.GetBackgroundObjectAt( target_x, target_y, false );
+                                    if ( target_bg && target_bg._merged )
+                                    target_bg.UnmergeBackgrounds();
+                                }
+                            }
                             
                             bullet_obj.time_left *= bullet_obj._owner.s / 100;
                         }


### PR DESCRIPTION
## Summary

- snapshot the Shift-shot cursor target when a projectile is fired
- let the projectile pass earlier backgrounds while preserving normal foreground collision, range, spread, damage, and safe-area behavior
- resolve merged and high-speed paths only when the projectile physically reaches the clicked 16px background cell

## Investigation

Shift/background shots currently store only a Boolean on the projectile, so normal movement consumes them on the first background crossed rather than the background under the cursor. A merged background adds a second failure: it splits into children after the current swept-hit list is built, and the original hit is not transferred to the selected child.

The fix captures the fire-time cursor, pre-unmerges an authoritative merged target, filters only non-target background cells, and uses bounded collision substeps plus a physical-overlap check for high-speed shots. Exact shared edges resolve to the cell approached by the projectile. Legacy background bullets without captured target coordinates keep their previous behavior.

## Validation

- changed-source syntax and 24-scenario BUG-014 harness on Node 18.16.0, 20.19.4, and 24.13.1
- 113/113 assertions on every runtime, covering merged/unmerged and negative-coordinate targets, centres/edges/corners, normal and rail speed-40 shots above/below, obstruction, range, empty cursor, Shift false, and legacy-unset-target behavior
- unchanged-main control: 61/113 with the exact 52 expected target-behavior failures on all three runtimes
- 20/20 isolated local Node 20 multiplayer assertions with two independent throttled Chrome clients: opposite-direction production sniper shots remove only their intended merged child on both clients; a foreground wall still takes exactly 125 damage while four backgrounds remain intact; zero page/console errors
- one commit, exactly two production files, +159/-19, clean status, and a 3,071/3,071 committed raw-byte audit

## Scope

No damage, velocity, spread, range/lifetime, recoil, safe-area, armor, foreground-collision, merge-cadence, balance, snapshot-format, UI, or unrelated refactor change. Evidence harnesses, local-server artifacts, and screenshots remain outside the game repository and are not included in this PR.

Open PR #208 changes both files as part of an old broad gameplay overhaul, but does not implement cursor-cell background targeting. Its relevant hunks alter recoil, velocity inheritance, damage, and AI interactions; GitHub currently marks it conflicting with `main`.