### PR TITLE
Remove dead matter_required_to_destroy_command_center property

### DIFF
--- a/game/entities/sdCharacter.js
+++ b/game/entities/sdCharacter.js
@@ -603,8 +603,7 @@ class sdCharacter extends sdEntity
 		sdCharacter.disowned_body_ttl = 30 * 60 * 1; // 1 min
 	
 		sdCharacter.starter_matter = 300;
-		sdCharacter.matter_required_to_destroy_command_center = 300; // Will be used to measure command centres' self-destruct if no characters with enough matter will showup near them
-		
+
 		sdCharacter.default_weapon_draw_time = 7;
 		
 		sdCharacter.ignored_classes_when_holding_x = [ 'sdCharacter', 'sdBullet', 'sdWorkbench', 'sdLifeBox', 'sdUpgradeStation', 'sdCaption', 'sdLandMine' ];

--- a/game/server/sdServerConfig.js
+++ b/game/server/sdServerConfig.js
@@ -1340,9 +1340,6 @@ class sdServerConfigFull extends sdServerConfigShort
 					}
 				}
 
-				let top_matter = 0;
-
-
 				for ( let i = 0; i < no_respawn_areas.length; i++ )
 				{
 					if ( sdWorld.time > no_respawn_areas[ i ].until )
@@ -1373,9 +1370,6 @@ class sdServerConfigFull extends sdServerConfigShort
 					if ( ent.hea > 0 )
 					if ( !ent._is_being_removed )
 					{
-						if ( ent.matter > top_matter )
-						top_matter = ent.matter;
-
 						if ( sdWorld.world_bounds.x2 - sdWorld.world_bounds.x1 > 4000 )
 						{
 							if ( ent.x < sdWorld.world_bounds.x1 + 2000 )
@@ -1458,12 +1452,6 @@ class sdServerConfigFull extends sdServerConfigShort
 				for ( let i = 0; i < sdCommandCentre.centres.length; i++ )
 				{
 					var ent = sdCommandCentre.centres[ i ];
-
-					if ( top_matter >= sdCharacter.matter_required_to_destroy_command_center )
-					if ( ent.self_destruct_on < sdWorld.time + sdCommandCentre.time_to_live_without_matter_keepers_near - 1000 * 5 )
-					{
-						ent.self_destruct_on = Math.min( ent.self_destruct_on + world_edge_think_rate * 2, sdWorld.time + sdCommandCentre.time_to_live_without_matter_keepers_near );
-					}
 
 					if ( ent.x < sdWorld.world_bounds.x1 + 1000 )
 					{


### PR DESCRIPTION
## Summary

- remove sdCharacter.matter_required_to_destroy_command_center, a property with no
  functional effect since 2022
- remove its sole dead reader in sdServerConfig.js, and the top_matter accumulator that
  existed only to feed that reader

## Investigation

sdCharacter.matter_required_to_destroy_command_center's only live/uncommented reader
(sdServerConfig.js) only ever mutated sdCommandCentre.self_destruct_on. That field's sole
constructor initialization was commented out in 2022 (bf8e34267, "Memory leak detector
and some changes to entities that caused long chains of cross-references removed
entities"), so self_destruct_on is always undefined on every command centre, and the
reader's `undefined < finite number` comparison is always false - the reader block never
executes. Even hypothetically, nothing downstream ever consumed self_destruct_on: the
trigger method (SyncedToPlayer) and the tooltip display that would have shown it are both
fully commented out in sdCommandCentre.js, and the live class defines no override of
SyncedToPlayer at all. This has been dead code for its entire time in sdServerConfig.js -
that block was added 11 months after the mechanic it depends on was already disabled.

This matches the source report's own framing ("still an extant property... lmao") as a
cleanup request, not a functional bug; restoring the disabled 24h self-destruct mechanic
would be an unrequested gameplay/balance redesign and is out of scope.

## Validation

- node --check on both changed files
- BUG-012 harness (Node v24.13.1) constructs a real sdCommandCentre via sdEntity.Create and
  inspects real instance/prototype state - 7/7 assertions pass on this branch versus 5/7 on
  unmodified main, with both previously-failing "still present" assertions now passing and
  nothing else regressing (i.e. the mechanic's no-op behavior is provably unchanged)
- one commit, exactly two production files, net -13 lines, clean status, git diff --check clean
- no live/manual protocol applies - there is no observable behavior to compare before/after

## Scope

No damage, matter cost, UI, balance, or unrelated refactor change. sdCommandCentre.js is
untouched (its self-destruct code is already fully commented out) and config_examples/*.js
are untouched (standalone example templates, not linked to this file by any build step,
and unaffected either way per investigation.md).

Open PR #208 modifies the line immediately preceding the removed property (unrelated
starter_matter value) but not the property line itself, and does not touch the
sdServerConfig.js section this PR edits at all; it is already marked conflicting/stale
against current main.