### PR TITLE
Fix nearest-antenna selection and hibernation-invisible antennas

### DIFF
--- a/game/entities/sdDeepSleep.js
+++ b/game/entities/sdDeepSleep.js
@@ -121,6 +121,7 @@ import sdSteeringWheel from './sdSteeringWheel.js';
 import sdThruster from './sdThruster.js';
 import sdRescueTeleport from './sdRescueTeleport.js';
 import sdBeacon from './sdBeacon.js';
+import sdLongRangeAntenna from './sdLongRangeAntenna.js';
 import sdHover from './sdHover.js';
 import sdTzyrgAbsorber from './sdTzyrgAbsorber.js';
 import sdWanderer from './sdWanderer.js';
@@ -1239,6 +1240,7 @@ class sdDeepSleep extends sdEntity
 								( e.is( sdLongRangeTeleport ) && e.is_server_teleport ) || // No server teleports (unless regular telepors will be available for in-world teleportation at some point?)
 								e.is( sdRescueTeleport ) || // It looks like there is no simple solution at all for these...
 								e.is( sdBeacon ) || // It looks like there is no simple solution at all for these...
+								e.is( sdLongRangeAntenna ) || // Must stay reachable for TELEPORT_ANTENNA regardless of chunk sleep state - same reasoning as the exemptions above
 								!sdWorld.server_config.AllowAggressiveHibernationFor( e )
 							)
 						{

--- a/game/entities/sdLongRangeTeleport.js
+++ b/game/entities/sdLongRangeTeleport.js
@@ -1526,10 +1526,9 @@ class sdLongRangeTeleport extends sdEntity
 
 									this.Deactivation();
 									let nearest_antenna = null;
+									let nearest_di = Infinity;
 									for ( let i = 0; i < sdLongRangeAntenna.antennas.length; i++ )
 									{
-										//let nearest_antenna = null;
-										let nearest_di = Infinity;
 										let antenna = sdLongRangeAntenna.antennas[ i ];
 										if ( antenna.progress >= 100 ) // At least one calibrated antenna
 										{


### PR DESCRIPTION
## Summary

- fix TELEPORT_ANTENNA's nearest-calibrated-antenna scan, which was selecting the last
  antenna in registration order instead of the geometrically nearest one
- keep calibrated long-range antennas reachable regardless of chunk sleep state, matching
  the existing sdLongRangeTeleport (server teleports) / sdRescueTeleport / sdBeacon
  hibernation exemptions

## Investigation

The nearest-antenna loop in sdLongRangeTeleport's TELEPORT_ANTENNA handler redeclared
`nearest_di` as `Infinity` inside the loop body on every iteration, so the "closer than
current best" comparison was always against Infinity and always true - the loop kept
overwriting `nearest_antenna` with every later calibrated antenna it visited, ending on
whichever one was registered last rather than the closest one.

Separately, sdDeepSleep's aggressive-hibernation exemption list (which already exempts
server teleports, rescue teleports, and beacons so they stay globally reachable) predates
sdLongRangeAntenna by about six months and was never extended to it. A calibrated
antenna whose chunk hibernates gets spliced out of the static antennas registry like any
ordinary block, and nothing proactively wakes that chunk just because a distant player
wants to teleport to it - so it stays invisible to TELEPORT_ANTENNA until unrelated player
movement/vision happens to reach that region again. This matches the reported "Long Range
Antenna chunks sleep rendering it useless" symptom.

## Validation

- node --check on both changed files
- BUG-011 regression harness (Node v24.13.1) drives the real, unmodified TELEPORT_ANTENNA
  command handler and AttemptTeleportToTarget directly - 9/9 assertions pass on this
  branch versus 8/9 on unmodified main, with the previously-failing nearest-selection
  assertion now passing and nothing else regressing
- one commit, exactly two production files, net +3/-2, clean status, git diff --check clean

## Scope

No damage, reward, matter/charge gating, wiring-requirement, UI, balance, or unrelated
refactor change. No live two-client multiplayer session was run for this fix; this gap
is disclosed rather than claimed as tested.

Open PR #208 also touches sdLongRangeTeleport.js, but only an unrelated CLAIM_REWARD_CRYSTALS
reward-claim hunk far from the antenna-selection code touched here; it does not touch
sdDeepSleep.js at all and is already marked conflicting/stale against current main.