### PR TITLE
Fix players getting stranded inside hibernated sdDeepSleep chunks after a lag spike

### DIFF
--- a/game/entities/sdDeepSleep.js
+++ b/game/entities/sdDeepSleep.js
@@ -187,6 +187,7 @@ class sdDeepSleep extends sdEntity
 		sdDeepSleep.dependence_distance_max = 500; // Anti-dependence hell measure
 		
 		sdDeepSleep.time_budget = 0; // If there was a lag spike - some of later sdDeepSleep updates will be ignored for some amount of time
+		sdDeepSleep.time_budget_min = -9; // Floor for the above. Without it a single very expensive iteration (a big cell being hibernated or decoded) can cost hundreds of frames of complete sdDeepSleep inactivity
 		
 		sdWorld.entity_classes[ this.name ] = this; // Register for object spawn
 	}
@@ -246,14 +247,27 @@ class sdDeepSleep extends sdEntity
 			1 
 		);
 		
-		sdDeepSleep.time_budget = Math.min( 3, sdDeepSleep.time_budget + 3 );
-		
+		// The inception catcher is documented (and warned about) as a per frame budget, yet it used to be reset only
+		// inside the loop below - which does not execute at all while .time_budget is negative. One expensive iteration
+		// drives the budget far below zero, so the reset stopped happening for many frames in a row and wake-up calls
+		// accumulated ACROSS frames instead of within one. Once that running total passed .inception_catcher_give_up_level
+		// every WakeUpArea call began returning early - vision, physical collision and forced reconnect wake-ups alike -
+		// leaving players standing inside hibernated cells that are still ThreatAsSolid(), until the budget recovered on
+		// its own and the counter finally cleared. Resetting here makes it per frame again, as intended.
 		if ( sdWorld.is_server )
-		while ( iters-- > 0 && sdDeepSleep.time_budget > 0 )
 		{
 			sdDeepSleep.inception_catcher = 0;
 			sdDeepSleep.inception_catcher_areas_awoken.length = 0;
-			
+		}
+
+		// Floor the carried-over debt too: unclamped, a single 500ms iteration buys ~166 frames during which nothing
+		// hibernates, no scheduled sleep matures and no cell is reconsidered. The clamp keeps the "skip some updates
+		// after a lag spike" intent while bounding recovery to a few frames.
+		sdDeepSleep.time_budget = Math.min( 3, Math.max( sdDeepSleep.time_budget_min, sdDeepSleep.time_budget ) + 3 );
+
+		if ( sdWorld.is_server )
+		while ( iters-- > 0 && sdDeepSleep.time_budget > 0 )
+		{
 			let t = Date.now();
 		
 			if ( sdWorld.server_config.aggressive_hibernation )
@@ -553,6 +567,12 @@ class sdDeepSleep extends sdEntity
 			}
 			
 		
+			// Forced wake-ups are never part of a runaway cascade - they come from explicit entry points only
+			// (WakeUpByArrayAndValue when a player reconnects, aggressive_hibernation being switched off). Refusing
+			// one strands a reconnecting player's character inside a sleeping cell, and since the reconnect path reads
+			// "character not found" as "spawn a brand new one", that refusal costs the player their character.
+			// Give up on cascading movement/vision wake-ups only.
+			if ( !forced )
 			if ( sdDeepSleep.inception_catcher > sdDeepSleep.inception_catcher_give_up_level )
 			{
 				console.warn( 'WakeUpArea was called over 512 times per frame - some crazy deep sleep inception has happened?' );


### PR DESCRIPTION
Players report ending up inside hibernated chunks: the world around them stays unloaded and solid, and — in the reporter's words — "the chunks eventually unhibernated later" with no action from them.

## Cause

`sdDeepSleep.inception_catcher` gates `WakeUpArea()`. Above `inception_catcher_give_up_level` (512) every wake-up returns early — vision (`SyncedToPlayer`), physical collision (`sdEntity` `CheckWallExistsBox`) and forced reconnect wake-ups alike.

The counter is documented, and warned about, as a **per frame** budget:

```js
console.warn( 'WakeUpArea was called over 512 times per frame - ...' );
```

but it was reset only inside `GlobalThink`'s

```js
while ( iters-- > 0 && sdDeepSleep.time_budget > 0 )
```

body. `.time_budget` is refilled by `+3` per frame (capped at 3) and decremented by the *real* elapsed ms of the iteration, so a single expensive iteration — a big cell being hibernated, or decoded on wake — drives it deeply negative. A 200ms iteration costs ~66 frames; a 500ms one ~166. For all of those frames the loop body never executes, so the counter is never cleared and wake-ups accumulate **across** frames instead of within one. Once that running total crosses 512, every wake-up is refused until the budget crawls back above zero by itself.

Hibernated cells are `ThreatAsSolid()`, which is why the player is left standing inside solid unloaded world rather than merely seeing it load late, and why it resolves on its own.

## Changes

- Reset the counter once per frame in `GlobalThink`, outside the budget-gated loop, so it means what the warning already claims it means.
- Floor the carried-over budget debt at a new `.time_budget_min`. Unclamped, one heavy iteration also buys hundreds of frames in which nothing hibernates and no scheduled sleep matures. The clamp keeps the "skip some updates after a lag spike" intent and bounds recovery to a few frames.
- Let forced wake-ups bypass the give-up return. Forced calls come only from explicit entry points (`WakeUpByArrayAndValue` when a player reconnects, `aggressive_hibernation` being switched off), never from a cascade, so they cannot run away. Refusing one strands a reconnecting player's character in a sleeping cell — and because the reconnect path reads "character not found" as "spawn a brand new one", that refusal costs the player their character.

The runaway-cascade protection the counter exists for is unchanged: a genuine >512-wake single frame is still cut off, and the counter clears cleanly on the next frame.

## Verification

Proven offline with a harness that models both the old and new algorithms against identical frame timings and wake requests. On a busy-but-healthy scenario where no single frame ever exceeds 512 wakes:

| | wakes refused | of which forced | longest budget stall |
|---|---|---|---|
| before | 7047 | 7 | 162 frames |
| after | 0 | 0 | 4 frames |

23/23 checks, including that the single-frame runaway cut-off still fires and that a reconnecting player is woken even mid-runaway. The harness fails its source-consistency checks against an unpatched file, so it cannot pass vacuously.

Not yet live-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
