### PR TITLE
Fix atlas rollout regressions: sdShop rendering corruption, shader-filter color clobbering, LRU cache thrash

### DIFF
--- a/game/client/sdAtlasMaterial.js
+++ b/game/client/sdAtlasMaterial.js
@@ -60,14 +60,15 @@ class sdSuperTexture
 			is_transparent_int !== sdAtlasMaterial.GROUP_OPAQUE_DECAL 
 		);
 		
+		// GROUP_TRANSPARENT_IN_GAME_HUD/ONSCREEN_HUD/ONSCREEN_FOREGROUND replace what used to be
+		// GROUP_TRANSPARENT_UNSORTED, which had depthTest:false (all HUD/foreground content draws
+		// on one z-plane, e.g. sdShop at z_offset=0 - depth-testing it against itself corrupts render).
+		// They must NOT be depth-tested, same as UNSORTED.
 		let depthTest = (
 			is_transparent_int === sdAtlasMaterial.GROUP_OPAQUE ||
 			is_transparent_int === sdAtlasMaterial.GROUP_OPAQUE_DECAL ||
 			is_transparent_int === sdAtlasMaterial.GROUP_TRANSPARENT ||
-			is_transparent_int === sdAtlasMaterial.GROUP_TRANSPARENT_ADDITIVE ||
-			is_transparent_int === sdAtlasMaterial.GROUP_TRANSPARENT_IN_GAME_HUD ||
-			is_transparent_int === sdAtlasMaterial.GROUP_TRANSPARENT_ONSCREEN_HUD ||
-			is_transparent_int === sdAtlasMaterial.GROUP_TRANSPARENT_ONSCREEN_FOREGROUND
+			is_transparent_int === sdAtlasMaterial.GROUP_TRANSPARENT_ADDITIVE
 		);
 
 		let additive = ( is_transparent_int === sdAtlasMaterial.GROUP_TRANSPARENT_ADDITIVE );
@@ -1678,9 +1679,11 @@ class sdAtlasMaterial
 		if ( globalThis.ATLAS_SHADER_FILTER && ctx.sd_filter_shader_color )
 		{
 			sd_filter_mode = 1;
-			cr = ctx.sd_filter_shader_color[ 0 ];
-			cg = ctx.sd_filter_shader_color[ 1 ];
-			cb = ctx.sd_filter_shader_color[ 2 ];
+			// Multiply (not replace) so an existing sd_color_mult (dimming, damage flash, hover/disabled
+			// state) still applies on top of the flat recolor, matching what the CPU-baked path did.
+			cr *= ctx.sd_filter_shader_color[ 0 ];
+			cg *= ctx.sd_filter_shader_color[ 1 ];
+			cb *= ctx.sd_filter_shader_color[ 2 ];
 		}
 		
 		const side_mult = 0.8;

--- a/game/client/sdRenderer.js
+++ b/game/client/sdRenderer.js
@@ -218,7 +218,10 @@ class sdRenderer
 		}
 		
 		sdRenderer.image_filter_cache = new Map();
-		sdRenderer.image_filter_cache_max_variants_per_image = 32; // ATLAS_LRU: cap on distinct sd_filter/tint variants baked per source image
+		sdRenderer.image_filter_cache_max_variants_per_image = 512; // ATLAS_LRU: cap on distinct sd_filter/tint variants baked per source image.
+		// 32 was far below realistic per-image variant counts (e.g. the godmode "Development tests
+		// crystals" shop category alone needs 324 distinct crystal-filter variants of one source sprite),
+		// which turned every frame into an evict-then-immediately-rebake loop instead of an actual cache.
 		
 		sdRenderer.unavailable_image_collector = null; // Fills up indefinitely if array
 	
@@ -233,6 +236,7 @@ class sdRenderer
 			ctx0.sd_status_effect_tint_filter = null;
 
 			ctx0.sd_filter_shader_color = null; // ATLAS_SHADER_FILTER: [ r, g, b ] (0-1) set only for the duration of a flood-fill sd_filter draw, read by sdAtlasMaterial.drawImage
+			ctx0._sd_filter_shader_color_scratch = [ 0, 0, 0 ]; // Reused across calls to avoid a per-draw allocation in the hot path
 			
 			ctx0.drawImageFilterCache = function( ...args )
 			{
@@ -290,13 +294,22 @@ class sdRenderer
 					if ( globalThis.ATLAS_SHADER_FILTER )
 					if ( sd_filter && sd_filter.s.length === 6 && !sd_tint_filter && filter === 'none' )
 					{
-						const r2 = parseInt( sd_filter.s.substring( 0, 2 ), 16 ) / 255;
-						const g2 = parseInt( sd_filter.s.substring( 2, 4 ), 16 ) / 255;
-						const b2 = parseInt( sd_filter.s.substring( 4, 6 ), 16 ) / 255;
+						const scratch = ctx0._sd_filter_shader_color_scratch;
 
-						ctx0.sd_filter_shader_color = [ r2, g2, b2 ];
-						ctx0.drawImage( ...args );
-						ctx0.sd_filter_shader_color = null;
+						scratch[ 0 ] = parseInt( sd_filter.s.substring( 0, 2 ), 16 ) / 255;
+						scratch[ 1 ] = parseInt( sd_filter.s.substring( 2, 4 ), 16 ) / 255;
+						scratch[ 2 ] = parseInt( sd_filter.s.substring( 4, 6 ), 16 ) / 255;
+
+						ctx0.sd_filter_shader_color = scratch;
+
+						try
+						{
+							ctx0.drawImage( ...args );
+						}
+						finally
+						{
+							ctx0.sd_filter_shader_color = null;
+						}
 
 						return;
 					}
@@ -343,7 +356,26 @@ class sdRenderer
 					{
 						if ( globalThis.ATLAS_LRU )
 						if ( image_obj_cache.size >= sdRenderer.image_filter_cache_max_variants_per_image )
-						image_obj_cache.delete( image_obj_cache.keys().next().value ); // Evict oldest variant (insertion-ordered Map)
+						{
+							// Map iteration order is recency order because every cache HIT below re-inserts its
+							// key at the end - so the first key really is the least-recently-used one, not just
+							// the least-recently-inserted one (those differ once a category cycles through more
+							// distinct variants than the cap: without the re-insert-on-hit touch, this evicts by
+							// pure FIFO and can evict variants still in active use every frame).
+							const evicted_key = image_obj_cache.keys().next().value;
+							const evicted_item = image_obj_cache.get( evicted_key );
+
+							image_obj_cache.delete( evicted_key );
+
+							// The evicted canvas may still hold a live atlas dedication (sdAtlasMaterial keys
+							// dedications by object identity). Force it stale now instead of leaving it to age
+							// out over the full TTL with nothing pointing at it - the next DedicateSpace() call
+							// on that group's trailing line can then reclaim it.
+							if ( evicted_item && evicted_item.super_textures )
+							for ( let g = 0; g < evicted_item.super_textures.length; g++ )
+							if ( evicted_item.super_textures[ g ] )
+							evicted_item.super_textures[ g ].last_time_used = 0;
+						}
 
 						if ( typeof OffscreenCanvas !== 'undefined' )
 						{
@@ -494,7 +526,17 @@ class sdRenderer
 						//image_obj_cache_named_item = hqx( image_obj_cache_named_item, 3 );
 						//image_obj_cache.set( complex_filter_name, image_obj_cache_named_item );
 					}
-					
+					else
+					if ( globalThis.ATLAS_LRU )
+					{
+						// Cache hit: touch this entry so it moves to the end of Map iteration order. This is
+						// what makes the eviction above true LRU instead of FIFO - without it, an entry's
+						// position only reflects when it was first baked, not when it was last used, and a
+						// variant drawn every frame could still be the next one evicted.
+						image_obj_cache.delete( complex_filter_name );
+						image_obj_cache.set( complex_filter_name, image_obj_cache_named_item );
+					}
+
 					//let sd_hue_rotation = ctx0.sd_hue_rotation; // This one is now handled by optimized rendering mode (v4)
 					
 					ctx0.filter = 'none';

--- a/game/client/sdShop.js
+++ b/game/client/sdShop.js
@@ -1521,6 +1521,13 @@ class sdShop
 			{
 				sdWorld.my_entity._build_params = current_shop_options[ i ];
 
+				// Cull rows scrolled outside the shop's visible clip rect instead of drawing (and, on the
+				// atlas path, live re-simulating every entity for) every entry regardless of scroll position.
+				// Margin matches the hit-test below (yy-20 .. yy+64+20) so nothing visible is ever culled.
+				let row_visible = ( yy + 64 + 20 >= 20 ) && ( yy - 20 <= sdRenderer.screen_height - 20 );
+
+				if ( row_visible )
+				{
 				ctx.save();
 				ctx.translate( xx, yy );
 				ctx.scale( 2, 2 );
@@ -1805,6 +1812,7 @@ class sdShop
 				}
 
 				ctx.restore();
+				}
 
 				xx += ( 32 + 16 ) * 2;
 				if ( xx + ( 32 ) * 2 > sdRenderer.screen_width - 40 || sdWorld.my_entity._build_params._opens_category === 'root' )


### PR DESCRIPTION
## Summary

PR #279 (atlas overflow fix) + PR #299 (enable by default) fixed the original "entities render behind backgrounds" bug, but the default-on rollout introduced regressions, most visibly severe `sdShop` rendering corruption and severe lag opening the godmode crystals category. This PR fixes those, plus one pre-existing shop performance issue the LRU rollout exposed.

- **`sdShop` rendering corruption.** `ATLAS_LAYER_SPLIT`'s new HUD/foreground groups (5/6/7, `sdAtlasMaterial.js`) were added to the `depthTest` predicate, but they replace `GROUP_TRANSPARENT_UNSORTED`, which had `depthTest:false`. `sdShop` draws its entire UI on one z-plane (`z_offset = 0`), so depth-testing it against itself discarded icons/panels drawn over any opaque fill. Fix: removed those three groups from the `depthTest` predicate so they inherit UNSORTED's `false`, same as before the layer split.

- **`ATLAS_SHADER_FILTER` clobbered `sd_color_mult`.** The flood-fill shader path overwrote `cr/cg/cb` with the recolor target instead of multiplying, so any sprite with both a `sd_filter` recolor and a color multiplier (dimming, damage flash, hover/disabled state) rendered at full flat color — the CPU-baked path it replaced multiplied the two. Fix: multiply instead of overwrite. Also removed a per-draw array allocation in the hot path (reused scratch array) and made the shader-color flag reset via `try`/`finally`.

- **`ATLAS_LRU`'s filter-variant cache thrashed instead of caching.** The per-image variant cache capped at 32 entries via pure insertion-order (FIFO) eviction with no re-insertion on cache hit, so a variant drawn every frame could still be the next one evicted once a source image needed more than 32 distinct recolors. The godmode "Development tests crystals" shop category alone needs 324 (`3 speciality × 9 types × 12 matter_max`), all recolored via native CSS `filter` strings that miss the shader fast path and fall back to CPU bakes — so this turned every frame into an evict-then-immediately-rebake storm, worst on Firefox where the atlas is ¼ the size. Evicted canvases also orphaned their atlas dedication with nothing freeing it until a lucky trailing-line TTL reclaim. Fix: raised the cap to a realistic level (512), made eviction true LRU (re-insert key on hit so Map iteration order reflects recency), and forced an evicted canvas's atlas dedication stale immediately instead of leaking it.

- **`sdShop`'s draw loop had no scroll culling (pre-existing, not caused by the rollout).** Every visible-category entry was drawn — and, on the atlas path, its entity live re-simulated — every frame regardless of scroll position. This is what turns a large category into a framerate problem on top of the LRU fix above. Added viewport culling using the same margin as the existing mouse hit-test, so off-screen rows are skipped entirely.

I also looked at `ATLAS_LRU_SOFT_CAP = 1` as a possible fifth regression (reclaim seemingly "armed" from the first super-texture in every group) and initially proposed raising it, but on closer reading the reclaim scan is already gated behind the group's fit-loop genuinely failing to place a dedication — so cap=1 fires exactly at overflow, not early. Left unchanged.

## Not included

Task 6/13 (verifying whether Firefox's tall-atlas cap, `ATLAS_FF_TALL`, still needs its old upload-time caution) needs an actual Firefox session to measure and isn't done here.

## Test plan

- [x] `node --check` clean on `sdAtlasMaterial.js`, `sdRenderer.js`, `sdShop.js`
- [x] Diff reviewed file-by-file; each change scoped to its issue
- [x] Confirmed by code reading that all five `ATLAS_*` flags still force their legacy path when explicitly set `false` pre-init (the existing rollback mechanism)
- [ ] Live smoke test: shop, godmode crystals category, chat, context menu, in Chrome and Firefox — not run in this session, needs a live browser
- [ ] Confirm the original PR #279 behind-background fix still holds under a live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
