### PR TITLE
Compensate crosshair rendering for earthquake screen shake

### DIFF
--- a/game/client/sdRenderer.js
+++ b/game/client/sdRenderer.js
@@ -2202,35 +2202,43 @@ class sdRenderer
 			if ( sdWorld.my_entity )
 			if ( sdRenderer.UseCrosshair() )
 			{
-				if ( !sdWorld.my_entity._is_being_removed && 
+				// Compensate for quake_offset_x/y: this block still draws through the same camera
+				// transform that includes earthquake screen shake, but sdWorld.mouse_world_x/y (the
+				// actual gameplay aim) is intentionally computed without it. Without compensation the
+				// crosshair visibly drifts away from the literal (OS-cursor-hidden) mouse position
+				// during a quake even though the real aim stays perfectly stable.
+				const hud_mouse_world_x = sdWorld.mouse_world_x + quake_offset_x;
+				const hud_mouse_world_y = sdWorld.mouse_world_y + quake_offset_y;
+
+				if ( !sdWorld.my_entity._is_being_removed &&
 					 sdWorld.my_entity._inventory[ sdWorld.my_entity.gun_slot ] &&
 					 sdGun.classes[ sdWorld.my_entity._inventory[ sdWorld.my_entity.gun_slot ].class ] &&
 					 sdGun.classes[ sdWorld.my_entity._inventory[ sdWorld.my_entity.gun_slot ].class ].is_build_gun )
 				{
-					ctx.drawImageFilterCache( sdWorld.img_crosshair_build, 
-						sdWorld.mouse_world_x - 16, 
-						sdWorld.mouse_world_y - 16, 32,32 );
-						
+					ctx.drawImageFilterCache( sdWorld.img_crosshair_build,
+						hud_mouse_world_x - 16,
+						hud_mouse_world_y - 16, 32,32 );
+
 					ctx.font = "5.5px Verdana";
 					ctx.textAlign = 'left';
-					
+
 					let item_selected = false; // Will be false for dummy objects
-					
+
 					if ( sdWorld.my_entity._build_params )
 					{
 						let cost = sdWorld.my_entity._inventory[ sdWorld.my_entity.gun_slot ].GetBulletCost( false );
-							
+
 						if ( cost === Infinity )
 						{
 						}
 						else
 						{
 							item_selected = true;
-							
+
 							ctx.fillStyle = '#ffff00';
-							ctx.fillText( T("Matter cost") + ": " + ( cost === Infinity ? '-' : sdWorld.RoundedThousandsSpaces( Math.ceil( cost ) ) ), sdWorld.mouse_world_x + 20, sdWorld.mouse_world_y - 2 );
+							ctx.fillText( T("Matter cost") + ": " + ( cost === Infinity ? '-' : sdWorld.RoundedThousandsSpaces( Math.ceil( cost ) ) ), hud_mouse_world_x + 20, hud_mouse_world_y - 2 );
 							ctx.fillStyle = '#00ffff';
-							ctx.fillText( T("Matter carried") + ": " + sdWorld.RoundedThousandsSpaces( sdWorld.my_entity.matter ), sdWorld.mouse_world_x + 20, sdWorld.mouse_world_y + 5 );
+							ctx.fillText( T("Matter carried") + ": " + sdWorld.RoundedThousandsSpaces( sdWorld.my_entity.matter ), hud_mouse_world_x + 20, hud_mouse_world_y + 5 );
 
 							if ( sdWorld.my_entity.matter >= cost )
 							{
@@ -2239,36 +2247,36 @@ class sdRenderer
 								if ( sdWorld.my_entity._build_params )
 								{
 									if ( sdWorld.my_entity._build_params.upgrade_name )
-									ctx.fillText( T("Click to install upgrade"), sdWorld.mouse_world_x + 20, sdWorld.mouse_world_y + 5 + 7 );
+									ctx.fillText( T("Click to install upgrade"), hud_mouse_world_x + 20, hud_mouse_world_y + 5 + 7 );
 									else
-									ctx.fillText( T("Click to build"), sdWorld.mouse_world_x + 20, sdWorld.mouse_world_y + 5 + 7 );
+									ctx.fillText( T("Click to build"), hud_mouse_world_x + 20, hud_mouse_world_y + 5 + 7 );
 								}
 							}
 							else
 							{
 								ctx.fillStyle = '#ff0000';
-								ctx.fillText( T("Not enough matter"), sdWorld.mouse_world_x + 20, sdWorld.mouse_world_y + 5 + 7 );
+								ctx.fillText( T("Not enough matter"), hud_mouse_world_x + 20, hud_mouse_world_y + 5 + 7 );
 							}
 						}
 					}
-					
+
 					if ( !item_selected )
 					{
 						ctx.fillStyle = '#ffff00';
-						ctx.fillText( T("Press B to pick item to build"), sdWorld.mouse_world_x + 20, sdWorld.mouse_world_y + 5 + 7 );
+						ctx.fillText( T("Press B to pick item to build"), hud_mouse_world_x + 20, hud_mouse_world_y + 5 + 7 );
 					}
 				}
 				else
 				{
 					ctx.save();
 					{
-						ctx.translate( sdWorld.mouse_world_x, sdWorld.mouse_world_y );
-						
+						ctx.translate( hud_mouse_world_x, hud_mouse_world_y );
+
 						//let s = 1 + ( sdWorld.my_entity._inventory[ sdWorld.my_entity.gun_slot ] && sdWorld.my_entity._inventory[ sdWorld.my_entity.gun_slot ].muzzle > 0 ? 0.3 : 0 );
 						//ctx.scale( s, s );
-						
-						ctx.drawImageFilterCache( sdWorld.img_crosshair, 
-							- 16, 
+
+						ctx.drawImageFilterCache( sdWorld.img_crosshair,
+							- 16,
 							- 16, 32,32 );
 					}
 					ctx.restore();


### PR DESCRIPTION
## Summary

- fix the in-game crosshair, build-crosshair, and build-cost tooltip visually drifting away
  from the literal mouse position during earthquake screen shake
- the actual gameplay aim (look_x/look_y) is unaffected and was already correct

## Investigation

sdWorld.mouse_world_x/y (assigned directly to look_x/look_y, the real gameplay aim) is
deliberately computed without any earthquake shake offset - a shooter's aim must never be
involuntarily dragged around by ambient screen shake, and this was already correct. But the
crosshair sprite and its build-cost tooltip are drawn at that same raw, uncompensated
position while still inside the same camera ctx transform used to draw the shaking world,
which *does* include the shake offset (quake_offset_x/y) whenever an earthquake is active.
Since the native OS cursor is hidden (sdRenderer.canvas.style.cursor = 'none') and this
drawn sprite is the player's only visible aim indicator, the practical effect is that the
crosshair visibly orbits/jitters around the true, perfectly stable aim point during a quake,
even while the physical mouse is held still.

An algebraic substitution of the two formulas shows the crosshair's effective on-screen
position is exactly `mouse_screen_position - quake_offset * camera_scale` - correctly
reducing to the literal mouse position whenever no quake is active, but drifting by the full
shake magnitude otherwise. git history shows the quake render-shake mechanism was added
2026-06-09, after the (2021-era) mouse-to-world formula and crosshair draw code already
existed, without updating either for the new shake term - a straightforward oversight from
that addition, not a longstanding design tension despite the source report's vague wording.

## Validation

- node --check on the changed file
- a numeric harness (Node v24.13.1) verifies the transcribed compensation formula against six
  camera/scale/shake samples, confirming it exactly cancels the render transform's shake term
  in every case (including a no-shake control, unaffected)
- one commit, exactly one production file, net +8 lines, clean status, git diff --check clean
- no live/manual browser session was run this session - canvas rendering can't execute
  headlessly in plain Node, and standing up a full client/server to force an earthquake was
  judged disproportionate for this Low-severity visual bug relative to the algebraic proof;
  disclosed rather than claimed as tested

## Scope

No change to look_x/look_y, entity-hover/targeting logic, camera shake itself (the world
still visibly shakes exactly as before), shake-mode settings, zoom, or any gameplay value.

Open PR #208 keeps the modified ctx.translate line as unchanged context but adds an
unrelated recoil-based crosshair scale/alpha effect on the four lines immediately after it
in the same block; it does not touch the build-crosshair/tooltip block this PR also edits,
and is already marked conflicting/stale against current main.